### PR TITLE
Added a default exception handler

### DIFF
--- a/doc/services.rst
+++ b/doc/services.rst
@@ -262,3 +262,8 @@ Core parameters
   Defaults to 443.
 
   This parameter can be used by the ``UrlGeneratorExtension``.
+
+* **debug** (optional): Returns whether or not the application is running in
+  debug mode.
+
+  Defaults to false.

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -347,6 +347,13 @@ If some part of your code throws an exception you will want to display
 some kind of error page to the user. This is what error handlers do. You
 can also use them to do additional things, such as logging.
 
+.. note::
+
+    Silex comes with a default error handler that displays a detailed error
+    message with the stack trace when **debug** is true, and a simple error
+    message otherwise. Error handlers registered via the ``error()`` method
+    always take precedence.
+
 To register an error handler, pass a closure to the ``error`` method
 which takes an ``Exception`` argument and returns a response::
 
@@ -360,7 +367,7 @@ You can also check for specific errors by using ``instanceof``, and handle
 them differently::
 
     use Symfony\Component\HttpFoundation\Response;
-    use Symfony\Component\HttpKernel\Exception\HttpException;
+    use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
     use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
     $app->error(function (\Exception $e) {
@@ -368,7 +375,8 @@ them differently::
             return new Response('The requested page could not be found.', 404);
         }
 
-        $code = ($e instanceof HttpException) ? $e->getStatusCode() : 500;
+        $code = $e instanceof HttpExceptionInterface ? $e->getStatusCode() : 500;
+
         return new Response('We are sorry, but something went terribly wrong.', $code);
     });
 

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -66,9 +66,16 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
             return new ControllerCollection($app['routes']);
         });
 
+        $this['exception_handler'] = $this->share(function () {
+            return new ExceptionHandler();
+        });
+
         $this['dispatcher'] = $this->share(function () use ($app) {
             $dispatcher = new EventDispatcher();
             $dispatcher->addSubscriber($app);
+            if (isset($app['exception_handler'])) {
+                $dispatcher->addSubscriber($app['exception_handler']);
+            }
 
             return $dispatcher;
         });
@@ -83,6 +90,13 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
 
         $this['request.http_port'] = 80;
         $this['request.https_port'] = 443;
+        $this['debug'] = function () {
+            if (!isset($_SERVER['REMOTE_ADDR'])) {
+                return false;
+            }
+
+            return in_array($_SERVER['REMOTE_ADDR'], array('127.0.0.1', '::1'));
+        };
     }
 
     /**

--- a/src/Silex/ExceptionHandler.php
+++ b/src/Silex/ExceptionHandler.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex;
+
+use Silex\Application;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+use Symfony\Component\HttpKernel\Debug\ExceptionHandler as DebugExceptionHandler;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Defaults exception handler.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class ExceptionHandler implements EventSubscriberInterface
+{
+    public function onSilexError(GetResponseForErrorEvent $event)
+    {
+        $app = $event->getKernel();
+        $exception = $event->getException();
+        $code = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
+
+        if ($app['debug']) {
+            $handler = new DebugExceptionHandler();
+
+            $response = new Response($handler->getErrorMessage($exception), $code);
+        } else {
+            $title = 'Whoops, looks like something went wrong.';
+            if ($exception instanceof NotFoundHttpException) {
+                $title = 'Sorry, the page you are looking for could not be found.';
+            }
+
+            $response = new Response(sprintf('<!DOCTYPE html><html><head><meta charset="utf-8"><title>%s</title></head><body><h1>%s</h1></body></html>', $title, $title), $code);
+        }
+
+        $event->setResponse($response);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    static public function getSubscribedEvents()
+    {
+        return array(SilexEvents::ERROR => array('onSilexError', -255));
+    }
+}

--- a/tests/Silex/Tests/FunctionalTest.php
+++ b/tests/Silex/Tests/FunctionalTest.php
@@ -118,6 +118,7 @@ EOF
         $mounted = new LazyApplication($tmp);
 
         $app = new Application();
+        unset($app['exception_handler']);
         $app->mount('/hello', $mounted);
 
         try {

--- a/tests/Silex/Tests/RouterTest.php
+++ b/tests/Silex/Tests/RouterTest.php
@@ -102,6 +102,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     public function testMissingRoute()
     {
         $app = new Application();
+        unset($app['exception_handler']);
 
         $request = Request::create('/baz');
         $app->handle($request);


### PR DESCRIPTION
Based on #51 and #132, here is another implementation of the same idea:
- the `debug` parameter is guessed based on the `$_SERVER` array (which avoids depending on a Request being available). It can easily be overridden if needed but the default should be good enough in most cases.
- the exception handler is registered by default (still based on the default exception handler provided by the `HttpKernel` component) but it can easily be disabled if needed: `unset($app['exception_handler'])`.

That should make everybody happy.
