### PR TITLE
fixed: typo in doctrine.rst

### DIFF
--- a/doc/extensions/doctrine.rst
+++ b/doc/extensions/doctrine.rst
@@ -24,10 +24,10 @@ Parameters
   * **host**: The host of the database to connect to. Defaults to
     localhost.
 
-  * **user**: The host of the database to connect to. Defaults to
+  * **user**: The user of the database to connect to. Defaults to
     root.
 
-  * **password**: The host of the database to connect to.
+  * **password**: The password of the database to connect to.
 
   * **path**: Only relevant for ``pdo_sqlite``, specifies the path to
     the SQLite database.


### PR DESCRIPTION
fixed typo in the DoctrineExtension document (doctrine.rst)
