### PR TITLE
Add method Application::on($eventName, $callback, $priority)

### DIFF
--- a/src/Silex/Application/EventDispatcherTrait.php
+++ b/src/Silex/Application/EventDispatcherTrait.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Application;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event Dispatcher trait.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+trait EventDispatcherTrait
+{
+    /**
+     * Adds an event listener that listens on the specified events.
+     *
+     * @param string   $eventName The event to listen on
+     * @param callable $listener  The listener
+     * @param integer  $priority  The higher this value, the earlier an event
+     *                            listener will be triggered in the chain (defaults to 0)
+     */
+    public function on($eventName, $callback, $priority = 0)
+    {
+        if (is_array($callback) && 2 === count($callback) && is_string($callback[0]) && isset($this[$callback[0]])) {
+            $id = $callback[0];
+            $method = $callback[1];
+            $app = $this;
+            $callback = function (Event $event) use ($app, $id, $method) {
+                return call_user_func(array($app[$id], $method), $event);
+            };
+        }
+
+        $stopCallback = function (Event $event) use ($callback) {
+            $ret = call_user_func($callback, $event);
+
+            if (false === $ret) {
+                $event->stopPropagation();
+            }
+        };
+
+        return $this['dispatcher']->addListener($eventName, $stopCallback, $priority);
+    }
+}

--- a/tests/Silex/Tests/Application/EventDispatcherApplication.php
+++ b/tests/Silex/Tests/Application/EventDispatcherApplication.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Application;
+
+use Silex\Application;
+
+class EventDispatcherApplication extends Application
+{
+    use Application\EventDispatcherTrait;
+}

--- a/tests/Silex/Tests/Application/EventDispatcherTraitTest.php
+++ b/tests/Silex/Tests/Application/EventDispatcherTraitTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Application;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * EventDispatcherTraitTest test cases.
+ *
+ * @author Jérôme Tamarelle <jerome@tamarelle.net>
+ */
+class EventDispatcherTraitTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        if (version_compare(phpversion(), '5.4.0', '<')) {
+            $this->markTestSkipped('PHP 5.4 is required for this test');
+        }
+    }
+
+    public function testOnWithClosure()
+    {
+        $app = $this->createApplication();
+        $app['rained'] = false;
+
+        $app->on('rain', function(Event $e) use ($app) {
+            $app['rained'] = true;
+        });
+
+        $app['dispatcher']->dispatch('rain');
+
+        $this->assertTrue($app['rained']);
+    }
+
+    public function testOnWithService()
+    {
+        $app = $this->createApplication();
+        $event = new Event();
+
+        $listener = $this->getMock('stdObject', array('listen'));
+        $listener->expects($this->once())
+            ->method('listen')
+            ->with($this->equalTo($event));
+        $app['listener'] = $listener;
+
+        $app->on('myevent', array('listener', 'listen'));
+
+        $app['dispatcher']->dispatch('myevent', $event);
+    }
+
+    public function testOnFalseStopPropagation()
+    {
+        $app = $this->createApplication();
+
+        $listener = $this->getMock('stdObject', array('listen1', 'listen2'));
+        $listener->expects($this->once())
+            ->method('listen1')
+            ->will($this->returnValue(false));
+        $listener->expects($this->never())
+            ->method('listen2');
+
+        $app->on('myevent', array($listener, 'listen2'), -1);
+        $app->on('myevent', array($listener, 'listen1'), 1);
+
+        $app['dispatcher']->dispatch('myevent');
+    }
+
+    public function createApplication()
+    {
+        $app = new EventDispatcherApplication();
+
+        return $app;
+    }
+}


### PR DESCRIPTION
This method is a shortcut to add a listener to the event dispatcher.

``` php
<?php
use Symfony\Component\Security\Http\SecurityEvents;

$app->on(SecurityEvents::SWITCH_USER, function ($event) {
    // ...
});
```

There is 2 added features :
- The callback can be an array of (serviceId, method) to lazy-load listeners (like in PR #426)
- If the callback returns `FALSE`, then the event propagation is stopped. This is how jQuery works and simplify usage.

I've added the method in a trait, but it might be in the Application class.
