### PR TITLE
Add method Application::on($eventName, $callback, $priority)

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -271,6 +271,19 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
     }
 
     /**
+     * Adds an event listener that listens on the specified events.
+     *
+     * @param string   $eventName The event to listen on
+     * @param callable $listener  The listener
+     * @param integer  $priority  The higher this value, the earlier an event
+     *                            listener will be triggered in the chain (defaults to 0)
+     */
+    public function on($eventName, $callback, $priority = 0)
+    {
+        return $this['dispatcher']->addListener($eventName, $callback, $priority);
+    }
+
+    /**
      * Registers a before filter.
      *
      * Before filters are run before any route has been matched.

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -106,6 +106,20 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foobar', $response->getContent());
     }
 
+    public function testOn()
+    {
+        $app = new Application();
+        $app['pass'] = false;
+
+        $app->on('test', function(Event $e) use ($app) {
+            $app['pass'] = true;
+        });
+
+        $app['dispatcher']->dispatch('test');
+
+        $this->assertTrue($app['pass']);
+    }
+
     public function testAbort()
     {
         $app = new Application();


### PR DESCRIPTION
Simplify PR #435

This method is a shortcut to add a listener to the event dispatcher.

``` php
<?php
use Symfony\Component\Security\Http\SecurityEvents;

$app->on(SecurityEvents::SWITCH_USER, function ($event) {
    // ...
});
```
