### PR TITLE
Configuration service provider pull request

### DIFF
--- a/src/Silex/Provider/ConfigurationServiceProvider.php
+++ b/src/Silex/Provider/ConfigurationServiceProvider.php
@@ -1,0 +1,203 @@
+<?php
+
+namespace Silex\Provider;
+
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+
+/**
+ * Configuration service provider.
+ *
+ * @package ServiceProvider
+ * @author Andrew Stephanoff <andrew.stephanoff@gmail.com>
+ */
+class ConfigurationServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * @var array
+     */
+    private $config;
+
+    /**
+     * @param string $filename
+     * @throws \InvalidArgumentException File not readable or not exists
+     */
+    public function __construct($filename)
+    {
+        if (!is_readable($filename)) {
+            throw new \InvalidArgumentException("File '{$filename}' not readable or not exists");
+        }
+
+        $type = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+
+        if ('ini' === $type) {
+            $this->config = self::parseIniFile($filename);
+
+        } else if ('json' === $type) {
+            $this->config = self::parseJsonFile($filename);
+
+        } else if ('xml' === $type) {
+            $this->config = self::parseXmlFile($filename);
+
+        } else if ('php' === $type) {
+            $this->config = require $filename;
+
+        } else {
+            $this->config = array();
+        }
+    }
+
+    /**
+     * @param \Silex\Application $app
+     */
+    public function register(Application $app)
+    {
+        $app['config'] = $this->config;
+
+        self::initializeApplication($app, $this->config);
+    }
+
+    /**
+     * @param Application $app
+     * @param array $config
+     */
+    private static function initializeApplication(Application $app, array $config)
+    {
+        if (!isset($config['silex'])) {
+            return;
+        }
+
+        if (isset($config['silex']['autoloader'])) {
+            self::processSectionAutoloader($app, $config['silex']['autoloader']);
+        }
+
+        if (isset($config['silex']['service_provider'])) {
+            self::processSectionServiceProvider($app, $config['silex']['service_provider']);
+        }
+
+        if (isset($config['silex']['controller_provider'])) {
+            self::processSectionControllerProvider($app, $config['silex']['controller_provider']);
+        }
+    }
+
+    /**
+     * Register namespaces and prefixes in autoloader.
+     *
+     * @param Application $app
+     * @param array $config
+     */
+    private static function processSectionAutoloader(Application $app, array $config)
+    {
+        if (isset($config['register_namespace'])) {
+            foreach ($config['register_namespace'] as $namespace) {
+                $app['autoloader']->registerNamespace($namespace['namespace'], $namespace['path']);
+            }
+        }
+
+        if (isset($config['register_prefix'])) {
+            foreach ($config['register_prefix'] as $prefix) {
+                $app['autoloader']->registerPrefix($prefix['prefix'], $prefix['path']);
+            }
+        }
+    }
+
+    /**
+     * Register service providers.
+     *
+     * @param Application $app
+     * @param array $config
+     */
+    private static function processSectionServiceProvider(Application $app, array $config)
+    {
+        foreach ($config as $section) {
+            $provider = self::instantinate($section);
+            $app->register($provider);
+        }
+    }
+
+    /**
+     * Register controller providers and mount them.
+     *
+     * @param Application $app
+     * @param array $config
+     */
+    private static function processSectionControllerProvider(Application $app, array $config)
+    {
+        foreach ($config as $section) {
+            $provider = self::instantinate($section);
+            $app->mount($section['mount'], $provider);
+        }
+    }
+
+    /**
+     * @param array $config
+     * @return object
+     */
+    private static function instantinate($config)
+    {
+        if (isset($config['constructor']) && $config['constructor']) {
+            $reflection = new \ReflectionClass($config['classname']);
+            $instance = $reflection->newInstanceArgs(array_values($config['constructor']));
+        } else {
+            $instance = new $config['classname'];
+        }
+
+        return $instance;
+    }
+
+    /**
+     * @param string $filename
+     * @return array
+     */
+    private static function parseIniFile($filename)
+    {
+        $config = parse_ini_file($filename, true);
+
+        foreach (array_keys($config) as $name) {
+            foreach ($config[$name] as $key => $value) {
+                if (false === strpos($key, '.')) {
+                    continue;
+                }
+
+                $chunks = explode('.', strtolower($key));
+                $last = count($chunks) - 1;
+
+                $c =& $config[$name];
+
+                for ($i = 0; $i < $last; ++ $i) {
+                    if (!isset($c[$chunks[$i]])) {
+                        $c[$chunks[$i]] = array();
+                    }
+                    $c =& $c[$chunks[$i]];
+                }
+
+                $c[$chunks[$last]] = $value;
+                unset($config[$name][$key]);
+            }
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param string $filename
+     * @return array
+     */
+    private static function parseJsonFile($filename)
+    {
+        if (null === ($config = json_decode(file_get_contents($filename), true))) {
+            throw new \RuntimeException("Json file '{$filename}' mailformed");
+        }
+        return $config;
+    }
+
+    /**
+     * @param string $filename
+     * @return array
+     */
+    private static function parseXmlFile($filename)
+    {
+        $xml = simplexml_load_file($filename);
+        return $xml;
+    }
+}

--- a/tests/Silex/Tests/Provider/ConfigurationServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ConfigurationServiceProviderTest.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Silex\Tests\Provider
+{
+    use Silex\Application;
+    use Silex\Provider\ConfigurationServiceProvider;
+
+class ConfigurationServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var \Silex\Application
+     */
+    private $app;
+
+    protected function setUp()
+    {
+        $this->app = new Application();
+    }
+
+    /**
+     *
+     */
+    public function testIni()
+    {
+        $filename = __DIR__ . '/fixtures/configuration.ini';
+        $this->app->register(new ConfigurationServiceProvider($filename));
+
+        $this->assertInstanceOf('Acme\ServiceProvider\MyServiceProvider', $this->app['acme']);
+        $this->assertInternalType('array', $this->app['config']);
+    }
+
+    public function testJson()
+    {
+        $filename = __DIR__ . '/fixtures/configuration.json';
+        $this->app->register(new ConfigurationServiceProvider($filename));
+
+        $this->assertInstanceOf('Acme\ServiceProvider\MyServiceProvider', $this->app['acme']);
+        $this->assertInternalType('array', $this->app['config']);
+    }
+}
+}
+
+namespace Acme\ServiceProvider
+{
+    use Silex\ServiceProviderInterface;
+    use Silex\Application;
+
+    class MyServiceProvider implements ServiceProviderInterface
+    {
+        public function register(Application $app)
+        {
+            $app['acme'] = $this;
+        }
+    }
+}
+
+namespace Acme
+{
+    use Silex\ControllerCollection;
+	use Silex\ControllerProviderInterface;
+    use Silex\Application;
+
+    class BlogControllerProvider implements ControllerProviderInterface
+    {
+        public function connect(Application $app)
+        {
+            $controllers = new ControllerCollection();
+            return $controllers;
+        }
+    }
+}

--- a/tests/Silex/Tests/Provider/fixtures/configuration.ini
+++ b/tests/Silex/Tests/Provider/fixtures/configuration.ini
@@ -1,0 +1,14 @@
+[silex]
+
+autoload.register_namespace.0.namespace = "Acme"
+autoload.register_namespace.0.path = "path/to/acme/src"
+
+service_provider.0.classname = "Acme\ServiceProvider\MyServiceProvider"
+
+controller_provider.0.mount = "/blog"
+controller_provider.0.classname = "Acme\BlogControllerProvider"
+
+[database]
+
+user = "root"
+password = "password"

--- a/tests/Silex/Tests/Provider/fixtures/configuration.json
+++ b/tests/Silex/Tests/Provider/fixtures/configuration.json
@@ -1,0 +1,24 @@
+{
+    "silex": {
+        "autoload": {
+            "register_namespace": [{
+                "namespace" : "Acme",
+                "path" : "path/to/acme/src"
+            }],
+
+            "register_prefix": [{
+                "prefix" : "Acme",
+                "path" : "path/to/acme/src"
+            }]
+        },
+
+        "service_provider": [{
+            "classname" : "Acme\\ServiceProvider\\MyServiceProvider"
+        }],
+
+        "controller_provider": [{
+            "mount": "/blog",
+            "classname" : "Acme\\BlogControllerProvider"
+        }]
+    }
+}

--- a/tests/Silex/Tests/Provider/fixtures/configuration.xml
+++ b/tests/Silex/Tests/Provider/fixtures/configuration.xml
@@ -1,0 +1,13 @@
+<?xml version="1"?>
+<configuration>
+    <silex>
+        <autoload>
+            <register_namespace namespace="Acme" path="path/to/acme/src" />
+            <register_namespace namespace="Acme" path="path/to/acme/src" />
+        </autoload>
+
+        <service_provider>
+            <classname>Acme\ServiceProvider\MyServiceProvider</classname>
+        </service_provider>
+    </silex>
+</configuration>


### PR DESCRIPTION
Hi Fabian,

First of all I want to say thank you for Symfony components and for Silex - this is a great tools!
This service provider can be used for configure $app['autoloader'] service and for registering other service providers and controller providers with configuration file instead of defining this configuration in code.
Could you please take a look on my code?

Thank you.
