### PR TITLE
added mention of SymfonyBridgesServiceProvider to example of using path Twig function

### DIFF
--- a/doc/providers/twig.rst
+++ b/doc/providers/twig.rst
@@ -80,7 +80,7 @@ from a template:
 
     {{ render('/sidebar') }}
 
-    {# or if you are also using UrlGeneratorServiceProvider #}
+    {# or if you are also using UrlGeneratorServiceProvider with the SymfonyBridgesServiceProvider #}
     {{ render(path('sidebar')) }}
 
 For more information, check out the `Twig documentation


### PR DESCRIPTION
I just spent an hour trying to figure out why using path() in Twig when using Silex wasn't working.  Turns out I hadn't included the SymfonyBridgesServiceProvider, which isn't mentioned in this piece of documentation.

I don't know if this makes the comment too verbose, but if it saves someone else wasting time it'll be worth it.
