### PR TITLE
[Doc] Fixed markup in security doc

### DIFF
--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -476,7 +476,7 @@ sample users::
     entities.
 
 Defining a custom Authentication Provider
------------------------------------------
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Symfony Security component provides a lot of ready-to-use authentication
 providers (form, HTTP, X509, remember me, ...), but you can add new ones


### PR DESCRIPTION
Changed title level of "Defining a custom Authentication Provider"
chapter to be more consistant with others.
