### PR TITLE
change pimple URL to pimple-project.org (since pimple has its own site no

### DIFF
--- a/doc/services.rst
+++ b/doc/services.rst
@@ -2,7 +2,7 @@ Services
 ========
 
 Silex is not only a microframework. It is also a micro service container.
-It does this by extending `Pimple <https://github.com/fabpot/Pimple>`_
+It does this by extending `Pimple <http://pimple-project.org>`_
 which provides service goodness in just 44 NCLOC.
 
 Dependency Injection


### PR DESCRIPTION
change pimple URL to pimple-project.org (since pimple has its own site now)
