### PR TITLE
Fix update_vendors.sh

### DIFF
--- a/update_vendors.sh
+++ b/update_vendors.sh
@@ -5,7 +5,7 @@ COMPONENTS='BrowserKit CssSelector EventDispatcher HttpFoundation Process ClassL
 cd vendor/Symfony/Component
 for COMPONENT in $COMPONENTS
 do
-    cd $COMPONENT && git fetch origin && git reset --hard origin/master && cd ..
+    cd $COMPONENT && (git fetch origin && git reset --hard origin/master || true) && cd ..
 done
 cd ../../..
 


### PR DESCRIPTION
If something bad happen during a `git fetch` (ie : if github is down ...) , the script will not return in parent folder. 
So it could make weird / not expected things.

Note : I did not test this code on Max OS platform, only on *nix
