### PR TITLE
[escape] html escaping shortcut

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -251,6 +251,17 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
     }
 
     /**
+     * Escapes a text for HTML.
+     *
+     * @param string $text The input text to be escaped
+     * @return string Escaped text
+     */
+    public function escape($text)
+    {
+        return htmlspecialchars($text, ENT_COMPAT, 'UTF-8');
+    }
+
+    /**
      * Handles the request and deliver the response.
      *
      * @param Request $request Request to process

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -84,4 +84,25 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $app->flush();
         $this->assertEquals(2, count($routes->all()));
     }
+
+    /**
+    * @dataProvider escapeProvider
+    */
+    public function testEscape($expected, $text)
+    {
+        $app = new Application();
+
+        $this->assertEquals($expected, $app->escape($text));
+    }
+
+    public function escapeProvider()
+    {
+        return array(
+            array('&lt;', '<'),
+            array('&gt;', '>'),
+            array('&quot;', '"'),
+            array("'", "'"),
+            array('abc', 'abc'),
+        );
+    }
 }


### PR DESCRIPTION
While twig provides phenomenal auto-escaping, it may be worthwhile to have a shortcut for HTML escaping. Asking people to write `htmlspecialchars` is just not going to cut it.

Sinatra uses `html_escape` which can be aliased to `h`. However I find `escape` to be a better name.

Usage:

```
$app->escape($input);

$app->escape($app['request']->get('input'));
```
