### PR TITLE
[docs] removed obsolete sentence (see 5a0860)

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -20,8 +20,6 @@ controller definitions, call the ``run`` method on your application.
 
     $app->run();
 
-The use statement aliases ``Silex\Application`` to ``Application``.
-
 One other thing you have to do is configure your web server. If you
 are using apache you can use a ``.htaccess`` file for this.
 


### PR DESCRIPTION
Since https://github.com/fabpot/Silex/commit/5a08609 use statements for Silex aren't used anymore. But this sentence wasn't removed...
