### PR TITLE
add "after($callback)" to Controller in order to mimic a "Route Middleware" feature in Silex

### DIFF
--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -155,6 +155,22 @@ class Controller
     }
 
     /**
+     * Sets a callback to handle before triggering the route callback.
+     * (a.k.a. "Route Middleware")
+     *
+     * @param mixed  $callback A PHP callback to be triggered when the Route is matched, just before the route callback
+     * @return Controller $this The current Controller instance
+     */
+    public function middleware($callback)
+    {
+        $middlewareCallbacks = $this->route->getDefault('_middlewares');
+        $middlewareCallbacks[] = $callback;
+        $this->route->setDefault('_middlewares', $middlewareCallbacks);
+
+        return $this;
+    }
+
+    /**
      * Freezes the controller.
      *
      * Once the controller is frozen, you can no longer change the route name


### PR DESCRIPTION
Hi !

As discussed in #262 and in my previous similar PR (https://github.com/fabpot/Silex/pull/270) with @GromNaN, here is another implementation of the Routes Middlewares feature, shipped with its Unit Test.

The feature addition is still 100% backward compatible, but this time it may be more "Silex style" compliant - and it's "100% no performance loss" :-)

With this PR the Silex `Controller` class has a new `before()` method, which registers a callback to trigger when the Route is matched, just before the route callback itself.
This `before()` method can be called more than one time on a single Route definition, allowing multiple secondary callbacks (a.k.a. "Routes Middlewares") to be executed before the Route main callback.

Would this feature be eligible for Silex integration, like this ?

Olivier
