### PR TITLE
Add / to FallbackResource apache directive

### DIFF
--- a/doc/web_servers.rst
+++ b/doc/web_servers.rst
@@ -28,7 +28,12 @@ Alternatively, if you use Apache 2.2.16 or higher, you can use the
 
 .. code-block:: apache
 
-    FallbackResource index.php
+    FallbackResource /index.php
+
+.. note::
+
+    If your site is not at the webroot level you will have to adjust the path to
+    point to your directory, relative from the webroot.
 
 nginx
 -----


### PR DESCRIPTION
If you don't add the slash, you can have the error `Request exceeded the limit of 10 subrequest nesting levels due to probable confguration error.` when the requested URL is, for example, /foo/bar.
