### PR TITLE
Added the git revision to the phar file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 phpunit.xml
 silex.phar
+version.xml

--- a/compile
+++ b/compile
@@ -3,7 +3,11 @@
 
 require_once __DIR__.'/autoload.php';
 
+use Silex\Versioning;
 use Silex\Compiler;
+
+$update = new Versioning();
+$update->putVersion();
 
 $compiler = new Compiler();
 $compiler->compile();

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -31,6 +31,7 @@ use Symfony\Component\Routing\Matcher\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Matcher\Exception\NotFoundException;
 use Symfony\Component\ClassLoader\UniversalClassLoader;
 use Silex\RedirectableUrlMatcher;
+use Silex\Versioning;
 
 /**
  * The Silex framework class.
@@ -75,6 +76,10 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
 
         $this['kernel'] = $this->share(function () use ($app) {
             return new HttpKernel($app['dispatcher'], $app['resolver']);
+        });
+
+        $this['versioning'] = $this->share(function() use ($app) {
+            return new Versioning();
         });
     }
 

--- a/src/Silex/Compiler.php
+++ b/src/Silex/Compiler.php
@@ -53,6 +53,7 @@ class Compiler
         }
 
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../LICENSE'), false);
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../version.xml'), false);
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../autoload.php'));
 
         // Stubs

--- a/src/Silex/Versioning.php
+++ b/src/Silex/Versioning.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Silex;
+
+class Versioning
+{
+    protected $file;
+
+    /**
+     * Constructor.
+     */
+    public function __construct()
+    {
+        $this->_file = __DIR__.'/../../version.xml';
+    }
+
+    /**
+     * Grabs the last checkout hash and timestamp via git.
+     */
+    protected function checkVersion()
+    {
+        $baseDir = __DIR__.'/../..';
+        if (!is_dir($baseDir.'/.git')) {
+            return array('unknown', 'unknown', 'unknown');
+        }
+        $cmd = sprintf('cd %s; git log --pretty="%%H %%ci" -n 1', $baseDir);
+        $output = array();
+        exec($cmd, $output);
+        $line = $output[0];
+        $tokens = explode(' ', $line);
+        $hash = array_shift($tokens);
+        $time = join(' ', $tokens);
+
+        return array($hash, $time, $line);
+    }
+
+    /**
+     * Writes the version to an xml file.
+     */
+    public function putVersion()
+    {
+        $vers = $this->checkVersion();
+        $version = $vers[0];
+        $created = $vers[1];
+
+        $template = '<?xml version="1.0" encoding="UTF-8"?>
+
+<silex>
+    <version>%s</version>
+    <created>%s</created>
+</silex>';
+        $contents = sprintf($template, $version, $created);
+        file_put_contents($this->_file, $contents);
+    }
+
+    /**
+     * Returns the last commit hash.
+     */
+    public function getHash()
+    {
+        $doc = new \DOMDocument();
+        $doc->load($this->_file);
+        $xp = new \DOMXPath($doc);
+        $hash = $xp->query('/silex/version')->item(0)->nodeValue;
+
+        return $hash;
+    }
+
+    /**
+     * Returns the time of the last commit.
+     */
+    public function getCreated()
+    {
+        $doc = new \DOMDocument();
+        $doc->load($this->_file);
+        $xp = new \DOMXPath($doc);
+        $created = $xp->query('/silex/created')->item(0)->nodeValue;
+
+        return $created;
+    }
+}


### PR DESCRIPTION
With the fast pace of development and me being unable to find any versioning info, I think it would be nice to at least have the git revision available without having to deconstruct the phar file.
