### PR TITLE
Fix server parameter array not being passed to new Client instance, unused createKernel options

### DIFF
--- a/src/Silex/WebTestCase.php
+++ b/src/Silex/WebTestCase.php
@@ -43,13 +43,12 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
     /**
      * Creates a Client.
      *
-     * @param array $options An array of options to pass to the createKernel class
      * @param array $server  An array of server parameters
      *
      * @return Client A Client instance
      */
-    public function createClient(array $options = array(), array $server = array())
+    public function createClient(array $server = array())
     {
-        return new Client($this->app);
+        return new Client($this->app, $server);
     }
 }

--- a/tests/Silex/Tests/WebTestCaseTest.php
+++ b/tests/Silex/Tests/WebTestCaseTest.php
@@ -33,6 +33,12 @@ class WebTestCaseTest extends WebTestCase
             return '<h1>title</h1>';
         });
 
+        $app->match('/server', function () use ($app) {
+            $user = $app['request']->server->get('PHP_AUTH_USER');
+            $pass = $app['request']->server->get('PHP_AUTH_PW');
+            return "<h1>$user:$pass</h1>";
+        });
+
         return $app;
     }
 
@@ -52,5 +58,19 @@ class WebTestCaseTest extends WebTestCase
 
         $crawler = $client->request('GET', '/html');
         $this->assertEquals('title', $crawler->filter('h1')->text());
+    }
+
+    public function testServerVariables()
+    {
+        $user = 'klaus';
+        $pass = '123456';
+
+        $client = $this->createClient(array(
+            'PHP_AUTH_USER' => $user,
+            'PHP_AUTH_PW'   => $pass,
+        ));
+
+        $crawler = $client->request('GET', '/server');
+        $this->assertEquals("$user:$pass", $crawler->filter('h1')->text());
     }
 }


### PR DESCRIPTION
Removed options since Silex WebTestCase has no createKernel and added missing server parameter array.
