### PR TITLE
Failed opening Silex/Application.php

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -542,9 +542,11 @@ The exact cause of this issue could not be determined yet.
 ioncube loader bug
 ~~~~~~~~~~~~~~~~~~
 
-Ioncube loader is an extension that can decode PHP encoded file. Unfortunately
-it is not working well with phar archive. If you installed this extension, you
-must disable it by commenting or removing this line in you php.ini file:
+Ioncube loader is an extension that can decode PHP encoded file. 
+Unfortunately, old versions (prior to version 4.0.9) are not working well 
+with phar archive.
+You must either upgrade Ioncube loder to version 4.0.9+ or disable it by 
+commenting or removing this line in you php.ini file:
 
 .. code-block:: ini
 


### PR DESCRIPTION
I created a simple php file with this source:

<pre>
require_once __DIR__ . '/silex.phar';
$app = new Silex\Application();
</pre>


It then throw this php fatal error:
 PHP Fatal error:  require(): Failed opening required 'phar:///home/laurent/projects/bishop/silex.phar/src/Silex/Application.php' (include_path='.:/usr/share/php:/usr/share/pear') in phar:///home/laurent/projects/bishop/silex.phar/vendor/Symfony/Component/ClassLoader/UniversalClassLoader.php on line 60

I have same kind of php error if I try to use silex in command line. For example:

<pre>
php silex.phar version
</pre>


My PHP version is: 5.3.5-1ubuntu7.2
