### PR TITLE
Removed the Symfony2 tests from the phar archive

### DIFF
--- a/src/Silex/Compiler.php
+++ b/src/Silex/Compiler.php
@@ -51,6 +51,7 @@ class Compiler
             ->ignoreVCS(true)
             ->name('*.php')
             ->notName('Compiler.php')
+            ->exclude('Tests')
             ->in(__DIR__.'/..')
             ->in(__DIR__.'/../../vendor/pimple/pimple/lib')
             ->in(__DIR__.'/../../vendor/symfony/class-loader/Symfony/Component/ClassLoader')


### PR DESCRIPTION
Components' tests are now distributed with the code, making the
archive far bigger if we don't exclude them.
