### PR TITLE
Fixed missing use statement in Forwards example

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -616,6 +616,7 @@ Forwards
 When you want to delegate the rendering to another controller, without a
 round-trip to the browser (as for a redirect), use an internal sub-request::
 
+    use Symfony\Component\HttpFoundation\Request;
     use Symfony\Component\HttpKernel\HttpKernelInterface;
 
     $app->get('/', function () use ($app) {


### PR DESCRIPTION
The example provided in the Forwards section didn't work for me as presented. I added a use statement to the example to make it clearer.
