### PR TITLE
Implements route after middleware (closes #336)

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -3,7 +3,9 @@ Changelog
 
 This changelog references all backward incompatibilities as we introduce them:
 
-* **2012-06-13**: Renamed ``middleware`` to ``before``
+* **2012-06-13**: Added a route ``before`` middleware
+
+* **2012-06-13**: Renamed the route ``middleware`` to ``before``
 
 * **2012-06-13**: Added an extension for the Symfony Security component
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -419,8 +419,13 @@ Route middlewares
 -----------------
 
 Route middlewares are PHP callables which are triggered when their associated
-route is matched. They are fired just before the route callback, but after the
-application ``before`` filters.
+route is matched:
+
+* ``before`` middlewares are fired just before the route callback, but after
+  the application ``before`` filters;
+
+* ``after`` middlewares are fired just after the route callback, but before
+  the application ``after`` filters.
 
 This can be used for a lot of use cases; for instance, here is a simple
 "anonymous/logged user" check::
@@ -452,21 +457,24 @@ This can be used for a lot of use cases; for instance, here is a simple
     })
     ->before($mustBeLogged);
 
-The ``before`` function can be called several times for a given route, in
-which case they are triggered in the same order as you added them to the
-route.
+The ``before`` and ``after`` methods can be called several times for a given
+route, in which case they are triggered in the same order as you added them to
+the route.
 
-For convenience, the route before middlewares functions are triggered with the
-current ``Request`` instance as their only argument.
+For convenience, the ``before`` middlewares are called with the current
+``Request`` instance as an argument and the ``after`` middlewares are called
+with the current ``Request`` and ``Response`` instance as arguments.
 
-If any of the route before middlewares returns a Symfony HTTP Response, it
-will short-circuit the whole rendering: the next middlewares won't be run,
-neither the route callback. You can also redirect to another page by returning
-a redirect response, which you can create by calling the Application
+If any of the before middlewares returns a Symfony HTTP Response, it will
+short-circuit the whole rendering: the next middlewares won't be run, neither
+the route callback. You can also redirect to another page by returning a
+redirect response, which you can create by calling the Application
 ``redirect`` method.
 
-If a route before middleware does not return a Symfony HTTP Response or
-``null``, a ``RuntimeException`` is thrown.
+.. note::
+
+    If a before middleware does not return a Symfony HTTP Response or
+    ``null``, a ``RuntimeException`` is thrown.
 
 Global Configuration
 --------------------

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -14,7 +14,6 @@ namespace Silex;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
-use Symfony\Component\HttpKernel\Event\KernelEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\FilterControllerEvent;
@@ -112,7 +111,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
             return new RedirectableUrlMatcher($app['routes'], $app['request_context']);
         });
 
-        $this['route_before_middlewares_trigger'] = $this->protect(function (KernelEvent $event) use ($app) {
+        $this['route_before_middlewares_trigger'] = $this->protect(function (GetResponseEvent $event) use ($app) {
             $request = $event->getRequest();
             $routeName = $request->attributes->get('_route');
             if (!$route = $app['routes']->get($routeName)) {
@@ -126,7 +125,24 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
 
                     return;
                 } elseif (null !== $ret) {
-                    throw new \RuntimeException(sprintf('The before middleware for route "%s" returned an invalid response value. Must return null or an instance of Response.', $routeName));
+                    throw new \RuntimeException(sprintf('A before middleware for route "%s" returned an invalid response value. Must return null or an instance of Response.', $routeName));
+                }
+            }
+        });
+
+        $this['route_after_middlewares_trigger'] = $this->protect(function (FilterResponseEvent $event) use ($app) {
+            $request = $event->getRequest();
+            $routeName = $request->attributes->get('_route');
+            if (!$route = $app['routes']->get($routeName)) {
+                return;
+            }
+
+            foreach ((array) $route->getOption('_after_middlewares') as $callback) {
+                $response = call_user_func($callback, $request, $event->getResponse());
+                if ($response instanceof Response) {
+                    $event->setResponse($response);
+                } elseif (null !== $response) {
+                    throw new \RuntimeException(sprintf('An after middleware for route "%s" returned an invalid response value. Must return null or an instance of Response.', $routeName));
                 }
             }
         });
@@ -516,8 +532,9 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
         if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
             $this->beforeDispatched = true;
             $this['dispatcher']->dispatch(SilexEvents::BEFORE, $event);
-            $this['route_before_middlewares_trigger']($event);
         }
+
+        $this['route_before_middlewares_trigger']($event);
     }
 
     /**
@@ -557,6 +574,8 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
      */
     public function onKernelResponse(FilterResponseEvent $event)
     {
+        $this['route_after_middlewares_trigger']($event);
+
         if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
             $this['dispatcher']->dispatch(SilexEvents::AFTER, $event);
         }

--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -170,6 +170,20 @@ class Controller
     }
 
     /**
+     * Sets a callback to handle after the route callback.
+     *
+     * @param mixed $callback A PHP callback to be triggered after the route callback
+     *
+     * @return Controller $this The current Controller instance
+     */
+    public function after($callback)
+    {
+        $this->route->after($callback);
+
+        return $this;
+    }
+
+    /**
      * Freezes the controller.
      *
      * Once the controller is frozen, you can no longer change the route name

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -222,7 +222,7 @@ class ControllerCollection
      *
      * @param mixed $callback A PHP callback to be triggered when the Route is matched, just before the route callback
      *
-     * @return ControllerCollection $this The current Controller instance
+     * @return ControllerCollection $this The current ControllerCollection instance
      */
     public function before($callback)
     {
@@ -230,6 +230,24 @@ class ControllerCollection
 
         foreach ($this->controllers as $controller) {
             $controller->before($callback);
+        }
+
+        return $this;
+    }
+
+    /**
+     * Sets a callback to handle after the route callback.
+     *
+     * @param mixed $callback A PHP callback to be triggered after the route callback
+     *
+     * @return ControllerCollection $this The current ControllerCollection instance
+     */
+    public function after($callback)
+    {
+        $this->defaultRoute->after($callback);
+
+        foreach ($this->controllers as $controller) {
+            $controller->after($callback);
         }
 
         return $this;

--- a/src/Silex/Route.php
+++ b/src/Silex/Route.php
@@ -120,4 +120,20 @@ class Route extends BaseRoute
 
         return $this;
     }
+
+    /**
+     * Sets a callback to handle after the route callback.
+     *
+     * @param mixed $callback A PHP callback to be triggered after the route callback
+     *
+     * @return Controller $this The current Controller instance
+     */
+    public function after($callback)
+    {
+        $callbacks = $this->getOption('_after_middlewares');
+        $callbacks[] = $callback;
+        $this->setOption('_after_middlewares', $callbacks);
+
+        return $this;
+    }
 }

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -145,4 +145,14 @@ class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array('mid1', 'mid2', 'mid3'), $controller->getRoute()->getOption('_before_middlewares'));
     }
+
+    public function testAfter()
+    {
+        $controllers = new ControllerCollection();
+        $controllers->after('mid1');
+        $controller = $controllers->match('/{id}/{name}/{extra}', function () {})->after('mid2');
+        $controllers->after('mid3');
+
+        $this->assertEquals(array('mid1', 'mid2', 'mid3'), $controller->getRoute()->getOption('_after_middlewares'));
+    }
 }


### PR DESCRIPTION
This PR renames the `middleware` method to `before` and adds a new `after` route middleware.

These changes make Silex more consistent from a user point of view:
- he can do something before the route callback on an application, a route collection, or just a route (by calling the `before` method on these objects);
- he can do something after the route callback by calling the `after` method on an application, a route collection, or just a route.
