### PR TITLE
Cache extension documentation

### DIFF
--- a/doc/extensions/http_cache.rst
+++ b/doc/extensions/http_cache.rst
@@ -91,6 +91,6 @@ For WAMP: the default configuration file is located under:
 C:\\wamp\\conf\\phpX.X\\php.ini where X.X is the PHP version you're using.
 
 * **Apache**: mod_cache, mod_disk_cach, mod_mem_cache
-Verify you're Apache configuration set up properly so that Apache won't override any 
-of you're caching directives.
+Verify that your Apache configuration is set up properly so that Apache won't override any 
+of your caching directives.
 


### PR DESCRIPTION
I've added information that will help setting up a dev. environment to use/test caching. It's been discussed in Silex Google user group.

The main problem is that MAMP/WAMP default configuration will sent anti caching headers and that will mess up the expected behavior using Silex caching. The addition to the documentation discusses that and how to configure it to get proper caching expects.
