### PR TITLE
Adding HttpException headers to the error response object.

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -639,6 +639,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
 
         if ($errorEvent->hasResponse()) {
             if ($event->getException() instanceof HttpException) {
+                $errorEvent->getResponse()->setStatusCode($event->getException()->getStatusCode());
                 $errorEvent->getResponse()->headers->add($event->getException()->getHeaders());
             }
             $event->setResponse($errorEvent->getResponse());


### PR DESCRIPTION
When an HttpException occurs, specific exceptions (such as MethodNotAllowedHttpException) may set HTTP headers, which can be retrieved using `$e->getHeaders()`. See [line 31 in MethodNotAllowedHttpException](https://github.com/symfony/symfony/blob/41621e42e9c0ae0745ef3b75c3b589eada2b0385/src/Symfony/Component/HttpKernel/Exception/MethodNotAllowedHttpException.php#L31).

Unfortunately, it does not appear these are making their way onto the Response object that is ultimately set on the event that Silex is using. See [lines 637-642 in Silex\Application](https://github.com/fabpot/Silex/blob/9acfa332f95a2fa72e33f4c6fc8499b721db2705/src/Silex/Application.php#L637).

For example, consider the following code:

``` php
<?php
require __DIR__ . '/../vendor/autoload.php';

use Silex\Application;
use Symfony\Component\HttpKernel\Exception\HttpException;

$app = new Application();

$app->error(function (HttpException $e, $code) {
    return $e->getMessage();
});

$app->get('/', function () {
    return 'getting foobar';
});

$app->post('/', function () {
    return 'posting to foobar';
});

$app->run();
```

The `/` route accepts GET and POST requests but nothing else. When I make a PUT request against `/`, I see the following response:

``` http
HTTP/1.0 200 OK
Date: Thu, 12 Jul 2012 22:26:58 GMT
Server: Apache/2.2.22 (Ubuntu)
X-Powered-By: PHP/5.3.10-1ubuntu3.2
cache-control: no-cache
Vary: Accept-Encoding
Content-Encoding: gzip
Content-Length: 80
Connection: close
Content-Type: text/html; charset=UTF-8

No route found for "PUT /": Method Not Allowed (Allow: GET, POST)
```

The message that I'm returning is correct, but the status code is 200 (I expect to see a 405) and there is no Allow header like I would expect to see, since RFC 2616 says it [MUST be present on a 405 response](http://tools.ietf.org/html/rfc2616#section-14.7). I would expect to see the following Allow header included in the response:

```
Allow: GET, POST
```

**Please note:** if you do not specify a custom error callback (like I am doing in the example), the response code is correctly 405, but the Allow header is still not present.

This pull request modifies `Silex\Application::onKernelException()` to add the headers from the HttpException object to the response being set on the event.
