### PR TITLE
Added an Error extension that provides a default error handler

### DIFF
--- a/doc/extensions.rst
+++ b/doc/extensions.rst
@@ -58,6 +58,7 @@ Included extensions
 There are a few extensions that you get out of the box.
 All of these are within the ``Silex\Extension`` namespace.
 
+* :doc:`ErrorExtension <extensions/error>`
 * :doc:`DoctrineExtension <extensions/doctrine>`
 * :doc:`MonologExtension <extensions/monolog>`
 * :doc:`SessionExtension <extensions/session>`

--- a/doc/extensions/error.rst
+++ b/doc/extensions/error.rst
@@ -1,0 +1,31 @@
+ErrorExtension
+==============
+
+The *ErrorExtension* provides a default error handler.
+
+It catches all exceptions and convert them to Responses, depending on the
+value of the **debug** parameter. When **debug** is true, it displays error
+messages with stack trace; if not, it displays a simple message to the end
+user.
+
+.. note::
+
+    This error handler can easily be overwritten by calling the ``error()``
+    method on the application.
+
+Parameters
+----------
+
+None.
+
+Services
+--------
+
+None.
+
+Registering
+-----------
+
+::
+
+    $app->register(new Silex\Extension\ErrorExtension());

--- a/doc/services.rst
+++ b/doc/services.rst
@@ -262,3 +262,8 @@ Core parameters
   Defaults to 443.
 
   This parameter can be used by the ``UrlGeneratorExtension``.
+
+* **debug** (optional): Returns whether or not the application is running in
+  debug mode.
+
+  Defaults to false.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -40,6 +40,21 @@ are using apache you can use a ``.htaccess`` file for this.
     ``RewriteBase`` statement and adjust the path to point to your directory,
     relative from the webroot.
 
+Debugging
+---------
+
+To ease debugging, enable the debug mode and register the Error extension::
+
+    require_once __DIR__.'/silex.phar';
+
+    $app = new Silex\Application();
+    $app['debug'] = true;
+    $app->register(new Silex\Extension\ErrorExtension());
+
+    // definitions
+
+    $app->run();
+
 Routing
 -------
 

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -83,6 +83,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
 
         $this['request.http_port'] = 80;
         $this['request.https_port'] = 443;
+        $this['debug'] = false;
     }
 
     /**

--- a/src/Silex/Extension/ErrorExtension.php
+++ b/src/Silex/Extension/ErrorExtension.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Extension;
+
+use Silex\Application;
+use Silex\ExtensionInterface;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Debug\ExceptionHandler;
+
+/**
+ * Defaults error handler.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ErrorExtension implements ExtensionInterface
+{
+    public function register(Application $app)
+    {
+        $app->error(function (\Exception $exception) use ($app) {
+            $code = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
+
+            if ($app['debug']) {
+                $handler = new ExceptionHandler();
+
+                return new Response($handler->getErrorMessage($exception), $code);
+            }
+
+            $title = 'Whoops, looks like something went wrong.';
+            if ($exception instanceof NotFoundHttpException) {
+                $title = 'Sorry, the page you are looking for could not be found.';
+            }
+
+            return new Response(sprintf('<!DOCTYPE html><html><head><meta charset="utf-8"><title>%s</title></head><body><h1>%s</h1></body></html>', $title, $title), $code);
+        });
+    }
+}

--- a/tests/Silex/Tests/Extension/ErrorExtensionTest.php
+++ b/tests/Silex/Tests/Extension/ErrorExtensionTest.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Extension;
+
+use Silex\Application;
+use Silex\Extension\ErrorExtension;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class ErrorExtensionTest extends \PHPUnit_Framework_TestCase
+{
+    public function testErrorHandlerExceptionNoDebug()
+    {
+        $app = new Application();
+        $app->register(new ErrorExtension());
+
+        $app->match('/foo', function () {
+            throw new \RuntimeException('foo exception');
+        });
+
+        $request = Request::create('/foo');
+        $response = $app->handle($request);
+        $this->assertContains('<title>Whoops, looks like something went wrong.</title>', $response->getContent());
+        $this->assertEquals(500, $response->getStatusCode());
+    }
+
+    public function testErrorHandlerExceptionDebug()
+    {
+        $app = new Application();
+        $app->register(new ErrorExtension());
+        $app['debug'] = true;
+
+        $app->match('/foo', function () {
+            throw new \RuntimeException('foo exception');
+        });
+
+        $request = Request::create('/foo');
+        $response = $app->handle($request);
+        $this->assertContains('<title>foo exception (500 Internal Server Error)</title>', $response->getContent());
+        $this->assertEquals(500, $response->getStatusCode());
+    }
+
+    public function testErrorHandlerNotFoundNoDebug()
+    {
+        $app = new Application();
+        $app->register(new ErrorExtension());
+
+        $request = Request::create('/foo');
+        $response = $app->handle($request);
+        $this->assertContains('<title>Sorry, the page you are looking for could not be found.</title>', $response->getContent());
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+
+    public function testErrorHandlerNotFoundDebug()
+    {
+        $app = new Application();
+        $app->register(new ErrorExtension());
+        $app['debug'] = true;
+
+        $request = Request::create('/foo');
+        $response = $app->handle($request);
+        $this->assertContains('<title>No route found for "GET /foo" (500 Internal Server Error)</title>', $response->getContent());
+        $this->assertEquals(404, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
This is a different implementation for #51. This one takes a different path for the implementation:
- the error handler is provided as an extension and not part of the core
- it is based on the default error handler provided by the HttpKernel component, instead of re-creating a new one.

The `debug` parameter is not automatically guessed as you need a Request object to do that and a request object is not always available.
