### PR TITLE
Remove use of the `use` in closure

### DIFF
--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -58,7 +58,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             $app['dbs.options'] = $tmp;
         });
 
-        $app['dbs'] = $app->share(function () use ($app) {
+        $app['dbs'] = $app->share(function ($app) {
             $app['dbs.options.initializer']();
 
             $dbs = new \Pimple();
@@ -78,7 +78,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             return $dbs;
         });
 
-        $app['dbs.config'] = $app->share(function () use ($app) {
+        $app['dbs.config'] = $app->share(function ($app) {
             $app['dbs.options.initializer']();
 
             $configs = new \Pimple();
@@ -89,7 +89,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             return $configs;
         });
 
-        $app['dbs.event_manager'] = $app->share(function () use ($app) {
+        $app['dbs.event_manager'] = $app->share(function ($app) {
             $app['dbs.options.initializer']();
 
             $managers = new \Pimple();
@@ -101,19 +101,19 @@ class DoctrineServiceProvider implements ServiceProviderInterface
         });
 
         // shortcuts for the "first" DB
-        $app['db'] = $app->share(function() use ($app) {
+        $app['db'] = $app->share(function ($app) {
             $dbs = $app['dbs'];
 
             return $dbs[$app['dbs.default']];
         });
 
-        $app['db.config'] = $app->share(function() use ($app) {
+        $app['db.config'] = $app->share(function ($app) {
             $dbs = $app['dbs.config'];
 
             return $dbs[$app['dbs.default']];
         });
 
-        $app['db.event_manager'] = $app->share(function() use ($app) {
+        $app['db.event_manager'] = $app->share(function ($app) {
             $dbs = $app['dbs.event_manager'];
 
             return $dbs[$app['dbs.default']];

--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -46,7 +46,7 @@ class FormServiceProvider implements ServiceProviderInterface
 
         $app['form.secret'] = md5(__DIR__);
 
-        $app['form.extensions'] = $app->share(function () use ($app) {
+        $app['form.extensions'] = $app->share(function ($app) {
             $extensions = array(
                 new CoreExtension(),
                 new CsrfExtension($app['form.csrf_provider']),
@@ -64,11 +64,11 @@ class FormServiceProvider implements ServiceProviderInterface
             return $extensions;
         });
 
-        $app['form.factory'] = $app->share(function () use ($app) {
+        $app['form.factory'] = $app->share(function ($app) {
             return new FormFactory($app['form.extensions']);
         });
 
-        $app['form.csrf_provider'] = $app->share(function () use ($app) {
+        $app['form.csrf_provider'] = $app->share(function ($app) {
             if (isset($app['session'])) {
                 return new SessionCsrfProvider($app['session'], $app['form.secret']);
             }

--- a/src/Silex/Provider/HttpCacheServiceProvider.php
+++ b/src/Silex/Provider/HttpCacheServiceProvider.php
@@ -26,15 +26,15 @@ class HttpCacheServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        $app['http_cache'] = $app->share(function () use ($app) {
+        $app['http_cache'] = $app->share(function ($app) {
             return new HttpCache($app, $app['http_cache.store'], $app['http_cache.esi'], $app['http_cache.options']);
         });
 
-        $app['http_cache.esi'] = $app->share(function () use ($app) {
+        $app['http_cache.esi'] = $app->share(function ($app) {
             return new Esi();
         });
 
-        $app['http_cache.store'] = $app->share(function () use ($app) {
+        $app['http_cache.store'] = $app->share(function ($app) {
             return new Store($app['http_cache.cache_dir']);
         });
 

--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -35,7 +35,7 @@ class MonologServiceProvider implements ServiceProviderInterface
 
         $app['monolog.logger.class'] = $bridge ? 'Symfony\Bridge\Monolog\Logger' : 'Monolog\Logger';
 
-        $app['monolog'] = $app->share(function () use ($app) {
+        $app['monolog'] = $app->share(function ($app) {
 
             $log = new $app['monolog.logger.class']($app['monolog.name']);
 

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -69,11 +69,11 @@ class SecurityServiceProvider implements ServiceProviderInterface
         $app['security.role_hierarchy'] = array();
         $app['security.access_rules'] = array();
 
-        $app['security'] = $app->share(function () use ($app) {
+        $app['security'] = $app->share(function ($app) {
             return new SecurityContext($app['security.authentication_manager'], $app['security.access_manager']);
         });
 
-        $app['security.authentication_manager'] = $app->share(function () use ($app) {
+        $app['security.authentication_manager'] = $app->share(function ($app) {
             $manager = new AuthenticationProviderManager($app['security.authentication_providers']);
             $manager->setEventDispatcher($app['dispatcher']);
 
@@ -81,36 +81,36 @@ class SecurityServiceProvider implements ServiceProviderInterface
         });
 
         // by default, all users use the digest encoder
-        $app['security.encoder_factory'] = $app->share(function () use ($app) {
+        $app['security.encoder_factory'] = $app->share(function ($app) {
             return new EncoderFactory(array(
                 'Symfony\Component\Security\Core\User\UserInterface' => $app['security.encoder.digest'],
             ));
         });
 
-        $app['security.encoder.digest'] = $app->share(function () use ($app) {
+        $app['security.encoder.digest'] = $app->share(function ($app) {
             return new MessageDigestPasswordEncoder();
         });
 
-        $app['security.user_checker'] = $app->share(function () use ($app) {
+        $app['security.user_checker'] = $app->share(function ($app) {
             return new UserChecker();
         });
 
-        $app['security.access_manager'] = $app->share(function () use ($app) {
+        $app['security.access_manager'] = $app->share(function ($app) {
             return new AccessDecisionManager($app['security.voters']);
         });
 
-        $app['security.voters'] = $app->share(function () use ($app) {
+        $app['security.voters'] = $app->share(function ($app) {
             return array(
                 new RoleHierarchyVoter(new RoleHierarchy($app['security.role_hierarchy'])),
                 new AuthenticatedVoter($app['security.trust_resolver']),
             );
         });
 
-        $app['security.firewall'] = $app->share(function () use ($app) {
+        $app['security.firewall'] = $app->share(function ($app) {
             return new Firewall($app['security.firewall_map'], $app['dispatcher']);
         });
 
-        $app['security.channel_listener'] = $app->share(function () use ($app) {
+        $app['security.channel_listener'] = $app->share(function ($app) {
             return new ChannelListener(
                 $app['security.access_map'],
                 new RetryAuthenticationEntryPoint($app['request.http_port'], $app['request.https_port']),
@@ -149,7 +149,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
             });
         }
 
-        $app['security.firewall_map'] = $app->share(function () use ($app) {
+        $app['security.firewall_map'] = $app->share(function ($app) {
             $positions = array('logout', 'pre_auth', 'form', 'http', 'remember_me', 'anonymous');
             $providers = array();
             $configs = array();
@@ -248,7 +248,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
             return $map;
         });
 
-        $app['security.access_listener'] = $app->share(function () use ($app) {
+        $app['security.access_listener'] = $app->share(function ($app) {
             return new AccessListener(
                 $app['security'],
                 $app['security.access_manager'],
@@ -258,7 +258,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
             );
         });
 
-        $app['security.access_map'] = $app->share(function () use ($app) {
+        $app['security.access_map'] = $app->share(function ($app) {
             $map = new AccessMap();
 
             foreach ($app['security.access_rules'] as $rule) {
@@ -272,15 +272,15 @@ class SecurityServiceProvider implements ServiceProviderInterface
             return $map;
         });
 
-        $app['security.trust_resolver'] = $app->share(function () use ($app) {
+        $app['security.trust_resolver'] = $app->share(function ($app) {
             return new AuthenticationTrustResolver('Symfony\Component\Security\Core\Authentication\Token\AnonymousToken', 'Symfony\Component\Security\Core\Authentication\Token\RememberMeToken');
         });
 
-        $app['security.session_strategy'] = $app->share(function () use ($app) {
+        $app['security.session_strategy'] = $app->share(function ($app) {
             return new SessionAuthenticationStrategy('migrate');
         });
 
-        $app['security.http_utils'] = $app->share(function () use ($app) {
+        $app['security.http_utils'] = $app->share(function ($app) {
             return new HttpUtils(isset($app['url_generator']) ? $app['url_generator'] : null, $app['url_matcher']);
         });
 

--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -39,7 +39,7 @@ class SessionServiceProvider implements ServiceProviderInterface
 
         $app['session.test'] = false;
 
-        $app['session'] = $app->share(function () use ($app) {
+        $app['session'] = $app->share(function ($app) {
             if (!isset($app['session.storage'])) {
                 if ($app['session.test']) {
                     $app['session.storage'] = $app['session.storage.test'];
@@ -51,11 +51,11 @@ class SessionServiceProvider implements ServiceProviderInterface
             return new Session($app['session.storage']);
         });
 
-        $app['session.storage.handler'] = $app->share(function () use ($app) {
+        $app['session.storage.handler'] = $app->share(function ($app) {
             return new FileSessionHandler($app['session.storage.save_path']);
         });
 
-        $app['session.storage.native'] = $app->share(function () use ($app) {
+        $app['session.storage.native'] = $app->share(function ($app) {
             return new NativeSessionStorage(
                 $app['session.storage.options'],
                 $app['session.storage.handler']

--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -27,21 +27,21 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface
 
         $app['mailer.initialized'] = false;
 
-        $app['mailer'] = $app->share(function () use ($app) {
+        $app['mailer'] = $app->share(function ($app) {
             $app['mailer.initialized'] = true;
 
             return new \Swift_Mailer($app['swiftmailer.spooltransport']);
         });
 
-        $app['swiftmailer.spooltransport'] = $app->share(function () use ($app) {
+        $app['swiftmailer.spooltransport'] = $app->share(function ($app) {
             return new \Swift_SpoolTransport($app['swiftmailer.spool']);
         });
 
-        $app['swiftmailer.spool'] = $app->share(function () use ($app) {
+        $app['swiftmailer.spool'] = $app->share(function ($app) {
             return new \Swift_MemorySpool();
         });
 
-        $app['swiftmailer.transport'] = $app->share(function () use ($app) {
+        $app['swiftmailer.transport'] = $app->share(function ($app) {
             $transport = new \Swift_Transport_EsmtpTransport(
                 $app['swiftmailer.transport.buffer'],
                 array($app['swiftmailer.transport.authhandler']),

--- a/src/Silex/Provider/TranslationServiceProvider.php
+++ b/src/Silex/Provider/TranslationServiceProvider.php
@@ -28,7 +28,7 @@ class TranslationServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        $app['translator'] = $app->share(function () use ($app) {
+        $app['translator'] = $app->share(function ($app) {
             $translator = new Translator($app['locale'], $app['translator.message_selector']);
 
             if (isset($app['locale_fallback'])) {

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -33,7 +33,7 @@ class TwigServiceProvider implements ServiceProviderInterface
         $app['twig.path'] = array();
         $app['twig.templates'] = array();
 
-        $app['twig'] = $app->share(function () use ($app) {
+        $app['twig'] = $app->share(function ($app) {
             $app['twig.options'] = array_replace(
                 array(
                     'charset'          => $app['charset'],
@@ -81,15 +81,15 @@ class TwigServiceProvider implements ServiceProviderInterface
             return $twig;
         });
 
-        $app['twig.loader.filesystem'] = $app->share(function () use ($app) {
+        $app['twig.loader.filesystem'] = $app->share(function ($app) {
             return new \Twig_Loader_Filesystem($app['twig.path']);
         });
 
-        $app['twig.loader.array'] = $app->share(function () use ($app) {
+        $app['twig.loader.array'] = $app->share(function ($app) {
             return new \Twig_Loader_Array($app['twig.templates']);
         });
 
-        $app['twig.loader'] = $app->share(function () use ($app) {
+        $app['twig.loader'] = $app->share(function ($app) {
             return new \Twig_Loader_Chain(array(
                 $app['twig.loader.filesystem'],
                 $app['twig.loader.array'],

--- a/src/Silex/Provider/UrlGeneratorServiceProvider.php
+++ b/src/Silex/Provider/UrlGeneratorServiceProvider.php
@@ -25,7 +25,7 @@ class UrlGeneratorServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        $app['url_generator'] = $app->share(function () use ($app) {
+        $app['url_generator'] = $app->share(function ($app) {
             $app->flush();
 
             return new UrlGenerator($app['routes'], $app['request_context']);

--- a/src/Silex/Provider/ValidatorServiceProvider.php
+++ b/src/Silex/Provider/ValidatorServiceProvider.php
@@ -28,7 +28,7 @@ class ValidatorServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        $app['validator'] = $app->share(function () use ($app) {
+        $app['validator'] = $app->share(function ($app) {
             if (isset($app['translator'])) {
                 $r = new \ReflectionClass('Symfony\Component\Validator\Validator');
                 $app['translator']->addResource('xliff', dirname($r->getFilename()).'/Resources/translations/validators.'.$app['locale'].'.xlf', $app['locale'], 'validators');
@@ -40,7 +40,7 @@ class ValidatorServiceProvider implements ServiceProviderInterface
             );
         });
 
-        $app['validator.mapping.class_metadata_factory'] = $app->share(function () use ($app) {
+        $app['validator.mapping.class_metadata_factory'] = $app->share(function ($app) {
             return new ClassMetadataFactory(new StaticMethodLoader());
         });
 


### PR DESCRIPTION
See https://github.com/fabpot/Pimple/blob/master/lib/Pimple.php#L81 :
Pimple give to the closure (as first argument) the container/application,
so we do not need to use `use($app)`.

Note : 
- I did not test on php 5.4. But tests are OK on 5.3
- I think it is cleaner to use php default arguments than the use of `use`
- I fixed the CS :  `function()` -> `function ()` (added a space before `(`)
