### PR TITLE
Removed SymfonyBridgesServiceProvider from the translation documentation

### DIFF
--- a/doc/providers/translation.rst
+++ b/doc/providers/translation.rst
@@ -179,7 +179,9 @@ templates:
 
     {{ app.translator.trans('translation_key') }}
 
-Moreover, you will be allowed to translate strings in the Twig way:
+Moreover, when using the Twig bridge provided by Symfony (see
+:doc:`TwigServiceProvider <twig>`), you will be allowed to translate
+strings in the Twig way:
 
 .. code-block:: jinja
 


### PR DESCRIPTION
Hi!

As you removed SymfonyBridgesServiceProvider (commit 75556d7e8fd06cf919f6f41afbab4f5b449e4c9a), I removed it from the translation documentation too.
