### PR TITLE
unify lambda CS, add a space after function keyword

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Silex is a simple web framework to develop simple websites based on
 
     $app = new Silex\Application();
 
-    $app->get('/hello/{name}', function($name) {
+    $app->get('/hello/{name}', function ($name) {
         return "Hello $name";
     });
 

--- a/doc/extensions.rst
+++ b/doc/extensions.rst
@@ -92,7 +92,7 @@ Here is an example of such an extension::
     {
         public function register(Application $app)
         {
-            $app['hello'] = $app->protect(function($name) use ($app) {
+            $app['hello'] = $app->protect(function ($name) use ($app) {
                 $default = ($app['hello.default_name']) ? $app['hello.default_name'] : '';
                 $name = $name ?: $default;
                 return "Hello $name";
@@ -115,7 +115,7 @@ You can now use this extension as follows::
         'hello.default_name' => 'Igor',
     ));
 
-    $app->get('/hello', function() use ($app) {
+    $app->get('/hello', function () use ($app) {
         $name = $app['request']->get('name');
         return $app['hello']($name);
     });
@@ -146,7 +146,7 @@ Here is an example of how to use it (based on `Buzz <https://github.com/kriswall
     {
         public function register(Application $app)
         {
-            $app['buzz'] = $app->share(function() { ... });
+            $app['buzz'] = $app->share(function () { ... });
 
             if (isset($app['buzz.class_path'])) {
                 $app['autoloader']->registerNamespace('Buzz', $app['buzz.class_path']);

--- a/doc/extensions/session.rst
+++ b/doc/extensions/session.rst
@@ -36,7 +36,7 @@ example that authenticates a user and creates a session for him::
 
     use Symfony\Component\HttpFoundation\Response;
 
-    $app->get('/login', function() use ($app) {
+    $app->get('/login', function () use ($app) {
         $username = $app['request']->server->get('PHP_AUTH_USER', false);
         $password = $app['request']->server->get('PHP_AUTH_PW');
 
@@ -51,7 +51,7 @@ example that authenticates a user and creates a session for him::
         return $response;
     });
 
-    $app->get('/account', function() use ($app) {
+    $app->get('/account', function () use ($app) {
         if (null === $user = $app['session']->get('user')) {
             return $app->redirect('/login');
         }

--- a/doc/extensions/twig.rst
+++ b/doc/extensions/twig.rst
@@ -62,7 +62,7 @@ The Twig extension provides a ``twig`` service.
 
 ::
 
-    $app->get('/hello/{name}', function($name) use ($app) {
+    $app->get('/hello/{name}', function ($name) use ($app) {
         return $app['twig']->render('hello.twig', array(
             'name' => $name,
         ));

--- a/doc/extensions/url_generator.rst
+++ b/doc/extensions/url_generator.rst
@@ -36,17 +36,17 @@ The UrlGenerator extension provides a ``url_generator`` service.
 
 ::
 
-    $app->get('/', function() {
+    $app->get('/', function () {
         return 'welcome to the homepage';
     })
     ->bind('homepage');
 
-    $app->get('/hello/{name}', function($name) {
+    $app->get('/hello/{name}', function ($name) {
         return "Hello $name!";
     })
     ->bind('hello');
 
-    $app->get('/navigation', function() use ($app) {
+    $app->get('/navigation', function () use ($app) {
         return '<a href="'.$app['url_generator']->generate('homepage').'">Home</a>'.
                ' | '.
                '<a href="'.$app['url_generator']->generate('hello', array('name' => 'Igor')).'">Hello Igor</a>';

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -26,7 +26,7 @@ step.
 
     $app = new Silex\Application();
 
-    $app->get('/hello/{name}', function($name) {
+    $app->get('/hello/{name}', function ($name) {
         return "Hello $name";
     });
 

--- a/doc/services.rst
+++ b/doc/services.rst
@@ -103,7 +103,7 @@ This allows for lazy service creation.
 
 ::
 
-    $app['some_service'] = function() {
+    $app['some_service'] = function () {
         return new Service();
     };
 
@@ -121,7 +121,7 @@ You may want to use the same instance of a service across all
 of your code. In order to do that you can make a *shared*
 service. ::
 
-    $app['some_service'] = $app->share(function() {
+    $app['some_service'] = $app->share(function () {
         return new Service();
     });
 
@@ -138,7 +138,7 @@ fetching services the current service depends on.
 Because of this, the container is passed to the closure as
 an argument. ::
 
-    $app['some_service'] = function($app) {
+    $app['some_service'] = function ($app) {
         return new Service($app['some_other_service'], $app['some_service.config']);
     };
 
@@ -168,7 +168,7 @@ from being executed, by using the ``protect`` method.
 
 ::
 
-    $app['closure_parameter'] = $app->protect(function($a, $b) {
+    $app['closure_parameter'] = $app->protect(function ($a, $b) {
         return $a + $b;
     });
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -63,7 +63,7 @@ A route pattern consists of:
 
 The controller is defined using a closure like this::
 
-    function() {
+    function () {
         // do something
     }
 
@@ -98,7 +98,7 @@ Here is an example definition of a ``GET`` route::
         ),
     );
 
-    $app->get('/blog', function() use ($blogPosts) {
+    $app->get('/blog', function () use ($blogPosts) {
         $output = '';
         foreach ($blogPosts as $post) {
             $output .= $post['title'];
@@ -121,7 +121,7 @@ posts::
 
     use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-    $app->get('/blog/show/{id}', function($id) use ($blogPosts) {
+    $app->get('/blog/show/{id}', function ($id) use ($blogPosts) {
         if (!isset($blogPosts[$id])) {
             throw new NotFoundHttpException();
         }
@@ -152,7 +152,7 @@ feedback form. We will use `Swift Mailer
 
     use Symfony\Component\HttpFoundation\Response;
 
-    $app->post('/feedback', function() use ($app) {
+    $app->post('/feedback', function () use ($app) {
         $request = $app['request'];
 
         $message = \Swift_Message::newInstance()
@@ -197,7 +197,7 @@ can also call ``match``, which will match all methods.
 
 ::
 
-    $app->put('/blog', function() {
+    $app->put('/blog', function () {
         ...
     });
 
@@ -211,7 +211,7 @@ Route variables
 
 As has been show before you can define variable parts in a route like this::
 
-    $app->get('/blog/show/{id}', function($id) {
+    $app->get('/blog/show/{id}', function ($id) {
         ...
     });
 
@@ -220,13 +220,13 @@ closure arguments match the names of the variable parts.
 
 ::
 
-    $app->get('/blog/show/{postId}/{commentId}', function($postId, $commentId) {
+    $app->get('/blog/show/{postId}/{commentId}', function ($postId, $commentId) {
         ...
     });
 
 While it's not suggested, you could also do this (note the switched arguments)::
 
-    $app->get('/blog/show/{postId}/{commentId}', function($commentId, $postId) {
+    $app->get('/blog/show/{postId}/{commentId}', function ($commentId, $postId) {
         ...
     });
 
@@ -240,14 +240,14 @@ requirements using regular expressions by calling ``assert`` on the
 The following will make sure the ``id`` argument is numeric, since ``\d+``
 matches any amount of digits::
 
-    $app->get('/blog/show/{id}', function($id) {
+    $app->get('/blog/show/{id}', function ($id) {
         ...
     })
     ->assert('id', '\d+');
 
 You can also chain these calls::
 
-    $app->get('/blog/show/{postId}/{commentId}', function($postId, $commentId) {
+    $app->get('/blog/show/{postId}/{commentId}', function ($postId, $commentId) {
         ...
     })
     ->assert('postId', '\d+')
@@ -261,7 +261,7 @@ the ``Controller`` object.
 
 ::
 
-    $app->get('/{pageName}', function($pageName) {
+    $app->get('/{pageName}', function ($pageName) {
         ...
     })
     ->value('pageName', 'index');
@@ -279,12 +279,12 @@ object that is returned by the routing methods.
 
 ::
 
-    $app->get('/', function() {
+    $app->get('/', function () {
         ...
     })
     ->bind('homepage');
 
-    $app->get('/blog/show/{id}', function($id) {
+    $app->get('/blog/show/{id}', function ($id) {
         ...
     })
     ->bind('blog_post');
@@ -301,11 +301,11 @@ Before and after filters
 Silex allows you to run code before and after every request. This happens
 through before and after filters. All you need to do is pass a closure::
 
-    $app->before(function() {
+    $app->before(function () {
         // set up
     });
 
-    $app->after(function() {
+    $app->after(function () {
         // tear down
     });
 
@@ -321,7 +321,7 @@ which takes an ``Exception`` argument and returns a response::
 
     use Symfony\Component\HttpFoundation\Response;
 
-    $app->error(function(\Exception $e) {
+    $app->error(function (\Exception $e) {
         return new Response('We are sorry, but something went terribly wrong.', 500);
     });
 
@@ -332,7 +332,7 @@ them differently::
     use Symfony\Component\HttpKernel\Exception\HttpException;
     use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
-    $app->error(function(\Exception $e) {
+    $app->error(function (\Exception $e) {
         if ($e instanceof NotFoundHttpException) {
             return new Response('The requested page could not be found.', 404);
         }
@@ -357,7 +357,7 @@ Redirects
 You can redirect to another page by returning a redirect response, which
 you can create by calling the ``redirect`` method::
 
-    $app->get('/', function() use ($app) {
+    $app->get('/', function () use ($app) {
         return $app->redirect('/hello');
     });
 
@@ -378,7 +378,7 @@ correctly, to prevent Cross-Site-Scripting attacks.
 * **Escaping HTML**: PHP provides the ``htmlspecialchars`` function for this.
   Silex provides a shortcut ``escape`` method::
 
-      $app->get('/name', function() use ($app) {
+      $app->get('/name', function () use ($app) {
           $name = $app['request']->get('name');
           return "You provided the name {$app->escape($name)}.";
       });
@@ -391,7 +391,7 @@ correctly, to prevent Cross-Site-Scripting attacks.
 
       use Symfony\Component\HttpFoundation\Response;
 
-      $app->get('/name.json', function() use ($app) {
+      $app->get('/name.json', function () use ($app) {
           $name = $app['request']->get('name');
           return new Response(
               json_encode(array('name' => $name)),

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -217,7 +217,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
      */
     public function error($callback)
     {
-        $this['dispatcher']->addListener(Events::onSilexError, function(GetResponseForErrorEvent $event) use ($callback) {
+        $this['dispatcher']->addListener(Events::onSilexError, function (GetResponseForErrorEvent $event) use ($callback) {
             $exception = $event->getException();
             $result = $callback($exception);
 

--- a/src/Silex/Extension/DoctrineExtension.php
+++ b/src/Silex/Extension/DoctrineExtension.php
@@ -29,15 +29,15 @@ class DoctrineExtension implements ExtensionInterface
             'password' => null,
         ), isset($app['db.options']) ? $app['db.options'] : array());
 
-        $app['db'] = $app->share(function() use($app) {
+        $app['db'] = $app->share(function () use($app) {
             return DriverManager::getConnection($app['db.options'], $app['db.config'], $app['db.event_manager']);
         });
 
-        $app['db.config'] = $app->share(function() {
+        $app['db.config'] = $app->share(function () {
             return new Configuration();
         });
 
-        $app['db.event_manager'] = $app->share(function() {
+        $app['db.event_manager'] = $app->share(function () {
             return new EventManager();
         });
 

--- a/src/Silex/Extension/MonologExtension.php
+++ b/src/Silex/Extension/MonologExtension.php
@@ -35,12 +35,12 @@ class MonologExtension implements ExtensionInterface
             $log->pushHandler($app['monolog.handler']);
         });
 
-        $app['monolog.handler'] = function() use ($app) {
+        $app['monolog.handler'] = function () use ($app) {
             return new StreamHandler($app['monolog.logfile'], $app['monolog.level']);
         };
 
         if (!isset($app['monolog.level'])) {
-            $app['monolog.level'] = function() {
+            $app['monolog.level'] = function () {
                 return Logger::DEBUG;
             };
         }
@@ -49,11 +49,11 @@ class MonologExtension implements ExtensionInterface
             $app['autoloader']->registerNamespace('Monolog', $app['monolog.class_path']);
         }
 
-        $app->before(function() use ($app) {
+        $app->before(function () use ($app) {
             $app['monolog']->addInfo($app['request']->getMethod().' '.$app['request']->getRequestUri());
         });
 
-        $app->error(function(\Exception $e) use ($app) {
+        $app->error(function (\Exception $e) use ($app) {
             if ($e instanceof HttpException) {
                 $app['monolog']->addWarning($e->getStatusCode().' '.$app['request']->getMethod().' '.$app['request']->getRequestUri());
             } else {

--- a/src/Silex/Extension/TranslationExtension.php
+++ b/src/Silex/Extension/TranslationExtension.php
@@ -22,7 +22,7 @@ class TranslationExtension implements ExtensionInterface
 {
     public function register(Application $app)
     {
-        $app['translator'] = $app->share(function() use ($app) {
+        $app['translator'] = $app->share(function () use ($app) {
             $translator = new Translator(isset($app['locale']) ? $app['locale'] : 'en', $app['translator.message_selector']);
 
             if (isset($app['locale_fallback'])) {
@@ -37,11 +37,11 @@ class TranslationExtension implements ExtensionInterface
             return $translator;
         });
 
-        $app['translator.loader'] = $app->share(function() {
+        $app['translator.loader'] = $app->share(function () {
             return new ArrayLoader();
         });
 
-        $app['translator.message_selector'] = $app->share(function() {
+        $app['translator.message_selector'] = $app->share(function () {
             return new MessageSelector();
         });
 

--- a/src/Silex/Extension/UrlGeneratorExtension.php
+++ b/src/Silex/Extension/UrlGeneratorExtension.php
@@ -20,7 +20,7 @@ class UrlGeneratorExtension implements ExtensionInterface
 {
     public function register(Application $app)
     {
-        $app['url_generator'] = $app->share(function() use ($app) {
+        $app['url_generator'] = $app->share(function () use ($app) {
             $app->flush();
 
             return new UrlGenerator($app['routes'], $app['request_context']);

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -26,19 +26,19 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $returnValue = $app->match('/foo', function() {});
+        $returnValue = $app->match('/foo', function () {});
         $this->assertInstanceOf('Silex\Controller', $returnValue);
 
-        $returnValue = $app->get('/foo', function() {});
+        $returnValue = $app->get('/foo', function () {});
         $this->assertInstanceOf('Silex\Controller', $returnValue);
 
-        $returnValue = $app->post('/foo', function() {});
+        $returnValue = $app->post('/foo', function () {});
         $this->assertInstanceOf('Silex\Controller', $returnValue);
 
-        $returnValue = $app->put('/foo', function() {});
+        $returnValue = $app->put('/foo', function () {});
         $this->assertInstanceOf('Silex\Controller', $returnValue);
 
-        $returnValue = $app->delete('/foo', function() {});
+        $returnValue = $app->delete('/foo', function () {});
         $this->assertInstanceOf('Silex\Controller', $returnValue);
     }
 
@@ -46,7 +46,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->get('/', function() {
+        $app->get('/', function () {
             return 'root';
         });
 
@@ -70,11 +70,11 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->get('/foo', function() {
+        $app->get('/foo', function () {
             return 'foo';
         });
 
-        $app->get('/bar', function() {
+        $app->get('/bar', function () {
             return 'bar';
         });
 

--- a/tests/Silex/Tests/BeforeAfterFilterTest.php
+++ b/tests/Silex/Tests/BeforeAfterFilterTest.php
@@ -31,17 +31,17 @@ class BeforeAfterFilterTest extends \PHPUnit_Framework_TestCase
 
         $app = new Application();
 
-        $app->before(function() use (&$i, $test) {
+        $app->before(function () use (&$i, $test) {
             $test->assertEquals(0, $i);
             $i++;
         });
 
-        $app->match('/foo', function() use (&$i, $test) {
+        $app->match('/foo', function () use (&$i, $test) {
             $test->assertEquals(1, $i);
             $i++;
         });
 
-        $app->after(function() use (&$i, $test) {
+        $app->after(function () use (&$i, $test) {
             $test->assertEquals(2, $i);
             $i++;
         });
@@ -58,12 +58,12 @@ class BeforeAfterFilterTest extends \PHPUnit_Framework_TestCase
 
         $app = new Application();
 
-        $app->match('/foo', function() use (&$i) {
+        $app->match('/foo', function () use (&$i) {
             $i++;
             return new Response('foo');
         });
 
-        $app->after(function() use (&$i) {
+        $app->after(function () use (&$i) {
             $i++;
         });
 
@@ -80,27 +80,27 @@ class BeforeAfterFilterTest extends \PHPUnit_Framework_TestCase
 
         $app = new Application();
 
-        $app->before(function() use (&$i, $test) {
+        $app->before(function () use (&$i, $test) {
             $test->assertEquals(0, $i);
             $i++;
         });
 
-        $app->before(function() use (&$i, $test) {
+        $app->before(function () use (&$i, $test) {
             $test->assertEquals(1, $i);
             $i++;
         });
 
-        $app->match('/foo', function() use (&$i, $test) {
+        $app->match('/foo', function () use (&$i, $test) {
             $test->assertEquals(2, $i);
             $i++;
         });
 
-        $app->after(function() use (&$i, $test) {
+        $app->after(function () use (&$i, $test) {
             $test->assertEquals(3, $i);
             $i++;
         });
 
-        $app->after(function() use (&$i, $test) {
+        $app->after(function () use (&$i, $test) {
             $test->assertEquals(4, $i);
             $i++;
         });
@@ -117,19 +117,19 @@ class BeforeAfterFilterTest extends \PHPUnit_Framework_TestCase
 
         $app = new Application();
 
-        $app->before(function() use (&$i) {
+        $app->before(function () use (&$i) {
             $i++;
         });
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             throw new \RuntimeException();
         });
 
-        $app->after(function() use (&$i) {
+        $app->after(function () use (&$i) {
             $i++;
         });
 
-        $app->error(function() {
+        $app->error(function () {
             return 'error handled';
         });
 
@@ -145,15 +145,15 @@ class BeforeAfterFilterTest extends \PHPUnit_Framework_TestCase
 
         $app = new Application();
 
-        $app->before(function() use (&$i) {
+        $app->before(function () use (&$i) {
             $i++;
         });
 
-        $app->after(function() use (&$i) {
+        $app->after(function () use (&$i) {
             $i++;
         });
 
-        $app->error(function() {
+        $app->error(function () {
             return 'error handled';
         });
 

--- a/tests/Silex/Tests/ErrorHandlerTest.php
+++ b/tests/Silex/Tests/ErrorHandlerTest.php
@@ -27,7 +27,7 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             throw new \RuntimeException('foo exception');
         });
 
@@ -44,11 +44,11 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             throw new \RuntimeException('foo exception');
         });
 
-        $app->error(function($e) {
+        $app->error(function ($e) {
             return new Response('foo exception handler');
         });
 
@@ -60,26 +60,26 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             throw new \RuntimeException('foo exception');
         });
 
         $errors = 0;
 
-        $app->error(function($e) use (&$errors) {
+        $app->error(function ($e) use (&$errors) {
             $errors++;
         });
 
-        $app->error(function($e) use (&$errors) {
+        $app->error(function ($e) use (&$errors) {
             $errors++;
         });
 
-        $app->error(function($e) use (&$errors) {
+        $app->error(function ($e) use (&$errors) {
             $errors++;
             return new Response('foo exception handler');
         });
 
-        $app->error(function($e) use (&$errors) {
+        $app->error(function ($e) use (&$errors) {
             // should not execute
             $errors++;
         });
@@ -94,13 +94,13 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             throw new \RuntimeException('foo exception');
         });
 
         $errors = 0;
 
-        $app->error(function($e) use (&$errors) {
+        $app->error(function ($e) use (&$errors) {
             $errors++;
         });
 
@@ -119,11 +119,11 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             throw new \RuntimeException('foo exception');
         });
 
-        $app->error(function($e) {
+        $app->error(function ($e) {
             return 'foo exception handler';
         });
 
@@ -135,11 +135,11 @@ class ErrorHandlerTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             throw new \RuntimeException('foo exception');
         });
 
-        $app->error(function($e) {
+        $app->error(function ($e) {
             throw new \RuntimeException('foo exception handler exception');
         });
 

--- a/tests/Silex/Tests/Extension/MonologExtensionTest.php
+++ b/tests/Silex/Tests/Extension/MonologExtensionTest.php
@@ -40,19 +40,19 @@ class MonologExtensionTest extends \PHPUnit_Framework_TestCase
             'monolog.class_path'    => __DIR__.'/../../../../vendor/monolog/src',
         ));
 
-        $app['monolog.handler'] = $app->share(function() use ($app) {
+        $app['monolog.handler'] = $app->share(function () use ($app) {
             return new TestHandler($app['monolog.level']);
         });
 
-        $app->get('/log', function() use ($app) {
+        $app->get('/log', function () use ($app) {
             $app['monolog']->addDebug('logging a message');
         });
 
-        $app->get('/error', function() {
+        $app->get('/error', function () {
             throw new \RuntimeException('very bad error');
         });
 
-        $app->error(function(\Exception $e) {
+        $app->error(function (\Exception $e) {
             return 'error handled';
         });
 

--- a/tests/Silex/Tests/Extension/SessionExtensionTest.php
+++ b/tests/Silex/Tests/Extension/SessionExtensionTest.php
@@ -30,16 +30,16 @@ class SessionExtensionTest extends \PHPUnit_Framework_TestCase
 
         $app->register(new SessionExtension());
 
-        $app['session.storage'] = $app->share(function() use ($app) {
+        $app['session.storage'] = $app->share(function () use ($app) {
             return new ArraySessionStorage();
         });
 
-        $app->get('/login', function() use ($app) {
+        $app->get('/login', function () use ($app) {
             $app['session']->set('logged_in', true);
             return 'Logged in successfully.';
         });
 
-        $app->get('/account', function() use ($app) {
+        $app->get('/account', function () use ($app) {
             if (!$app['session']->get('logged_in')) {
                 return 'You are not in.';
             }

--- a/tests/Silex/Tests/Extension/TwigExtensionTest.php
+++ b/tests/Silex/Tests/Extension/TwigExtensionTest.php
@@ -39,7 +39,7 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
             'twig.class_path'   => __DIR__.'/../../../../vendor/twig/lib',
         ));
 
-        $app->get('/hello/{name}', function($name) use ($app) {
+        $app->get('/hello/{name}', function ($name) use ($app) {
             return $app['twig']->render('hello', array('name' => $name));
         });
 

--- a/tests/Silex/Tests/Extension/UrlGeneratorExtensionTest.php
+++ b/tests/Silex/Tests/Extension/UrlGeneratorExtensionTest.php
@@ -29,10 +29,10 @@ class UrlGeneratorExtensionTest extends \PHPUnit_Framework_TestCase
 
         $app->register(new UrlGeneratorExtension());
 
-        $app->get('/hello/{name}', function($name) {})
+        $app->get('/hello/{name}', function ($name) {})
             ->bind('hello');
 
-        $app->get('/', function() use ($app) {
+        $app->get('/', function () use ($app) {
             return $app['url_generator']->generate('hello', array('name' => 'john'));
         });
 

--- a/tests/Silex/Tests/FunctionalTest.php
+++ b/tests/Silex/Tests/FunctionalTest.php
@@ -27,12 +27,12 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->get('/', function() {
+        $app->get('/', function () {
             return 'hello';
         })
         ->bind('homepage');
 
-        $app->get('/foo', function() {
+        $app->get('/foo', function () {
             return 'foo';
         })
         ->bind('foo_abc');
@@ -71,7 +71,7 @@ class FunctionalTest extends \PHPUnit_Framework_TestCase
 
         $app = new Application();
         $app->mount('/hello', $mountedFactory);
-        $app->get('/main', function() {
+        $app->get('/main', function () {
             return new Response('main app');
         });
 

--- a/tests/Silex/Tests/RouterTest.php
+++ b/tests/Silex/Tests/RouterTest.php
@@ -29,15 +29,15 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             return 'foo';
         });
 
-        $app->match('/bar', function() {
+        $app->match('/bar', function () {
             return 'bar';
         });
 
-        $app->match('/', function() {
+        $app->match('/', function () {
             return 'root';
         });
 
@@ -50,15 +50,15 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->put('/created', function() {
+        $app->put('/created', function () {
             return new Response('', 201);
         });
 
-        $app->match('/forbidden', function() {
+        $app->match('/forbidden', function () {
             return new Response('', 403);
         });
 
-        $app->match('/not_found', function() {
+        $app->match('/not_found', function () {
             return new Response('', 404);
         });
 
@@ -79,11 +79,11 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/redirect', function() {
+        $app->match('/redirect', function () {
             return new RedirectResponse('/target');
         });
 
-        $app->match('/redirect2', function() use ($app) {
+        $app->match('/redirect2', function () use ($app) {
             return $app->redirect('/target2');
         });
 
@@ -111,27 +111,27 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->match('/foo', function() {
+        $app->match('/foo', function () {
             return 'foo';
         });
 
-        $app->match('/bar', function() {
+        $app->match('/bar', function () {
             return 'bar';
         }, 'GET|POST');
 
-        $app->get('/resource', function() {
+        $app->get('/resource', function () {
             return 'get resource';
         });
 
-        $app->post('/resource', function() {
+        $app->post('/resource', function () {
             return 'post resource';
         });
 
-        $app->put('/resource', function() {
+        $app->put('/resource', function () {
             return 'put resource';
         });
 
-        $app->delete('/resource', function() {
+        $app->delete('/resource', function () {
             return 'delete resource';
         });
 
@@ -146,10 +146,10 @@ class RouterTest extends \PHPUnit_Framework_TestCase
 
     public function testRequestShouldBeStoredRegardlessOfRouting() {
         $app = new Application();
-        $app->get('/foo', function() use ($app) {
+        $app->get('/foo', function () use ($app) {
             return new Response($app['request']->getRequestUri());
         });
-        $app->error(function($e) use ($app) {
+        $app->error(function ($e) use ($app) {
             return new Response($app['request']->getRequestUri());
         });
         foreach(array('/foo', '/bar') as $path) {
@@ -162,7 +162,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     public function testTrailingSlashBehavior()
     {
         $app = new Application();
-        $app->get('/foo/', function() use ($app) {
+        $app->get('/foo/', function () use ($app) {
             return new Response('ok');
         });
 

--- a/tests/Silex/Tests/WebTestCaseTest.php
+++ b/tests/Silex/Tests/WebTestCaseTest.php
@@ -25,11 +25,11 @@ class WebTestCaseTest extends WebTestCase
     {
         $app = new Application();
 
-        $app->match('/hello', function() {
+        $app->match('/hello', function () {
             return 'world';
         });
 
-        $app->match('/html', function() {
+        $app->match('/html', function () {
             return '<h1>title</h1>';
         });
 


### PR DESCRIPTION
the decision to have a space after `function`, so `function () {}`
instead of `function() {}` is based on douglas crockford's javascript
code conventions [1].

[1] http://javascript.crockford.com/code.html
