### PR TITLE
Convert '-' to '_' in Controller::defaultRouteName() and strip invalid ch

### DIFF
--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -98,8 +98,8 @@ class Controller
         $method = isset($requirements['_method']) ? $requirements['_method'] : '';
 
         $routeName = $method.$this->route->getPattern();
-        $routeName = str_replace(array('{', '}'), '', $routeName);
-        $routeName = str_replace(array('/', ':', '|'), '_', $routeName);
+        $routeName = str_replace(array('/', ':', '|', '-'), '_', $routeName);
+        $routeName = preg_replace('/[^a-z0-9A-Z_.]+/', '', $routeName);
 
         return $routeName;
     }

--- a/tests/Silex/Tests/ControllerTest.php
+++ b/tests/Silex/Tests/ControllerTest.php
@@ -50,4 +50,24 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($ret, $controller);
         $this->assertEquals(array('bar' => '\d+'), $controller->getRoute()->getRequirements());
     }
+
+    /**
+     * @dataProvider provideRouteAndExpectedRouteName
+     */
+    public function testDefaultRouteNameGeneration(Route $route, $expectedRouteName)
+    {
+        $controller = new Controller($route);
+
+        $this->assertEquals($expectedRouteName, $controller->getRouteName());
+    }
+
+    public function provideRouteAndExpectedRouteName()
+    {
+        return array(
+            array(new Route('/Invalid%Symbols#Stripped', array(), array('_method' => 'POST')), 'POST_InvalidSymbolsStripped'),
+            array(new Route('/post/{id}', array(), array('_method' => 'GET')), 'GET_post_id'),
+            array(new Route('/colon:pipe|dashes-escaped'), '_colon_pipe_dashes_escaped'),
+            array(new Route('/underscores_and.periods'), '_underscores_and.periods'),
+        );
+    }
 }


### PR DESCRIPTION
Convert '-' to '_' in Controller::defaultRouteName() and strip invalid characters

Dashes are common in URL patterns, so it would be helpful to convert them to underscores for default route generation. Any invalid characters (according to Symfony\Component\Routing\RouteCollection) should be stripped entirely, lest an exception is raised.
