### PR TITLE
Added priority 20 to Application::onKernelRequest()

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -449,7 +449,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
         return array(
             KernelEvents::REQUEST    => array(
                 array('onEarlyKernelRequest', 256),
-                array('onKernelRequest')
+                array('onKernelRequest', 20)
             ),
             KernelEvents::CONTROLLER => 'onKernelController',
             KernelEvents::RESPONSE   => 'onKernelResponse',


### PR DESCRIPTION
The onKernelRequest listener method is called _after_ the
RouterListener::onKernelRequest() listener method, rendering Responses from
callbacks registered by the Application::before() method useless. 

Setting the priority to 20 in Application::getSubscribedEvents() fixes this problem.
