### PR TITLE
Tweaked composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.2",
-        "pimple/pimple": "dev-master",
+        "php": ">=5.3.3",
+        "pimple/pimple": "1.*",
         "symfony/browser-kit": "2.1.*",
         "symfony/class-loader": "2.1.*",
         "symfony/css-selector": "2.1.*",


### PR DESCRIPTION
- Symfony components  now require php >= 5.3.3
- Pimple is now taggued
