### PR TITLE
Build script does not depend only on curl (added wget and lwp-request)

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -3,6 +3,14 @@
 PHP=`which php`
 GIT=`which git`
 DIR=`$PHP -r "echo dirname(dirname(realpath('$0')));"`
+CMDS=("curl -s" "wget -q -O /dev/stdout" "lwp-request -m GET")
+
+# choose the first available command to download composer
+for i in ${!CMDS[*]}
+do
+    CMD=${CMDS[$i]}
+    which ${CMD%% *} &> /dev/null && break
+done
 
 if [ ! -d "$DIR/build" ]; then
     mkdir -p $DIR/build
@@ -11,7 +19,7 @@ fi
 cd $DIR/build
 
 if [ ! -f "composer.phar" ]; then
-    curl -s http://getcomposer.org/installer 2>/dev/null | $PHP >/dev/null 2>/dev/null
+    $CMD http://getcomposer.org/installer 2>/dev/null | $PHP >/dev/null 2>/dev/null
 else
     $PHP composer.phar self-update >/dev/null 2>/dev/null
 fi


### PR DESCRIPTION
Hi, I was playing with Silex a little and I realised that Ubuntu Desktop doesn't come with `curl` pre-installed by default so I made a small research what command I could use to make build script more cross-platform:
- OS X 10.7 - curl, lwp-download
- Ubuntu Desktop 12.04 - wget
- Ubuntu Server 12.04 - curl, wget
- Fedora 17 - curl
- Debian 6 - wget, lwp-download
- OpenSUSE 12.1 - curl, wget, lwp-download

I think this might change in later releases because I remember me installing `curl` on Ubuntu Server 8.04.

The only thing this commit does is that it finds the first available command and uses it to download composer. If this `build` script was intended to be used only in some internal or specific situations, then it's probably not neccesary to make it more complicated and discard this pull request.
