### PR TITLE
Documentation fix

### DIFF
--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -234,7 +234,7 @@ You can now use this provider as follows::
 
     $app = new Silex\Application();
 
-    $app->connect('/blog', new Acme\HelloControllerProvider());
+    $app->mount('/blog', new Acme\HelloControllerProvider());
 
 In this example, the ``/blog/`` path now references the controller defined in
 the provider.


### PR DESCRIPTION
Connect method does not exists in providers doc ; but mount exists and this is the one expected in the example
