### PR TITLE
added autoload_classmap.php to the list of .composer files to include

### DIFF
--- a/src/Silex/Compiler.php
+++ b/src/Silex/Compiler.php
@@ -71,6 +71,7 @@ class Compiler
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/ClassLoader.php'));
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload_namespaces.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload_classmap.php'));
 
         // Stubs
         $phar->setStub($this->getStub());


### PR DESCRIPTION
Hi,

I suspect this is my own stupidity since no-one else has reported it, but for me the silex.phar dies when required because it doesn't contain a file that it tries to require: "vendor/.composer/autoload_classmap.php".

I've tried the silex.phar from the project homepage, and also compiled my own from the source code with the same result.  Unpacking either shows indeed that there is no autoload_classmap.php file.

Had a quick look and saw that some other vendor/.composer/*.php files were listed in the Compiler.php class, added in the missing classmap file, and everything seemed to work fine.

As I said, I think I must be missing something, because otherwise silex would be completely broken for just about everybody! using the phar!
