### PR TITLE
Implement a service provider for the JMSSerializerBundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,7 @@
         "symfony/routing": "2.1.*"
     },
     "require-dev": {
+        "jms/serializer-bundle": ">=0.9",
         "symfony/security": "2.1.*",
         "symfony/config": "2.1.*",
         "symfony/locale": "2.1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -1,5 +1,5 @@
 {
-    "hash": "3ec54c6c3e37fe1b74143cc1c9631567",
+    "hash": "03f8c9a6a13986ce0f7ba6a2fb3d183c",
     "packages": [
         {
             "package": "pimple/pimple",
@@ -10,20 +10,8 @@
         {
             "package": "pimple/pimple",
             "version": "dev-master",
-            "alias-pretty-version": "1.0.x-dev",
-            "alias-version": "1.0.9999999.9999999-dev"
-        },
-        {
-            "package": "pimple/pimple",
-            "version": "dev-master",
-            "source-reference": "86cae5c9e85cd02f1703c774ddf12f2448a5938c",
-            "commit-date": "1340285678"
-        },
-        {
-            "package": "symfony/event-dispatcher",
-            "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
+            "source-reference": "d2cfa2f02f50abef65c238747c753a5f6786f6be",
+            "commit-date": "1341139100"
         },
         {
             "package": "symfony/event-dispatcher",
@@ -46,14 +34,8 @@
         {
             "package": "symfony/http-foundation",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/http-foundation",
-            "version": "dev-master",
-            "source-reference": "eede6abb9b49fa6632f9776c857c703d8d8268e0",
-            "commit-date": "1340656150"
+            "source-reference": "f28a2ffa86ca77a83e56778ab290b0cd3005f36f",
+            "commit-date": "1341259877"
         },
         {
             "package": "symfony/http-kernel",
@@ -64,14 +46,8 @@
         {
             "package": "symfony/http-kernel",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/http-kernel",
-            "version": "dev-master",
-            "source-reference": "37338444a653dfd26e4c6c9abe535318de0957e6",
-            "commit-date": "1340654694"
+            "source-reference": "11edf19e52544350f57ebff42f297be026bde512",
+            "commit-date": "1341304110"
         },
         {
             "package": "symfony/routing",
@@ -88,8 +64,8 @@
         {
             "package": "symfony/routing",
             "version": "dev-master",
-            "source-reference": "ed1a7d9118dd1ee332b485f19b920a9e0077022a",
-            "commit-date": "1340625003"
+            "source-reference": "622a168a3be54a87e34ad65e9d50a738fb89ff7e",
+            "commit-date": "1341312726"
         }
     ],
     "packages-dev": [
@@ -102,14 +78,8 @@
         {
             "package": "doctrine/common",
             "version": "dev-master",
-            "alias-pretty-version": "2.3.x-dev",
-            "alias-version": "2.3.9999999.9999999-dev"
-        },
-        {
-            "package": "doctrine/common",
-            "version": "dev-master",
-            "source-reference": "8df9cdf3b921a3b59bbba51d5ba9063509ef6a1a",
-            "commit-date": "1340561340"
+            "source-reference": "d2f8a36b8696b446bf25cfe2b0b3aaf03e0835e6",
+            "commit-date": "1341088911"
         },
         {
             "package": "doctrine/dbal",
@@ -118,32 +88,30 @@
             "commit-date": "1338146238"
         },
         {
+            "package": "jms/metadata",
+            "version": "dev-master",
+            "alias-pretty-version": "1.2.x-dev",
+            "alias-version": "1.2.9999999.9999999-dev"
+        },
+        {
+            "package": "jms/metadata",
+            "version": "dev-master",
+            "source-reference": "dbfbb15b3ffdf96c5ff14e5cd4451d78a7083a36",
+            "commit-date": "1339680164"
+        },
+        {
+            "package": "jms/serializer-bundle",
+            "version": "dev-master",
+            "source-reference": "16661d599a2e882d0c9d808b228d8dbde6ba06a7",
+            "commit-date": "1341260728"
+        },
+        {
             "package": "monolog/monolog",
             "version": "1.1.0"
         },
         {
             "package": "swiftmailer/swiftmailer",
-            "version": "dev-master",
-            "alias-pretty-version": "4.1.x-dev",
-            "alias-version": "4.1.9999999.9999999-dev"
-        },
-        {
-            "package": "swiftmailer/swiftmailer",
-            "version": "dev-master",
-            "alias-pretty-version": "4.1.x-dev",
-            "alias-version": "4.1.9999999.9999999-dev"
-        },
-        {
-            "package": "swiftmailer/swiftmailer",
-            "version": "dev-master",
-            "source-reference": "0173abd7bb539bc5dd0b823b06b46636121384e9",
-            "commit-date": "1340373948"
-        },
-        {
-            "package": "symfony/browser-kit",
-            "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
+            "version": "v4.1.8"
         },
         {
             "package": "symfony/browser-kit",
@@ -166,20 +134,8 @@
         {
             "package": "symfony/config",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/config",
-            "version": "dev-master",
-            "source-reference": "v2.1.0-BETA1",
-            "commit-date": "1340300540"
-        },
-        {
-            "package": "symfony/css-selector",
-            "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
+            "source-reference": "5b1a7a0a205b2c465a957142b03f1fc3202966e1",
+            "commit-date": "1340892719"
         },
         {
             "package": "symfony/css-selector",
@@ -202,12 +158,6 @@
         {
             "package": "symfony/dom-crawler",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/dom-crawler",
-            "version": "dev-master",
             "source-reference": "v2.1.0-BETA1",
             "commit-date": "1337632035"
         },
@@ -220,14 +170,8 @@
         {
             "package": "symfony/finder",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/finder",
-            "version": "dev-master",
-            "source-reference": "v2.1.0-BETA1",
-            "commit-date": "1340118982"
+            "source-reference": "4d6a965beae234bd0fa7f61681bd8a54df60f042",
+            "commit-date": "1341212719"
         },
         {
             "package": "symfony/form",
@@ -238,14 +182,8 @@
         {
             "package": "symfony/form",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/form",
-            "version": "dev-master",
-            "source-reference": "v2.1.0-BETA1",
-            "commit-date": "1340220813"
+            "source-reference": "55d7fe70afe21f7a756efe6d871b1b56c09007ff",
+            "commit-date": "1341175087"
         },
         {
             "package": "symfony/locale",
@@ -256,20 +194,8 @@
         {
             "package": "symfony/locale",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/locale",
-            "version": "dev-master",
-            "source-reference": "v2.1.0-BETA1",
-            "commit-date": "1338433443"
-        },
-        {
-            "package": "symfony/monolog-bridge",
-            "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
+            "source-reference": "3e6e0c21835c958a131c4455bcad207a1faefcad",
+            "commit-date": "1340985661"
         },
         {
             "package": "symfony/monolog-bridge",
@@ -304,12 +230,6 @@
         {
             "package": "symfony/process",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/process",
-            "version": "dev-master",
             "source-reference": "v2.1.0-BETA1",
             "commit-date": "1337882028"
         },
@@ -322,20 +242,8 @@
         {
             "package": "symfony/security",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/security",
-            "version": "dev-master",
-            "source-reference": "a86fab245763a1bb7e81a55d5acb621cf3f31345",
-            "commit-date": "1340702315"
-        },
-        {
-            "package": "symfony/translation",
-            "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
+            "source-reference": "4cdc2febdf2536098323a9a96533b4bb083da018",
+            "commit-date": "1341177900"
         },
         {
             "package": "symfony/translation",
@@ -358,14 +266,8 @@
         {
             "package": "symfony/twig-bridge",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/twig-bridge",
-            "version": "dev-master",
-            "source-reference": "v2.1.0-BETA1",
-            "commit-date": "1339357889"
+            "source-reference": "2a577b6cf0fe32f383acf4a972c1d5d8f48ae1e2",
+            "commit-date": "1340549862"
         },
         {
             "package": "symfony/validator",
@@ -376,14 +278,8 @@
         {
             "package": "symfony/validator",
             "version": "dev-master",
-            "alias-pretty-version": "2.1.x-dev",
-            "alias-version": "2.1.9999999.9999999-dev"
-        },
-        {
-            "package": "symfony/validator",
-            "version": "dev-master",
-            "source-reference": "v2.1.0-BETA1",
-            "commit-date": "1340185384"
+            "source-reference": "71ab5eaf2da8db90afdfc906945c0f26e13bf1d5",
+            "commit-date": "1341219258"
         },
         {
             "package": "twig/twig",
@@ -394,8 +290,8 @@
         {
             "package": "twig/twig",
             "version": "dev-master",
-            "source-reference": "4679ad51c5390648b7ea4c8f0ecd2c0c344145ba",
-            "commit-date": "1339959143"
+            "source-reference": "73da773aaad0f97f2e967ec8241b8adf7b1e03d2",
+            "commit-date": "1340890758"
         }
     ],
     "aliases": [

--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -50,6 +50,7 @@ There are a few provider that you get out of the box. All of these are within
 the ``Silex\Provider`` namespace:
 
 * :doc:`DoctrineServiceProvider <providers/doctrine>`
+* :doc:`JMSSerializerProvider <providers/jms_serializer>`
 * :doc:`MonologServiceProvider <providers/monolog>`
 * :doc:`SessionServiceProvider <providers/session>`
 * :doc:`SwiftmailerServiceProvider <providers/swiftmailer>`

--- a/doc/providers/jms_serializer.rst
+++ b/doc/providers/jms_serializer.rst
@@ -1,0 +1,132 @@
+JMSSerializerServiceProvider
+============================
+
+The ``JMSSerializerServiceProvider`` provides a service for serializing objects.
+This service provider uses the `JMS\SerializerBundle
+<http://jmsyst.com/bundles/JMSSerializerBundle>`_ for serializing.
+
+Parameters
+----------
+
+* **serializer.cache.directory**: The directory to use for storing the metadata
+  cache.
+
+* **serializer.naming_strategy.seperator** (optional): The separator string used
+  when normalizing properties.
+
+* **serializer.naming_strategy.lower_case** (optional): Boolean flag indicating
+  if the properties should be normalized as lower case strings.
+
+* **serializer.date_time_handler.format** (optional): The format used to
+  serialize and deserialize *DateTime* objects. Refer to the `PHP documentation
+  for supported Date/Time formats <http://php.net/manual/en/datetime.formats.php>`_
+
+* **serializer.date_time_handler.default_timezone** (optional): The timezone to
+  use when serializing and deserializing *DateTime* objects. Refer to the `PHP
+  documentation for a list of supported timezones
+  <http://php.net/manual/en/timezones.php>`_
+
+* **serializer.disable_external_entities** (optional): Boolean flag indicating
+  if the serializer should disable external entities for the XML serialization
+  format.
+
+Services
+--------
+
+* **serializer**: An instance of *JMS\SerializerBundle\Serializer\Serializer*.
+
+Registering
+-----------
+
+.. code-block:: php
+
+    $app->register(new Silex\Provider\JMSSerializerServiceProvider());
+
+Usage
+-----
+
+Annotate the class you wish to serialize, refer to the `annotation documentation
+<http://jmsyst.com/bundles/JMSSerializerBundle/master/reference/annotations>`::
+
+.. code-block:: php
+
+    <?php
+
+    use JMS\SerializerBundle\Annotation;
+
+    // The serializer bundle doesn't need getters or setters
+    class Page
+    {
+        /**
+         * @Type("integer")
+         */
+        private $id;
+
+        /**
+         * @Type("string")
+         */
+        private $title;
+
+        /**
+         * @Type("string")
+         */
+        private $body;
+
+        /**
+         * @Type("DateTime")
+         */
+        private $created;
+
+        /**
+         * @Type("Author")
+         */
+        private $author;
+
+        /**
+         * @Type("boolean")
+         */
+        private $featured;
+    }
+
+    class Author
+    {
+        /**
+         * @Type("string")
+         */
+        private $name;
+    }
+
+The ``JMSSerializerServiceProvider`` provider provides a ``serializer`` service.
+Use it in your application to serialize and deserialize your objects::
+
+.. code-block:: php
+
+    <?php
+
+    use Silex\Application;
+    use Silex\Provider\JMSSerializerServiceProvider;
+    use Symfony\Component\HttpFoundation\Response;
+
+    $app = new Application();
+
+    // Make sure that the PHP script can write in the cache directory and that
+    // the directory exists
+    $app->register(new JMSSerializerServiceProvider(), array(
+        'serializer.cache.directory' => __DIR__."/cache/serializer"
+    ));
+
+    // only accept content types supported by the serializer via the assert method.
+    $app->get("/pages/{id}.{_format}", function ($id) use ($app) {
+        // assume a page_repository service exists that returns Page objects.
+        $page = $app['page_repository']->find($id);
+        $format = $app['request']->getFormat();
+
+        if (!$page instanceof Page) {
+            $this->abort("No page found for id: $id");
+        }
+
+        return new Response($app['serializer']->serialize($page, $format), 200, array(
+            "Content-Type" => $app['request']->getMimeType($format)
+        ));
+    })->assert("_format", "xml|json")
+      ->assert("id", "\d+");

--- a/src/Silex/Provider/JMSSerializerServiceProvider.php
+++ b/src/Silex/Provider/JMSSerializerServiceProvider.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Provider;
+
+use DateTime;
+use Doctrine\Common\Annotations\AnnotationReader;
+use JMS\SerializerBundle\Serializer\Serializer;
+use JMS\SerializerBundle\Serializer\Construction\UnserializeObjectConstructor;
+use JMS\SerializerBundle\Metadata\Driver\AnnotationDriver;
+use JMS\SerializerBundle\Serializer\Naming\CamelCaseNamingStrategy;
+use JMS\SerializerBundle\Serializer\Naming\SerializedNameAnnotationStrategy;
+use JMS\SerializerBundle\Serializer\Handler\ArrayCollectionHandler;
+use JMS\SerializerBundle\Serializer\Handler\ConstraintViolationHandler;
+use JMS\SerializerBundle\Serializer\Handler\DateTimeHandler;
+use JMS\SerializerBundle\Serializer\Handler\DoctrineProxyHandler;
+use JMS\SerializerBundle\Serializer\Handler\FormErrorHandler;
+use JMS\SerializerBundle\Serializer\Handler\ObjectBasedCustomHandler;
+use JMS\SerializerBundle\Serializer\JsonDeserializationVisitor;
+use JMS\SerializerBundle\Serializer\JsonSerializationVisitor;
+use JMS\SerializerBundle\Serializer\XmlDeserializationVisitor;
+use JMS\SerializerBundle\Serializer\XmlSerializationVisitor;
+use JMS\SerializerBundle\Serializer\YamlSerializationVisitor;
+use Metadata\MetadataFactory;
+use Metadata\Cache\FileCache;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+
+/**
+ * JMS Serializer Bundle integration for Silex.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Marijn Huizendveld <marijn@pink-tie.com>
+ */
+class JMSSerializerServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        $app['serializer.naming_strategy.seperator'] = '_';
+        $app['serializer.naming_strategy.lower_case'] = true;
+        $app['serializer.date_time_handler.format'] = DateTime::ISO8601;
+        $app['serializer.date_time_handler.default_timezone'] = 'UTC';
+        $app['serializer.disable_external_entities'] = true;
+
+        $app['serializer.metatadata.cache'] = $app->share(function () use ($app) {
+            return new FileCache($app['serializer.cache.directory']);
+        });
+        
+        $app['serializer.metadata.annotation_reader'] = $app->share(function () use ($app) {
+            return new AnnotationReader();
+        });
+        
+        $app['serializer.metadata.annotation_driver'] = $app->share(function () use ($app) {
+            return new AnnotationDriver($app['serializer.metadata.annotation_reader']);
+        });
+
+        $app['serializer.naming_strategy'] = $app->share(function () use ($app) {
+            $seperator = $app['serializer.naming_strategy.seperator'];
+            $lowerCase = $app['serializer.naming_strategy.lower_case'];
+
+            return new SerializedNameAnnotationStrategy(new CamelCaseNamingStrategy($seperator, $lowerCase));
+        });
+
+        $app['serializer.custom_handlers.array_collection_handler'] = $app->share(function () use ($app) {
+            return new ArrayCollectionHandler();
+        });
+
+        $app['serializer.custom_handlers.date_time_handler'] = $app->share(function () use ($app) {
+            $format = $app['serializer.date_time_handler.format'];
+            $defaultTimezone = $app['serializer.date_time_handler.default_timezone'];
+
+            return new DateTimeHandler($format, $defaultTimezone);
+        });
+
+        $app['serializer.custom_handlers.doctrine_proxy_handler'] = $app->share(function () use ($app) {
+            return new DoctrineProxyHandler();
+        });
+
+        $app['serializer.custom_handlers.object_based_custom_handler'] = $app->share(function () use ($app) {
+            return new ObjectBasedCustomHandler($app['serializer.object_constructor'], $app['serializer.metadata_factory']);
+        });
+
+        if (class_exists('Symfony\Component\Validator\ConstraintViolation')) {
+            $app['serializer.custom_handlers.constraing_violation_handler'] = $app->share(function () use ($app) {
+                return new ConstraintViolationHandler();
+            });
+        }
+
+        if (isset($app['translator'])) {
+            $app['serializer.custom_handlers.form_error_handler'] = $app->share(function () use ($app) {
+                return new FormErrorHandler($app['translator']);
+            });
+        }
+
+        $app['serializer.serialization.custom_handlers'] = $app->share(function () use ($app) {
+            $handlers = array(
+                $app['serializer.custom_handlers.date_time_handler'],
+                $app['serializer.custom_handlers.doctrine_proxy_handler'],
+                $app['serializer.custom_handlers.object_based_custom_handler']
+            );
+
+            if (isset($app['serializer.custom_handlers.constraing_violation_handler'])) {
+                $handlers[] = $app['serializer.custom_handlers.constraing_violation_handler'];
+            }
+
+            if (isset($app['serializer.custom_handlers.form_error_handler'])) {
+                $handlers[] = $app['serializer.custom_handlers.form_error_handler'];
+            }
+
+            return $handlers;
+        });
+
+        $app['serializer.deserialization.custom_handlers'] = $app->share(function () use ($app) {
+            return array(
+                $app['serializer.custom_handlers.array_collection_handler'],
+                $app['serializer.custom_handlers.date_time_handler'],
+                $app['serializer.custom_handlers.object_based_custom_handler']
+            );
+        });
+
+        $app['serializer.object_constructor'] = $app->share(function () use ($app) {
+            return new UnserializeObjectConstructor();
+        });
+
+        $app['serializer.metadata_factory'] = $app->share(function () use ($app) {
+            $factory = new MetadataFactory(
+                $app['serializer.metadata.annotation_driver'],
+                'Metadata\ClassHierarchyMetadata'
+            );
+
+            $factory->setCache($app['serializer.metatadata.cache']);
+
+            return $factory;
+        });
+
+        $app['serializer.serialization_visitors'] = $app->share(function () use ($app) {
+            $namingStrategy = $app['serializer.naming_strategy'];
+            $customHandlers = $app['serializer.serialization.custom_handlers'];
+
+            return array(
+                "json" => new JsonSerializationVisitor($namingStrategy, $customHandlers),
+                "xml" => new XmlSerializationVisitor($namingStrategy, $customHandlers),
+                "yaml" => new YamlSerializationVisitor($namingStrategy, $customHandlers)
+            );
+        });
+
+        $app['serializer.deserialization_visitors'] = $app->share(function () use ($app) {
+            $namingStrategy = $app['serializer.naming_strategy'];
+            $customHandlers = $app['serializer.deserialization.custom_handlers'];
+            $objectConstructor = $app['serializer.object_constructor'];
+            $disableExternalEntities = $app['serializer.disable_external_entities'];
+
+            return array(
+                "json" => new JsonDeserializationVisitor($namingStrategy, $customHandlers, $objectConstructor),
+                "xml" => new XmlDeserializationVisitor($namingStrategy, $customHandlers, $objectConstructor, $disableExternalEntities)
+            );
+        });
+
+        $app['serializer'] = $app->share(function () use ($app) {
+            return new Serializer(
+                $app['serializer.metadata_factory'],
+                $app['serializer.serialization_visitors'],
+                $app['serializer.deserialization_visitors']
+            );
+        });
+    }
+
+    public function boot(Application $app)
+    {
+    }
+}

--- a/tests/Silex/Tests/Provider/JMSSerializerServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/JMSSerializerServiceProviderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Provider;
+
+use DateTime;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use Silex\Application;
+use Silex\Provider\JMSSerializerServiceProvider;
+
+/**
+ * JMSSerializerServiceProvider test cases.
+ *
+ * @author Marijn Huizendveld <marijn@pink-tie.com>
+ */
+class JMSSerializerServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    private $cache;
+
+    public function setup()
+    {
+        $this->cache = sys_get_temp_dir()."/JMSSerializerServiceProviderTest";
+
+        if (file_exists($this->cache)) {
+            $this->dropMetaDataCache($this->cache);
+        }
+
+        mkdir($this->cache);
+    }
+
+    public function teardown()
+    {
+        if (file_exists($this->cache)) {
+            $this->dropMetaDataCache($this->cache);
+        }
+    }
+
+    public function testRegister()
+    {
+        $app = new Application();
+
+        $app->register(new JMSSerializerServiceProvider(), array(
+            'serializer.cache.directory' => $this->cache
+        ));
+
+        $this->assertInstanceOf("JMS\SerializerBundle\Serializer\Serializer", $app['serializer']);
+
+        return $app;
+    }
+
+    /**
+     * @depends testRegister
+     */
+    public function testSerialize(Application $app)
+    {
+        $fabien = new SerializableUser(1, "Fabien Potencier", new DateTime("2005-10-01T00:00:00+0000"));
+        $fabienJson = '{"id":1,"name":"Fabien Potencier","created":"2005-10-01T00:00:00+0000"}';
+        $fabienXml = <<<XML
+<?xml version="1.0" encoding="UTF-8"?>
+<result>
+  <id>1</id>
+  <name><![CDATA[Fabien Potencier]]></name>
+  <created>2005-10-01T00:00:00+0000</created>
+</result>
+
+XML;
+
+        $this->assertEquals($fabienJson, $app['serializer']->serialize($fabien, "json"));
+        $this->assertEquals($fabienXml, $app['serializer']->serialize($fabien, "xml"));
+        $this->assertEquals($fabien, $app['serializer']->deserialize($fabienJson, "Silex\Tests\Provider\SerializableUser", "json"));
+        $this->assertEquals($fabien, $app['serializer']->deserialize($fabienXml, "Silex\Tests\Provider\SerializableUser", "xml"));
+        $this->assertFileExists($this->cache."/Silex-Tests-Provider-SerializableUser.cache.php");
+    }
+
+    private function dropMetaDataCache($directory)
+    {
+        $iterator = new RecursiveDirectoryIterator($directory);
+        $files = new RecursiveIteratorIterator($iterator, RecursiveIteratorIterator::CHILD_FIRST);
+
+        foreach($files as $file) {
+            if ($file->isDir()){
+                rmdir($file->getRealPath());
+            } else {
+                unlink($file->getRealPath());
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Silex/Tests/Provider/SerializableUser.php
+++ b/tests/Silex/Tests/Provider/SerializableUser.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Provider;
+
+use DateTime;
+use JMS\SerializerBundle\Annotation\Type;
+
+/**
+ * This class is used by the JMSSerializerServiceProviderTest.
+ *
+ * @author Marijn Huizendveld <marijn@pink-tie.com>
+ */
+class SerializableUser
+{
+    /**
+     * @Type("integer")
+     */
+    private $id;
+
+    /**
+     * @Type("string")
+     */
+    private $name;
+
+    /**
+     * @Type("DateTime")
+     */
+    private $created;
+
+    public function __construct($id, $name, DateTime $created)
+    {
+        $this->id = $id;
+        $this->name = $name;
+        $this->created = $created;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -2,3 +2,13 @@
 
 $loader = require __DIR__.'/../vendor/autoload.php';
 $loader->add('Silex\Tests', __DIR__);
+
+Doctrine\Common\Annotations\AnnotationRegistry::registerLoader(function($class) {
+    if (0 === strpos(ltrim($class, '/'), 'JMS\SerializerBundle\Annotation')) {
+        if (file_exists($file = dirname(__DIR__).'/vendor/jms/serializer-bundle/'.str_replace('\\', '/', $class).'.php')) {
+            require_once $file;
+        }
+    }
+
+    return class_exists($class, false);
+});


### PR DESCRIPTION
While I was working on #401 I realized that the serializer provided by the `Symfony\Component\Serializer` really can't stack up to the one provided by `JMSSerializerBundle`. I wondered if it would be easy to implement in Silex, it turns out it was :smile:. Anyway, I understand if you rather want this bundled as a third-party extension, though I'd like you to consider bundling this as a default :blush:. 

The serializer provided by `JMSSerializerBundle` can be used like this:

``` php
<?php

use Silex\Application;
use Silex\Provider\JMSSerializerServiceProvider;
use Symfony\Component\HttpFoundation\Response;

$app = new Application();

// Make sure that the PHP script can write in the cache directory and that
// the directory exists
$app->register(new JMSSerializerServiceProvider(), array(
    'serializer.cache.directory' => __DIR__."/cache/serializer"
));

// only accept content types supported by the serializer via the assert method.
$app->get("/pages/{id}.{_format}", function ($id) use ($app) {
    // assume a page_repository service exists that returns Page objects.
    $page = $app['page_repository']->find($id);
    $format = $app['request']->getFormat();

    if (!$page instanceof Page) {
        $this->abort("No page found for id: $id");
    }

    return new Response($app['serializer']->serialize($page, $format), 200, array(
        "Content-Type" => $app['request']->getMimeType($format)
    ));
})->assert("_format", "xml|json")
  ->assert("id", "\d+");
```

An example `Page` and related `Author` class as example (taken from the docs in this PR).

``` php
<?php

use JMS\SerializerBundle\Annotation;

// The serializer bundle doesn't need getters or setters
class Page
{
    /**
     * @Type("integer")
     */
    private $id;

    /**
     * @Type("string")
     */
    private $title;

    /**
     * @Type("string")
     */
    private $body;

    /**
     * @Type("DateTime")
     */
    private $created;

    /**
     * @Type("Author")
     */
    private $author;

    /**
     * @Type("boolean")
     */
    private $featured;
}
```

``` php
<?php

use JMS\SerializerBundle\Annotation;

// The serializer bundle doesn't need getters or setters
class Author
{
    /**
     * @Type("string")
     */
    private $name;
}
```
