### PR TITLE
Spelling correction in Phar stub error message output

### DIFF
--- a/src/Silex/Compiler.php
+++ b/src/Silex/Compiler.php
@@ -129,7 +129,7 @@ if ('cli' === php_sapi_name() && basename(__FILE__) === $argv[0] && isset($argv[
             break;
 
         default:
-            printf("Unkown command '%s' (available commands: version, check, and update).\n", $argv[1]);
+            printf("Unknown command '%s' (available commands: version, check, and update).\n", $argv[1]);
     }
 
     exit(0);


### PR DESCRIPTION
Just a simple change (I verified that it compiles after). Hopefully I will be able to contribute back some actual work in the future :)
