### PR TITLE
Change 'security.authentication_listener.form._proto' definition to the ...

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -362,13 +362,11 @@ class SecurityServiceProvider implements ServiceProviderInterface
             });
         });
 
-        $app['security.authentication_listener.form._proto'] = $app->protect(function ($name, $options, $class = null) use ($app, $that) {
-            return $app->share(function () use ($app, $name, $options, $that, $class) {
+        $app['security.authentication_listener.form._proto'] = $app->protect(function ($name, $options) use ($app, $that) {
+            return $app->share(function () use ($app, $name, $options, $that) {
                 $that->addFakeRoute(array('match', $tmp = isset($options['check_path']) ? $options['check_path'] : '/login_check', str_replace('/', '_', ltrim($tmp, '/'))));
 
-                if (null === $class) {
-                    $class = 'Symfony\\Component\\Security\\Http\\Firewall\\UsernamePasswordFormAuthenticationListener';
-                }
+                $class = isset($options['listener_class']) ? $options['listener_class'] : 'Symfony\\Component\\Security\\Http\\Firewall\\UsernamePasswordFormAuthenticationListener';
 
                 if (!isset($app['security.authentication.success_handler.'.$name])) {
                     $app['security.authentication.success_handler.'.$name] = $app['security.authentication.success_handler._proto']($name, $options);


### PR DESCRIPTION
...same signature all other _protos have.

This is a fix to remove the unussed (third) $class parameter from the 'security.authentication_listener.form._proto' definition and allow to customize the class via $options['listener_class'] instead.

Fixes https://github.com/fabpot/Silex/issues/459
