### PR TITLE
Load default form_div_layout.html.twig from TwigBridge

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -52,6 +52,11 @@ class TwigServiceProvider implements ServiceProviderInterface
 
                 if (isset($app['form.factory'])) {
                     $twig->addExtension(new TwigFormExtension(array('form_div_layout.html.twig')));
+
+                    // add loader for form_div_layout.html.twig
+                    $reflected = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
+                    $path = dirname($reflected->getFileName()).'/../Resources/views/Form';
+                    $app['twig.loader']->addLoader(new \Twig_Loader_Filesystem($path));
                 }
             }
 


### PR DESCRIPTION
Load default form_div_layout.html.twig when using form and twig service providers. This means you no longer have to copy form_div_layout.html.twig to your project.
