### PR TITLE
Change visibility of providers array

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -48,8 +48,8 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
 {
     const VERSION = '1.0-DEV';
 
-    private $providers = array();
-    private $booted = false;
+    protected $providers = array();
+    protected $booted = false;
     private $beforeDispatched = false;
 
     /**


### PR DESCRIPTION
I'm trying to extend Silex\Application and override register method with own ServiceProviderInterface that has typehint to my application class for proper code autocomplete during development, for this i need to have access to providers array
