### PR TITLE
populate the request attributes before onSilexBefore is fired

### DIFF
--- a/tests/Silex/Tests/BeforeAfterFilterTest.php
+++ b/tests/Silex/Tests/BeforeAfterFilterTest.php
@@ -162,4 +162,22 @@ class BeforeAfterFilterTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(2, $i);
     }
+
+    public function testRequestShouldBePopulatedOnBefore() {
+        $app = new Application();
+
+        $app->before(function () use ($app) {
+            $app['locale'] = $app['request']->get('locale');
+        });
+
+        $app->match('/foo/{locale}', function () use ($app) {
+            return $app['locale'];
+        });
+
+        $request = Request::create('/foo/en');
+        $this->assertEquals('en', $app->handle($request)->getContent());
+
+        $request = Request::create('/foo/de');
+        $this->assertEquals('de', $app->handle($request)->getContent());
+    }
 }


### PR DESCRIPTION
if we don't do this, it's impossible to use route parameters in before
handlers.

look at the test for an example.

I'm not 100% happy with the way the try/catch is done, but it's the best I could come up with.
