### PR TITLE
[Doc] Used assertCount(1, ...) instead of assertEquals(1, count(..)) in Testing

### DIFF
--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -129,8 +129,8 @@ and allows you to interact with your application. Here's how it works::
             $crawler = $client->request('GET', '/');
 
             $this->assertTrue($client->getResponse()->isOk());
-            $this->assertEquals(1, count($crawler->filter('h1:contains("Contact us")')));
-            $this->assertEquals(1, count($crawler->filter('form')));
+            $this->assertCount(1, $crawler->filter('h1:contains("Contact us")'));
+            $this->assertCount(1, $crawler->filter('form'));
             ...
         }
 


### PR DESCRIPTION
It's better to use the `assertCount()` method from PHPunit for testing a length of a array. This method is avaible since PHPunit 3.6.0
