### PR TITLE
Updated the compiler for the new Composer file location

### DIFF
--- a/compile
+++ b/compile
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-require_once __DIR__.'/vendor/.composer/autoload.php';
+require_once __DIR__.'/vendor/autoload.php';
 
 use Silex\Compiler;
 

--- a/src/Silex/Compiler.php
+++ b/src/Silex/Compiler.php
@@ -69,10 +69,10 @@ class Compiler
         }
 
         $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../LICENSE'), false);
-        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload.php'));
-        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/ClassLoader.php'));
-        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload_namespaces.php'));
-        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/.composer/autoload_classmap.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/autoload.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/ClassLoader.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/autoload_namespaces.php'));
+        $this->addFile($phar, new \SplFileInfo(__DIR__.'/../../vendor/autoload_classmap.php'));
 
         // Stubs
         $phar->setStub($this->getStub());
@@ -112,7 +112,7 @@ class Compiler
 
 Phar::mapPhar('silex.phar');
 
-require_once 'phar://silex.phar/vendor/.composer/autoload.php';
+require_once 'phar://silex.phar/vendor/autoload.php';
 
 if ('cli' === php_sapi_name() && basename(__FILE__) === basename($_SERVER['argv'][0]) && isset($_SERVER['argv'][1])) {
     switch ($_SERVER['argv'][1]) {


### PR DESCRIPTION
This updates the phar for the new location of composer files since composer/composer#603

Old files are created by composer for BC reason but it would not help here as they need the new ones which would not be included in the phar before my change. I haven't included the BC files in the phar as they are not needed (users will not access them directly anyway)
