### PR TITLE
Add minimum-stability flag to all composer.json samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ composer](http://getcomposer.org). Just create a `composer.json` file and
 run the `php composer.phar install` command to install it:
 
     {
+        "minimum-stability": "dev",
         "require": {
             "silex/silex": "1.0.*"
         }

--- a/bin/skeleton/fat_composer.json
+++ b/bin/skeleton/fat_composer.json
@@ -1,4 +1,5 @@
 {
+    "minimum-stability": "dev",
     "require": {
         "silex/silex": "1.0.*",
         "symfony/browser-kit": "2.1.*",

--- a/bin/skeleton/slim_composer.json
+++ b/bin/skeleton/slim_composer.json
@@ -1,4 +1,5 @@
 {
+    "minimum-stability": "dev",
     "require": {
         "silex/silex": "1.0.*"
     }

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -24,6 +24,7 @@ If you want more flexibility, use Composer instead. Create a
 .. code-block:: json
 
     {
+        "minimum-stability": "dev",
         "require": {
             "silex/silex": "1.0.*"
         }


### PR DESCRIPTION
Today marks the release of composer alpha4. This changes the default
stability from dev to stable, which means that if you want to use un-
stable dependencies, you either have to specify a root package level
minimum-stability, or use the @dev constraint, i.e. "1.0.*@dev".

We are setting the minimum-stability, so that we do not have to use
@dev for all dependencies, and all dependencies of dependencies.

We can increase the stability to beta once we release a beta of silex
(this will use Symfony 2.1 beta releases), and when we make a final
release (some time after Symfony 2.1.0), the flag can be removed.
