### PR TITLE
new option for TwigExtension to allow using another Environment-class - u

### DIFF
--- a/src/Silex/Extension/TwigExtension.php
+++ b/src/Silex/Extension/TwigExtension.php
@@ -23,7 +23,8 @@ class TwigExtension implements ExtensionInterface
     public function register(Application $app)
     {
         $app['twig'] = $app->share(function () use ($app) {
-            $twig = new \Twig_Environment($app['twig.loader'], isset($app['twig.options']) ? $app['twig.options'] : array());
+            $twigEnvironmentClass = isset($app['twig.environment_class']) ? $app['twig.environment_class'] : '\\Twig_Environment';
+            $twig = new $twigEnvironmentClass($app['twig.loader'], isset($app['twig.options']) ? $app['twig.options'] : array());
             $twig->addGlobal('app', $app);
 
             if (isset($app['symfony_bridges'])) {

--- a/tests/Silex/Tests/Extension/TwigExtensionTest.php
+++ b/tests/Silex/Tests/Extension/TwigExtensionTest.php
@@ -47,4 +47,21 @@ class TwigExtensionTest extends \PHPUnit_Framework_TestCase
         $response = $app->handle($request);
         $this->assertEquals('Hello john!', $response->getContent());
     }
+
+    public function testRegisterWithOtherEnvironmentClass()
+    {
+        $app = new Application();
+
+        $app->register(new TwigExtension(), array(
+            'twig.templates'    => array('hello' => 'Hello {{ name }}!'),
+            'twig.class_path'   => __DIR__.'/../../../../vendor/twig/lib',
+            'twig.environment_class' => '\\Silex\\Tests\\Extension\\Environment'
+        ));
+
+        $this->assertInstanceof('\\Silex\\Tests\\Extension\\Environment', $app['twig']);
+    }
+}
+
+class Environment extends \Twig_Environment {
+
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -14,3 +14,8 @@ if (file_exists($file = __DIR__.'/../autoload.php')) {
 } elseif (file_exists($file = __DIR__.'/../autoload.php.dist')) {
     require_once $file;
 }
+
+if (!class_exists('Twig_Autoloader')) {
+    require_once __DIR__ . '/../vendor/twig/lib/Twig/Autoloader.php';
+    Twig_Autoloader::register();
+}


### PR DESCRIPTION
It would be nice to be able to use my own Twig-Environment-Class.

Commit includes a simple test.
If adding the Twig_Autoloader to the bootstrap php is not wanted, have a look at 
https://github.com/robo47/Silex/commit/1460cc709a52b9675ffae80848b82d3fd0221f52
for another solution.
