### PR TITLE
[composer] add branch-alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,8 @@
 {
     "name": "silex/silex",
-    "type": "library",
     "description": "The PHP micro-framework based on the Symfony2 Components",
     "keywords": ["microframework"],
     "homepage": "http://silex.sensiolabs.org",
-    "version": "1.0.0",
     "license": "MIT",
     "authors": [
         {


### PR DESCRIPTION
This means we get a 1.0-dev version that can be installed as `1.0.*` or `>=1.0-dev`
