### PR TITLE
provider doc correction

### DIFF
--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -234,7 +234,7 @@ You can now use this provider as follows::
 
     $app = new Silex\Application();
 
-    $app->connect('/blog', new Acme\HelloControllerProvider());
+    $app->mount('/blog', new Acme\HelloControllerProvider());
 
 In this example, the ``/blog/`` path now references the controller defined in
 the provider.


### PR DESCRIPTION
Silex\Application::connect() doesn't exist (anymore). replaced it with mount()
