### PR TITLE
Added the LocaleListener to handle setting the locale

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -21,6 +21,7 @@ use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\LocaleListener;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
 use Symfony\Component\HttpKernel\EventListener\RouterListener;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
@@ -85,6 +86,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
                 return $app['url_matcher'];
             });
             $dispatcher->addSubscriber(new RouterListener($urlMatcher, $app['logger']));
+            $dispatcher->addSubscriber(new LocaleListener($app['request.default_locale'], $urlMatcher));
 
             return $dispatcher;
         });
@@ -469,7 +471,6 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
         $current = HttpKernelInterface::SUB_REQUEST === $type ? $this['request'] : $this['request_error'];
 
         $this['request'] = $request;
-        $this['request']->setDefaultLocale($this['request.default_locale']);
 
         $this->flush();
 


### PR DESCRIPTION
This registers the LocaleListener setting the request locale according to the matching of the special `_locale` parameter and setting the locale in the routing RequestContext so that it is always available.

This PR should be merged only after the update of the subtree split as it requires the typehint change merged just before in Symfony
