### PR TITLE
added the ServiceProviderInterface::boot() method

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,6 +3,8 @@ Changelog
 
 This changelog references all backward incompatibilities as we introduce them:
 
+* **2012-05-26**: added ``boot()`` to ``ServiceProviderInterface``
+
 * **2012-05-26**: Removed ``SymfonyBridgesServiceProvider``
 
 * **2012-05-26**: Removed the ``translator.messages`` parameter (use

--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -119,4 +119,8 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             return $dbs[$app['dbs.default']];
         });
     }
+
+    public function boot(Application $app)
+    {
+    }
 }

--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -52,4 +52,8 @@ class FormServiceProvider implements ServiceProviderInterface
             return new DefaultCsrfProvider($app['form.secret']);
         });
     }
+
+    public function boot(Application $app)
+    {
+    }
 }

--- a/src/Silex/Provider/HttpCacheServiceProvider.php
+++ b/src/Silex/Provider/HttpCacheServiceProvider.php
@@ -42,4 +42,8 @@ class HttpCacheServiceProvider implements ServiceProviderInterface
             $app['http_cache.options'] = array();
         }
     }
+
+    public function boot(Application $app)
+    {
+    }
 }

--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -50,7 +50,10 @@ class MonologServiceProvider implements ServiceProviderInterface
                 return Logger::DEBUG;
             };
         }
+    }
 
+    public function boot(Application $app)
+    {
         $app->before(function (Request $request) use ($app) {
             $app['monolog']->addInfo('> '.$request->getMethod().' '.$request->getRequestUri());
         });

--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -49,8 +49,6 @@ class SessionServiceProvider implements ServiceProviderInterface
             );
         });
 
-        $app['dispatcher']->addListener(KernelEvents::REQUEST, array($this, 'onKernelRequest'), 128);
-
         if (!isset($app['session.storage.options'])) {
             $app['session.storage.options'] = array();
         }
@@ -69,5 +67,10 @@ class SessionServiceProvider implements ServiceProviderInterface
         if ($request->hasPreviousSession()) {
             $request->getSession()->start();
         }
+    }
+
+    public function boot(Application $app)
+    {
+        $app['dispatcher']->addListener(KernelEvents::REQUEST, array($this, 'onKernelRequest'), 128);
     }
 }

--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -76,14 +76,17 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface
             return new \Swift_Events_SimpleEventDispatcher();
         });
 
-        $app->finish(function () use ($app) {
-            $app['swiftmailer.spooltransport']->getSpool()->flushQueue($app['swiftmailer.transport']);
-        });
-
         if (isset($app['swiftmailer.class_path'])) {
             require_once $app['swiftmailer.class_path'].'/Swift.php';
 
             \Swift::registerAutoload($app['swiftmailer.class_path'].'/../swift_init.php');
         }
+    }
+
+    public function boot(Application $app)
+    {
+        $app->finish(function () use ($app) {
+            $app['swiftmailer.spooltransport']->getSpool()->flushQueue($app['swiftmailer.transport']);
+        });
     }
 }

--- a/src/Silex/Provider/TranslationServiceProvider.php
+++ b/src/Silex/Provider/TranslationServiceProvider.php
@@ -53,4 +53,8 @@ class TranslationServiceProvider implements ServiceProviderInterface
             return new MessageSelector();
         });
     }
+
+    public function boot(Application $app)
+    {
+    }
 }

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -90,4 +90,8 @@ class TwigServiceProvider implements ServiceProviderInterface
             ));
         });
     }
+
+    public function boot(Application $app)
+    {
+    }
 }

--- a/src/Silex/Provider/UrlGeneratorServiceProvider.php
+++ b/src/Silex/Provider/UrlGeneratorServiceProvider.php
@@ -31,4 +31,8 @@ class UrlGeneratorServiceProvider implements ServiceProviderInterface
             return new UrlGenerator($app['routes'], $app['request_context']);
         });
     }
+
+    public function boot(Application $app)
+    {
+    }
 }

--- a/src/Silex/Provider/ValidatorServiceProvider.php
+++ b/src/Silex/Provider/ValidatorServiceProvider.php
@@ -43,4 +43,8 @@ class ValidatorServiceProvider implements ServiceProviderInterface
             return new ConstraintValidatorFactory();
         });
     }
+
+    public function boot(Application $app)
+    {
+    }
 }

--- a/src/Silex/ServiceProviderInterface.php
+++ b/src/Silex/ServiceProviderInterface.php
@@ -21,7 +21,19 @@ interface ServiceProviderInterface
     /**
      * Registers services on the given app.
      *
+     * This method should only be used to configure services and parameters.
+     * It should not get services.
+     *
      * @param Application $app An Application instance
      */
     function register(Application $app);
+
+    /**
+     * Bootstraps the application.
+     *
+     * This method is called after all services are registers
+     * and should be used for "dynamic" configuration (whenever
+     * a service must be requested).
+     */
+    function boot(Application $app);
 }


### PR DESCRIPTION
The `register` method for the service providers should only be about configuring services and parameters. But some service providers (monolog, swiftmailer, and session) also register some event listeners which means that the `dispatcher` service is created.

This makes some things impossible like replacing the `dispatcher` service (except if you make sure to override it _before_ the other providers). Also, if you want to use Monolog for the logger, it won't work as there is a chicken and egg problem.

So, I propose to introduce a new `boot()` method on `ServiceProviderInterface` that must be called after all the providers are registered.

The `boot()` method is automatically called by the `handle()` method if not already called by the developer.

TODO: update the doc
