### PR TITLE
Can instanciate our own Session class

### DIFF
--- a/src/Silex/Extension/SessionExtension.php
+++ b/src/Silex/Extension/SessionExtension.php
@@ -15,7 +15,6 @@ use Silex\Application;
 use Silex\ExtensionInterface;
 
 use Symfony\Component\HttpFoundation\SessionStorage\NativeSessionStorage;
-use Symfony\Component\HttpFoundation\Session;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 class SessionExtension implements ExtensionInterface
@@ -27,7 +26,9 @@ class SessionExtension implements ExtensionInterface
         $this->app = $app;
 
         $app['session'] = $app->share(function () use ($app) {
-            return new Session($app['session.storage']);
+            $class_name = isset($app['session.class_name']) ? $app['session.class_name'] : 'Symfony\Component\HttpFoundation\Session';
+
+            return new $class_name($app['session.storage']);
         });
 
         $app['session.storage'] = $app->share(function () use ($app) {

--- a/tests/Silex/Tests/Extension/SessionExtensionTest.php
+++ b/tests/Silex/Tests/Extension/SessionExtensionTest.php
@@ -18,6 +18,13 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\SessionStorage\ArraySessionStorage;
 
 /**
+ * Extended Session for test
+ **/
+class MySession extends \Symfony\Component\HttpFoundation\Session
+{
+}
+
+/**
  * SessionExtension test cases.
  *
  * @author Igor Wiedler <igor@wiedler.ch>
@@ -54,5 +61,13 @@ class SessionExtensionTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/account');
         $response = $app->handle($request);
         $this->assertEquals('This is your account.', $response->getContent());
+    }
+
+    public function testOwnSession()
+    {
+        $app = new Application();
+
+        $app->register(new SessionExtension(), array('session.class_name' => 'Silex\Tests\Extension\MySession'));
+        $this->assertTrue($app['session'] instanceof \Silex\Tests\Extension\MySession);
     }
 }


### PR DESCRIPTION
It was not possible to extend the session class to implement logic in the session layer.
This commit comes with the according tests.
