### PR TITLE
Add a SerializerServiceProvider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
         "symfony/finder": "2.1.*",
         "symfony/monolog-bridge": "2.1.*",
         "symfony/process": "2.1.*",
+        "symfony/serializer": "2.1.*",
         "symfony/translation": "2.1.*",
         "symfony/twig-bridge": "2.1.*",
         "symfony/validator": "2.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "e6e70518ed416cbc558237a189fdce1b",
+    "hash": "80f7ebb825c3b49c5aea743e4828a320",
     "packages": [
         {
             "package": "pimple/pimple",
@@ -46,8 +46,8 @@
         {
             "package": "symfony/http-kernel",
             "version": "dev-master",
-            "source-reference": "3ed400b75c0c2eae3e8f6f991210a8930bdd7467",
-            "commit-date": "1341838460"
+            "source-reference": "ff65fbaa20ace7e39ce6df92afe97c5c9586a2d1",
+            "commit-date": "1341849771"
         },
         {
             "package": "symfony/routing",
@@ -58,8 +58,8 @@
         {
             "package": "symfony/routing",
             "version": "dev-master",
-            "source-reference": "48c201da53b7c3b787609b0f6702456b86939577",
-            "commit-date": "1341838460"
+            "source-reference": "67c72b042d753e6ee3675eb4b0c2165243d34055",
+            "commit-date": "1341890620"
         }
     ],
     "packages-dev": [
@@ -154,8 +154,8 @@
         {
             "package": "symfony/finder",
             "version": "dev-master",
-            "source-reference": "fccf904140dd00656a7cea17ff6f54d78b095649",
-            "commit-date": "1341838460"
+            "source-reference": "53377047bae92edd04e232c79b653d2beb309bf6",
+            "commit-date": "1341846417"
         },
         {
             "package": "symfony/form",
@@ -166,8 +166,8 @@
         {
             "package": "symfony/form",
             "version": "dev-master",
-            "source-reference": "57d3b508c1522a1343f7b505b573c307e7ad0023",
-            "commit-date": "1341838460"
+            "source-reference": "b1f4c42f42892008dd5d72449e0074abf81d1e4b",
+            "commit-date": "1341915525"
         },
         {
             "package": "symfony/locale",
@@ -230,6 +230,18 @@
             "commit-date": "1341840540"
         },
         {
+            "package": "symfony/serializer",
+            "version": "dev-master",
+            "alias-pretty-version": "2.1.x-dev",
+            "alias-version": "2.1.9999999.9999999-dev"
+        },
+        {
+            "package": "symfony/serializer",
+            "version": "dev-master",
+            "source-reference": "cf9b6a457c4ed5a147e3438867049bd1f97e0917",
+            "commit-date": "1341838460"
+        },
+        {
             "package": "symfony/translation",
             "version": "dev-master",
             "alias-pretty-version": "2.1.x-dev",
@@ -238,8 +250,8 @@
         {
             "package": "symfony/translation",
             "version": "dev-master",
-            "source-reference": "1b50bdbbd88e091a9fdd362b3a0c5e1fb93cf53f",
-            "commit-date": "1341838460"
+            "source-reference": "d2ce6bcdaf479b2121e35fa850fd229817c1ee2a",
+            "commit-date": "1341851012"
         },
         {
             "package": "symfony/twig-bridge",
@@ -250,8 +262,8 @@
         {
             "package": "symfony/twig-bridge",
             "version": "dev-master",
-            "source-reference": "33295b10cad60026f074d0ee614e9a0cbe04e232",
-            "commit-date": "1341838460"
+            "source-reference": "5d3e234a5d366f510185a9de3a545b730f327632",
+            "commit-date": "1341913448"
         },
         {
             "package": "symfony/validator",
@@ -262,8 +274,8 @@
         {
             "package": "symfony/validator",
             "version": "dev-master",
-            "source-reference": "2d02293c193be5e93019fe7961922a7ce05cddb0",
-            "commit-date": "1341838460"
+            "source-reference": "9ee44012534850f8b9bccd150f728c6227821ea9",
+            "commit-date": "1341908518"
         },
         {
             "package": "twig/twig",

--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -52,6 +52,7 @@ the ``Silex\Provider`` namespace:
 * :doc:`DoctrineServiceProvider <providers/doctrine>`
 * :doc:`MonologServiceProvider <providers/monolog>`
 * :doc:`SessionServiceProvider <providers/session>`
+* :doc:`SerializerServiceProvider <providers/serializer>`
 * :doc:`SwiftmailerServiceProvider <providers/swiftmailer>`
 * :doc:`TwigServiceProvider <providers/twig>`
 * :doc:`TranslationServiceProvider <providers/translation>`

--- a/doc/providers/serializer.rst
+++ b/doc/providers/serializer.rst
@@ -1,0 +1,67 @@
+SerializerServiceProvider
+===========================
+
+The *SerializerServiceProvider* provides a service for serializing objects.
+
+Parameters
+----------
+
+None.
+
+Services
+--------
+
+* **serializer**: An instance of `Symfony\Component\Serializer\Serializer
+  <http://api.symfony.com/master/Symfony/Component/Serializer/Serializer.html>`_.
+
+* **serializer.encoders**: `Symfony\Component\Serializer\Encoder\JsonEncoder
+  <http://api.symfony.com/master/Symfony/Component/Serializer/Encoder/JsonEncoder.html>`_
+  and `Symfony\Component\Serializer\Encoder\XmlEncoder
+  <http://api.symfony.com/master/Symfony/Component/Serializer/Encoder/XmlEncoder>`_.
+
+* **serializer.normalizers**: `Symfony\Component\Serializer\Normalizer\CustomNormalizer
+  <http://api.symfony.com/master/Symfony/Component/Serializer/Normalizer/CustomNormalizer>`_
+  and `Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer
+  <http://api.symfony.com/master/Symfony/Component/Serializer/Normalizer/GetSetMethodNormalizer>`_.
+
+Registering
+-----------
+
+.. code-block:: php
+
+    $app->register(new Silex\Provider\SerializerServiceProvider());
+
+Usage
+-----
+
+The ``SerializerServiceProvider`` provider provides a ``serializer`` service::
+
+.. code-block:: php
+
+    <?php
+    
+    use Silex\Application;
+    use Silex\Provider\SerializerServiceProvider;
+    use Symfony\Component\HttpFoundation\Response;
+    
+    $app = new Application();
+    
+    $app->register(new SerializerServiceProvider());
+    
+    // only accept content types supported by the serializer via the assert method.
+    $app->get("/pages/{id}.{_format}", function ($id) use ($app) {
+        // assume a page_repository service exists that returns Page objects. The
+        // object returned has getters and setters exposing the state.
+        $page = $app['page_repository']->find($id);
+        $format = $app['request']->getFormat();
+    
+        if (!$page instanceof Page) {
+            $app->abort("No page found for id: $id");
+        }
+    
+        return new Response($app['serializer']->serialize($page, $format), 200, array(
+            "Content-Type" => $app['request']->getMimeType($format)
+        ));
+    })->assert("_format", "xml|json")
+      ->assert("id", "\d+");
+

--- a/src/Silex/Provider/SerializerServiceProvider.php
+++ b/src/Silex/Provider/SerializerServiceProvider.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Provider;
+
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Component\Serializer\Serializer;
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Encoder\XmlEncoder;
+use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
+use Symfony\Component\Serializer\Normalizer\GetSetMethodNormalizer;
+
+/**
+ * Symfony Serializer component Provider.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Marijn Huizendveld <marijn@pink-tie.com>
+ */
+class SerializerServiceProvider implements ServiceProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * This method registers a serializer service. {@link http://api.symfony.com/master/Symfony/Component/Serializer/Serializer.html
+     * The service is provided by the Symfony Serializer component}.
+     *
+     * @param Silex\Application $app
+     */
+    public function register(Application $app)
+    {
+        $app['serializer'] = $app->share(function () use ($app) {
+            return new Serializer($app['serializer.normalizers'], $app['serializer.encoders']);
+        });
+
+        $app['serializer.encoders'] = $app->share(function () {
+            return array(
+                new JsonEncoder(),
+                new XmlEncoder()
+            );
+        });
+
+        $app['serializer.normalizers'] = $app->share(function () {
+            return array(
+                new CustomNormalizer(),
+                new GetSetMethodNormalizer()
+            );
+        });
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * This provider does not execute any code when booting.
+     *
+     * @param Silex\Application $app
+     */
+    public function boot(Application $app)
+    {
+    }
+}

--- a/tests/Silex/Tests/Provider/SerializerServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SerializerServiceProviderTest.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Provider;
+
+use Silex\Application;
+use Silex\Provider\SerializerServiceProvider;
+
+/**
+ * SerializerServiceProvider test cases.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class SerializerServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRegister()
+    {
+        $app = new Application();
+
+        $app->register(new SerializerServiceProvider);
+
+        $this->assertInstanceOf("Symfony\Component\Serializer\Serializer", $app['serializer']);
+        $this->assertTrue($app['serializer']->supportsEncoding('xml'));
+        $this->assertTrue($app['serializer']->supportsEncoding('json'));
+        $this->assertTrue($app['serializer']->supportsDecoding('xml'));
+        $this->assertTrue($app['serializer']->supportsDecoding('json'));
+    }
+}


### PR DESCRIPTION
## Usage

``` php
<?php

use Silex\Application;
use Silex\Provider\SerializerServiceProvider;
use Symfony\Component\HttpFoundation\Response;

$app = new Application();

$app->register(new SerializerServiceProvider);

// only accept content types supported by the serializer via the assert method.
$app->get("/pages/{id}.{_format}", function ($id) use ($app) {
    // assume a page_repository service exists that returns Page objects. The
    // object returned has getters and setters exposing the state.
    $page = $app['page_repository']->find($id);
    $format = $app['request']->getFormat();

    if (!$page instanceof Page) {
        $this->abort("No page found for id: $id");
    }

    return new Response($app['serializer']->serialize($page, $format), 200, array(
        "Content-Type" => $app['request']->getMimeType($format)
    ));
})->assert("_format", "xml|json")
  ->assert("id", "\d+");
```
