### PR TITLE
Composer Requirements Reference Non-Existent Versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,12 +21,12 @@
         "symfony/class-loader": "2.1.*",
         "symfony/css-selector": "2.1.*",
         "symfony/dom-crawler": "2.1.*",
-        "symfony/event-dispatcher": "2.1.*",
+        "symfony/event-dispatcher": "2.0.12",
         "symfony/http-foundation": "2.1.*",
-        "symfony/http-kernel": "2.1.*",
+        "symfony/http-kernel": "2.0.12",
         "symfony/routing": "2.1.*",
         "symfony/process": "2.1.*",
-        "symfony/finder": "2.1.*"
+        "symfony/finder": "2.0.12"
     },
     "require-dev": {
         "symfony/form": "2.1.*",


### PR DESCRIPTION
The Composer requirements reference non-existent versions (`2.1.*`) of `symfony/event-dispatcher`, `symfony/http-kernel`, and `symfony/finder`. This causes Composer to fail when attempting to fetch dependencies since these dependencies are impossible to fulfill. This change updates the version requirements for these items to `2.0.12` (the most recent version of each). I would have used `2.0.*`, but this also causes Composer to fail for some reason (this part may be a Composer issue).
