### PR TITLE
fix documentation on callable controllers (thanks Bart)

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -60,15 +60,7 @@ A route pattern consists of:
   only ``GET`` and ``POST`` are used, but it is possible to use the
   others as well.
 
-The controller can be any PHP callable, so either of::
-
-    'functionName'
-
-    array('Class', 'staticMethodName')
-
-    array($object, 'methodName')
-
-But the encouraged way of defining controllers is a closure is this::
+The controller is defined using a closure like this::
 
     function() {
         // do something
@@ -86,6 +78,10 @@ closure in a function and import local variables of that function.
     ``Closure`` class, we will not make a distinction here.
 
 The return value of the closure becomes the content of the page.
+
+There is also an alternate way for defining controllers using a
+class method. The syntax for that is ``ClassName::methodName``.
+Static methods are also possible.
 
 Example GET route
 ~~~~~~~~~~~~~~~~~

--- a/tests/Silex/Tests/FunctionalTest.php
+++ b/tests/Silex/Tests/FunctionalTest.php
@@ -14,7 +14,7 @@ namespace Silex\Tests;
 use Silex\Application;
 
 /**
- * Controller test cases.
+ * Functional test cases.
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */

--- a/tests/Silex/Tests/RouterTest.php
+++ b/tests/Silex/Tests/RouterTest.php
@@ -173,10 +173,41 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('/foo/', $response->headers->get('Location'));
     }
 
+    public function testClassNameControllerSyntax()
+    {
+        $app = new Application();
+
+        $app->get('/foo', 'Silex\Tests\MyController::getFoo');
+
+        $this->checkRouteResponse($app, '/foo', 'foo');
+    }
+
+    public function testClassNameControllerSyntaxWithStaticMethod()
+    {
+        $app = new Application();
+
+        $app->get('/bar', 'Silex\Tests\MyController::getBar');
+
+        $this->checkRouteResponse($app, '/bar', 'bar');
+    }
+
     protected function checkRouteResponse($app, $path, $expectedContent, $method = 'get', $message = null)
     {
         $request = Request::create($path, $method);
         $response = $app->handle($request);
         $this->assertEquals($expectedContent, $response->getContent(), $message);
+    }
+}
+
+class MyController
+{
+    public function getFoo()
+    {
+        return 'foo';
+    }
+
+    static public function getBar()
+    {
+        return 'bar';
     }
 }


### PR DESCRIPTION
Turns out you cannot pass any callable to silex, you must use the Symfony2 controller syntax for classes.
