### PR TITLE
Possible fix for Issue 452

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -650,7 +650,7 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
         return array(
             KernelEvents::REQUEST    => array(
                 array('onEarlyKernelRequest', 256),
-                array('onKernelRequest')
+                array('onKernelRequest', 64)
             ),
             KernelEvents::CONTROLLER => 'onKernelController',
             KernelEvents::RESPONSE   => 'onKernelResponse',


### PR DESCRIPTION
It looks like there are some strange things going on with event handler
priorities in the Symfony code.  From what I can tell, there is an interaction
between the RouterListener and part of the Secuirty Component that requires
specific priorities on their respective handler methods.  Unfortunately, this
seems to break some assumptions in the way that Silex is registering its own
handler method for before filters.
