### PR TITLE
[docs] set detect_unicode=off, so phar:// is no longer needed

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -582,6 +582,7 @@ the following may help.
 
 .. code-block:: ini
 
+    detect_unicode = Off
     phar.readonly = Off
     phar.require_hash = Off
 
@@ -610,10 +611,10 @@ The exact cause of this issue could not be determined yet.
 ioncube loader bug
 ~~~~~~~~~~~~~~~~~~
 
-Ioncube loader is an extension that can decode PHP encoded file. 
-Unfortunately, old versions (prior to version 4.0.9) are not working well 
+Ioncube loader is an extension that can decode PHP encoded file.
+Unfortunately, old versions (prior to version 4.0.9) are not working well
 with phar archives.
-You must either upgrade Ioncube loader to version 4.0.9 or newer or disable it 
+You must either upgrade Ioncube loader to version 4.0.9 or newer or disable it
 by commenting or removing this line in your php.ini file:
 
 .. code-block:: ini


### PR DESCRIPTION
detect_unicode was causing some issues with wrongly detecting the encoding. This is one of the reasons that phar:// was required, but I am not sure if this is the only case. I will leave the "phar-stub bug" section there for now.
