### PR TITLE
Avoid XSS

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -27,7 +27,7 @@ step.
     $app = new Silex\Application();
 
     $app->get('/hello/{name}', function ($name) {
-        return "Hello $name";
+        return 'Hello ' . htmlspecialchars($name);
     });
 
     $app->run();


### PR DESCRIPTION
This example (used even on the homepage of Silex) is vulnerable to Cross Site Scripting. Bad habits should not be promoted.
