### PR TITLE
Fix bug ; httpcache does not trig the terminate event

### DIFF
--- a/src/Silex/HttpCache.php
+++ b/src/Silex/HttpCache.php
@@ -32,6 +32,9 @@ class HttpCache extends BaseHttpCache
             $request = Request::createFromGlobals();
         }
 
-        $this->handle($request)->send();
+        $response = $this->handle($request);
+        $response->send();
+
+        $this->terminate($request, $response);
     }
 }


### PR DESCRIPTION
After having implemented TerminableInterface, we forgot to modify the HttpCache provider, here is the fix, and it is important as its sends the emails when using SwiftMailer provider
