### PR TITLE
Add custom firewall types to the end of the positions array

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -204,6 +204,10 @@ class SecurityServiceProvider implements ServiceProviderInterface
                             $entryPoint = $entryPointId;
                         }
 
+                        if (!in_array($position, $positions)) {
+                            $positions[] = $position;
+                        }
+
                         $factories[$position][] = $listenerId;
                         $providers[] = $providerId;
                     }


### PR DESCRIPTION
I noticed that while the ability to hook up new authentication mechanisms was added in e408ca41ae8d922c33c88c5804c52c4cde42d31b, it seems to have regressed in 9022e420f97bd51f175993abbe4e38e9534fcd9c, due to the usage of a $positions array to fix the order of auth listeners. This means that custom auth listeners are never registered in the $listeners array.

To fix this, I added a bit of code to append custom firewall types to the end of the $positions array. I'm not sure if the order matters (like whether it should be placed before the "anonymous" listener) but this works for me so far.
