### PR TITLE
Fixed a bug when using http authentication on the security service provider

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -116,7 +116,6 @@ class SecurityServiceProvider implements ServiceProviderInterface
         $app['security.firewall_map'] = $app->share(function () use ($app) {
             $map = new FirewallMap();
             $entryPoint = 'form';
-            $providers = array();
             foreach ($app['security.firewalls'] as $name => $firewall) {
                 $pattern = isset($firewall['pattern']) ? $firewall['pattern'] : null;
                 $users = isset($firewall['users']) ? $firewall['users'] : array();
@@ -160,6 +159,10 @@ class SecurityServiceProvider implements ServiceProviderInterface
                             }
 
                             if (!isset($app['security.authentication.'.$name.'.'.$type])) {
+                                if (!isset($app['security.entry_point.'.$entryPoint.'.'.$name])) {
+                                    $app['security.entry_point.'.$entryPoint.'.'.$name] = $app['security.entry_point.'.$entryPoint.'._proto']($name);
+                                }
+
                                 $app['security.authentication.'.$name.'.'.$type] = $app['security.authentication.'.$type.'._proto']($name, $options);
                             }
 
@@ -319,7 +322,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
                 $app['security'],
                 $app['security.authentication_manager'],
                 $providerKey,
-                $app['security.entry_point.http'],
+                $app['security.entry_point.http.'.$providerKey],
                 $app['logger']
             );
         });

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
@@ -15,6 +15,7 @@ use Silex\Application;
 use Silex\WebTestCase;
 use Silex\Provider\SecurityServiceProvider;
 use Silex\Provider\SessionServiceProvider;
+use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\HttpFoundation\Request;
 
 /**
@@ -29,15 +30,13 @@ class SecurityServiceProviderTest extends WebTestCase
         if (!is_dir(__DIR__.'/../../../../vendor/symfony/security')) {
             $this->markTestSkipped('Security dependency was not installed.');
         }
-
-        parent::setUp();
     }
 
-    public function test()
+    public function testFormAuthentication()
     {
-        $app = $this->app;
+        $app = $this->createApplication('form');
 
-        $client = $this->createClient();
+        $client = new Client($app);
 
         $client->request('get', '/');
         $this->assertEquals('ANONYMOUS', $client->getResponse()->getContent());
@@ -81,10 +80,47 @@ class SecurityServiceProviderTest extends WebTestCase
         $this->assertEquals('admin', $client->getResponse()->getContent());
     }
 
-    public function createApplication()
+    public function testHttpAuthentication()
+    {
+        $app = $this->createApplication('http');
+
+        $client = new Client($app);
+
+        $client->request('get', '/');
+        $this->assertEquals(401, $client->getResponse()->getStatusCode());
+        $this->assertEquals('Basic realm="Secured"', $client->getResponse()->headers->get('www-authenticate'));
+
+        $client->request('get', '/', array(), array(), array('PHP_AUTH_USER' => 'dennis', 'PHP_AUTH_PW' => 'foo'));
+        $this->assertEquals('dennisAUTHENTICATED', $client->getResponse()->getContent());
+        $client->request('get', '/admin');
+        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+
+        $client->restart();
+
+        $client->request('get', '/');
+        $this->assertEquals(401, $client->getResponse()->getStatusCode());
+        $this->assertEquals('Basic realm="Secured"', $client->getResponse()->headers->get('www-authenticate'));
+
+        $client->request('get', '/', array(), array(), array('PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => 'foo'));
+        $this->assertEquals('adminAUTHENTICATEDADMIN', $client->getResponse()->getContent());
+        $client->request('get', '/admin');
+        $this->assertEquals('admin', $client->getResponse()->getContent());
+    }
+
+    public function createApplication($authenticationMethod = 'form')
     {
         $app = new Application();
         $app->register(new SessionServiceProvider());
+
+        $app = call_user_func(array($this, 'add'.ucfirst($authenticationMethod).'Authentication'), $app);
+
+        $app['session.test'] = true;
+
+        return $app;
+    }
+
+    private function addFormAuthentication($app)
+    {
         $app->register(new SecurityServiceProvider(), array(
             'security.firewalls' => array(
                 'login' => array(
@@ -136,7 +172,50 @@ class SecurityServiceProviderTest extends WebTestCase
             return 'admin';
         });
 
-        $app['session.test'] = true;
+        return $app;
+    }
+
+    private function addHttpAuthentication($app)
+    {
+        $app->register(new SecurityServiceProvider(), array(
+            'security.firewalls' => array(
+                'http-auth' => array(
+                    'pattern' => '^.*$',
+                    'http' => true,
+                    'users' => array(
+                        // password is foo
+                        'dennis' => array('ROLE_USER', '5FZ2Z8QIkA7UTZ4BYkoC+GsReLf569mSKDsfods6LYQ8t+a8EW9oaircfMpmaLbPBh4FOBiiFyLfuZmTSUwzZg=='),
+                        'admin'  => array('ROLE_ADMIN', '5FZ2Z8QIkA7UTZ4BYkoC+GsReLf569mSKDsfods6LYQ8t+a8EW9oaircfMpmaLbPBh4FOBiiFyLfuZmTSUwzZg=='),
+                    ),
+                ),
+            ),
+            'security.access_rules' => array(
+                array('^/admin', 'ROLE_ADMIN'),
+            ),
+            'security.role_hierarchy' => array(
+                'ROLE_ADMIN' => array('ROLE_USER'),
+            ),
+        ));
+
+        $app->get('/', function() use ($app) {
+            $user = $app['security']->getToken()->getUser();
+
+            $content = is_object($user) ? $user->getUsername() : 'ANONYMOUS';
+
+            if ($app['security']->isGranted('IS_AUTHENTICATED_FULLY')) {
+                $content .= 'AUTHENTICATED';
+            }
+
+            if ($app['security']->isGranted('ROLE_ADMIN')) {
+                $content .= 'ADMIN';
+            }
+
+            return $content;
+        });
+
+        $app->get('/admin', function() use ($app) {
+            return 'admin';
+        });
 
         return $app;
     }


### PR DESCRIPTION
Hi Fabien,

When I added HTTP authentication to my Silex application an exception was thrown. Due the exception I wasn't able to use HTTP authentication when I accessed the application through the browser.

I used the following security firewall:

``` php
'http-auth' => array(
    'pattern' => '^.*$',
    'http' => true,
    'users' => array(
        // password is foo
        'admin'  => array('ROLE_ADMIN', '5FZ2Z8QIkA7UTZ4BYkoC+GsReLf569mSKDsfods6LYQ8t+a8EW9oaircfMpmaLbPBh4FOBiiFyLfuZmTSUwzZg=='),
    ),
)
```

The following exception was thrown:

```
InvalidArgumentException: Identifier "security.entry_point.http" is not defined
```

It's a small fix and I also added some tests. All tests passed before I committed my changes. 

I would appreciate it when you take a look at this pull request.
