### PR TITLE
fastcgi_pass requires unix: prefix when using a socket

### DIFF
--- a/doc/web_servers.rst
+++ b/doc/web_servers.rst
@@ -46,7 +46,7 @@ resources to ``index.php``:
         }
 
         location ~ index\.php$ {
-            fastcgi_pass   /var/run/php5-fpm.sock;
+            fastcgi_pass   unix:/var/run/php5-fpm.sock;
             fastcgi_index  index.php;
             include fastcgi_params;
         }


### PR DESCRIPTION
This is the case on my system at any rate. Possible that it is not
required in all cases or newer/older versions of nginx?
