### PR TITLE
Add mapping file for the form in the validator service

### DIFF
--- a/src/Silex/Provider/ValidatorServiceProvider.php
+++ b/src/Silex/Provider/ValidatorServiceProvider.php
@@ -17,6 +17,8 @@ use Silex\ServiceProviderInterface;
 use Symfony\Component\Validator\Validator;
 use Symfony\Component\Validator\Mapping\ClassMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
+use Symfony\Component\Validator\Mapping\Loader\LoaderChain;
+use Symfony\Component\Validator\Mapping\Loader\XmlFileLoader;
 use Symfony\Component\Validator\ConstraintValidatorFactory;
 
 /**
@@ -36,6 +38,15 @@ class ValidatorServiceProvider implements ServiceProviderInterface
         });
 
         $app['validator.mapping.class_metadata_factory'] = $app->share(function () use ($app) {
+            if (isset($app['form.factory'])) {
+                $reflClass = new \ReflectionClass('Symfony\\Component\\Form\\FormInterface');
+
+                return new ClassMetadataFactory(new LoaderChain(array(
+                    new StaticMethodLoader(),
+                    new XmlFileLoader(dirname($reflClass->getFileName()) . '/Resources/config/validation.xml')
+                )));
+            }
+
             return new ClassMetadataFactory(new StaticMethodLoader());
         });
 

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -44,4 +44,36 @@ class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
     {
         $this->assertInstanceOf('Symfony\Component\Validator\Validator', $app['validator']);
     }
+
+    /**
+     * @depends testRegister
+     */
+    public function testValidatorServiceWithFormServiceDisabled($app)
+    {
+        if (!is_dir(__DIR__ . '/../../../../vendor/symfony/form')) {
+            $this->markTestSkipped('Form submodule was not installed.');
+        }
+
+        $metadatas = $app['validator']->getMetadataFactory()->getClassMetadata('Symfony\Component\Form\Form');
+
+        $this->assertEquals(0, count($metadatas->constraints));
+    }
+
+    /**
+     * @depends testRegister
+     */
+    public function testValidatorServiceWithFormServiceEnabled($app)
+    {
+        if (!is_dir(__DIR__ . '/../../../../vendor/symfony/form')) {
+            $this->markTestSkipped('Form submodule was not installed.');
+        }
+
+        $app->register(new ValidatorServiceProvider());
+
+        $app['form.factory'] = true;
+
+        $metadatas = $app['validator']->getMetadataFactory()->getClassMetadata('Symfony\Component\Form\Form');
+
+        $this->assertEquals(1, count($metadatas->constraints));
+    }
 }


### PR DESCRIPTION
Hi,

I've added mapping file for the form in the validator in order to get the proper validation process when a form instance is build using a Form Definition class + a Data Class.
