### PR TITLE
Check if $argv[0] isset before using it in compiled phar/Compiler

### DIFF
--- a/src/Silex/Compiler.php
+++ b/src/Silex/Compiler.php
@@ -105,7 +105,7 @@ Phar::mapPhar('silex.phar');
 
 require_once 'phar://silex.phar/autoload.php';
 
-if ('cli' === php_sapi_name() && basename(__FILE__) === $argv[0] && isset($argv[1])) {
+if ('cli' === php_sapi_name() && isset($argv[0]) &&  basename(__FILE__) === $argv[0] && isset($argv[1])) {
     switch ($argv[1]) {
         case 'update':
             $remoteFilename = 'http://silex-project.org/get/silex.phar';


### PR DESCRIPTION
https://github.com/fabpot/Silex/commit/3d8ba8432023239f476837150a4f7c4a95bb8542

Made my unittests fail because of "Undefined variable: argv"

Commit should fix this by checking via isset first.
