### PR TITLE
Support including a phar from another phar

### DIFF
--- a/src/Silex/Compiler.php
+++ b/src/Silex/Compiler.php
@@ -36,7 +36,7 @@ class Compiler
         }
         $this->version = trim($process->getOutput());
 
-        $phar = new \Phar($pharFile, 0, 'Silex');
+        $phar = new \Phar($pharFile, 0, 'silex.phar');
         $phar->setSignatureAlgorithm(\Phar::SHA1);
 
         $phar->startBuffering();
@@ -66,9 +66,7 @@ class Compiler
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../autoload.php'));
 
         // Stubs
-        $phar['_cli_stub.php'] = $this->getStub();
-        $phar['_web_stub.php'] = $this->getStub();
-        $phar->setDefaultStub('_cli_stub.php', '_web_stub.php');
+        $phar->setStub($this->getStub());
 
         $phar->stopBuffering();
 
@@ -103,7 +101,9 @@ class Compiler
  * with this source code in the file LICENSE.
  */
 
-require_once __DIR__.'/autoload.php';
+Phar::mapPhar('silex.phar');
+
+require_once 'phar://silex.phar/autoload.php';
 
 if ('cli' === php_sapi_name()) {
     $command = isset($argv[1]) ? $argv[1] : null;


### PR DESCRIPTION
The default stubs mess up when you try to run a phar which includes
another phar. In my case I was running pip.phar on the CLI, which
included app.php, which in turn included silex.phar.

It broke the **DIR** calls. This was able to fix it.

Needs testing in lots of different setups, because the default stubs are
no longer used.
