### PR TITLE
add a prefix to defaultRouteName to prevent route name conflicts

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -283,7 +283,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
      */
     public function flush($prefix = '')
     {
-        $this['routes']->addCollection($this['controllers']->flush(), $prefix);
+        $this['routes']->addCollection($this['controllers']->flush($prefix), $prefix);
     }
 
     /**
@@ -326,7 +326,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
             throw new \LogicException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
         }
 
-        $this['routes']->addCollection($app->flush(), $prefix);
+        $this['routes']->addCollection($app->flush($prefix), $prefix);
     }
 
     /**

--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -152,12 +152,12 @@ class Controller
         $this->isFrozen = true;
     }
 
-    public function bindDefaultRouteName()
+    public function bindDefaultRouteName($prefix)
     {
         $requirements = $this->route->getRequirements();
         $method = isset($requirements['_method']) ? $requirements['_method'] : '';
 
-        $routeName = $method.$this->route->getPattern();
+        $routeName = $prefix.$method.$this->route->getPattern();
         $routeName = str_replace(array('/', ':', '|', '-'), '_', $routeName);
         $routeName = preg_replace('/[^a-z0-9A-Z_.]+/', '', $routeName);
 

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -115,13 +115,13 @@ class ControllerCollection
      *
      * @return RouteCollection A RouteCollection instance
      */
-    public function flush()
+    public function flush($prefix = '')
     {
         $routes = new RouteCollection();
 
         foreach ($this->controllers as $controller) {
             if (!$controller->getRouteName()) {
-                $controller->bindDefaultRouteName();
+                $controller->bindDefaultRouteName($prefix);
             }
             $routes->add($controller->getRouteName(), $controller->getRoute());
             $controller->freeze();

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -70,4 +70,19 @@ class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
         } catch (ControllerFrozenException $e) {
         }
     }
+
+    public function testConflictingRouteNames()
+    {
+        $controllers = new ControllerCollection();
+
+        $mountedRootController = new Controller(new Route('/'));
+        $controllers->add($mountedRootController);
+
+        $mainRootController = new Controller(new Route('/'));
+        $mainRootController->bindDefaultRouteName('main_');
+
+        $controllers->flush();
+
+        $this->assertNotEquals($mainRootController->getRouteName(), $mountedRootController->getRouteName());
+    }
 }

--- a/tests/Silex/Tests/ControllerTest.php
+++ b/tests/Silex/Tests/ControllerTest.php
@@ -75,7 +75,7 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testDefaultRouteNameGeneration(Route $route, $expectedRouteName)
     {
         $controller = new Controller($route);
-        $controller->bindDefaultRouteName();
+        $controller->bindDefaultRouteName('');
 
         $this->assertEquals($expectedRouteName, $controller->getRouteName());
     }


### PR DESCRIPTION
- closes #189
- identical route names no longer conflict when merging RouteCollections
- route names are automatically generated by
  Controller::bindDefaultRouteName
