### PR TITLE
Add IRC channel to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ To run the test suite, you need [composer](http://getcomposer.org) and
     $ php composer.phar install --dev
     $ phpunit
 
+## Community
+
+Check out #silex-php on irc.freenode.net.
+
 ## License
 
 Silex is licensed under the MIT license.


### PR DESCRIPTION
I think the only place this has been mentioned is the mailing list, but people keep coming in there. So adding it to the README would be a good idea imo.
