### PR TITLE
Rename {Validation => Validator}Extension

### DIFF
--- a/src/Silex/Extension/ValidatorExtension.php
+++ b/src/Silex/Extension/ValidatorExtension.php
@@ -19,7 +19,7 @@ use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 
-class ValidationExtension implements ExtensionInterface
+class ValidatorExtension implements ExtensionInterface
 {
     public function register(Application $app)
     {


### PR DESCRIPTION
Rename validation.class_path to validator.class_path. This is to be consistent with the rest of the extension.

**Since the Symfony2 component is actually called Validator (and not Validation) we should consider renaming the extension to ValidatorExtension. Thoughts on that?**
