### PR TITLE
Changed a typo on the security section of the documentation

### DIFF
--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -127,10 +127,10 @@ Each user is defined with the following information:
 
 The default configuration of the extension enforces encoded passwords. To
 generate a valid encoded password from a raw password, use the
-``security.encoder`` service::
+``security.encoder.digest`` service::
 
     // find the encoded password for foo
-    $password = $app['security.encoder']->encodePassword('foo', null);
+    $password = $app['security.encoder.digest']->encodePassword('foo', null);
 
 The second argument is the salt to be used for the user (defaults to
 ``null``).


### PR DESCRIPTION
Hi Fabien,

I came across, as what I think is, a typo on the security section of the Silex documentation. When I requested the 'security.encoder' service an exception was thrown. When requesting the service 'security.encoder.digest' it gave me exactly the encoder as it's being described on the documentation.

Hereby my change for the documentation.
