### PR TITLE
Option to Use ApcUniversalClassLoader

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -39,6 +39,7 @@ use Symfony\Component\Routing\Exception\ExceptionInterface as RoutingException;
 use Symfony\Component\Routing\Exception\MethodNotAllowedException;
 use Symfony\Component\Routing\Exception\ResourceNotFoundException;
 use Symfony\Component\ClassLoader\UniversalClassLoader;
+use Symfony\Component\ClassLoader\ApcUniversalClassLoader;
 use Silex\RedirectableUrlMatcher;
 use Silex\ControllerResolver;
 
@@ -54,12 +55,25 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
     /**
      * Constructor.
      */
-    public function __construct()
+    public function __construct($apc_loader = null)
     {
         $app = $this;
 
         $this['autoloader'] = $this->share(function () {
-            $loader = new UniversalClassLoader();
+            /* Use ApcUniversalClassLoader */
+            if (true === $apc_loader) {
+                /* ensure APC is loaded */
+                if ( extension_loaded('apc') ) {
+                    $loader = new ApcUniversalClassLoader('silex.loader');
+                } else {
+                    /* fallback to normal loader and let the developer know */
+                    trigger_error("APC not loaded; falling back to default 'UniversalClassLoader()'", E_USER_WARNING);
+                    $loader = new UniversalClassLoader();
+                }
+            } else {
+                $loader = new UniversalClassLoader();
+            }
+
             $loader->register();
 
             return $loader;


### PR DESCRIPTION
Setting Application.php's constructor argument to true will cause Silex to use ApcUniversalClassLoader for a performance boost. Adding no argument to the constructor will cause Silex to use the default UniversalClassLoader as before.

A constructor argument seems best since the class loader is initialized in the constructor, thus no $app['apc'] option could be used here.

Will add tests if you think this is a reasonable change.
