### PR TITLE
Apply config values before calling register() in service provider

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -177,13 +177,13 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
      */
     public function register(ServiceProviderInterface $provider, array $values = array())
     {
-        $this->providers[] = $provider;
-
-        $provider->register($this);
-
         foreach ($values as $key => $value) {
             $this[$key] = $value;
         }
+
+        $this->providers[] = $provider;
+
+        $provider->register($this);
     }
 
     /**


### PR DESCRIPTION
When I register a service provider, my configuration values are not available in the provider's register() function. This is at odds with the documentation:

"You can also provide some parameters as a second argument. These will be set **before** the provider is registered:"

To fix this, I shifted the code that adds the values to the container up to the top of Application::register().
