### PR TITLE
Make silex.phar usable in CLI applications

### DIFF
--- a/src/Silex/Compiler.php
+++ b/src/Silex/Compiler.php
@@ -105,7 +105,7 @@ Phar::mapPhar('silex.phar');
 
 require_once 'phar://silex.phar/autoload.php';
 
-if ('cli' === php_sapi_name() && isset($argv[1])) {
+if ('cli' === php_sapi_name() && basename(__FILE__) === $argv[0] && isset($argv[1])) {
     switch ($argv[1]) {
         case 'update':
             $remoteFilename = 'http://silex-project.org/get/silex.phar';


### PR DESCRIPTION
Currently, requiring silex.phar in a CLI application that takes arguments is not possible, as the phar stub interferes with the execution of the application. I added a check to the stub which will execute the main stub code only if the phar file is directly invoked.
We ran into this issue when trying to reuse the dependency setup from our Silex-based web application in the Doctrine2 ORM CLI console application, which obviously requires arguments. I know Silex is not supposed to run command line applications, but being able to reuse already configured dependencies in a CLI application should be made possible.
