### PR TITLE
Aren't parameters set after the provider is registered ?

### DIFF
--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -20,7 +20,7 @@ application::
     $app->register(new Acme\DatabaseServiceProvider());
 
 You can also provide some parameters as a second argument. These
-will be set **after** the provider is registered, but **before** is booted:
+will be set **after** the provider is registered, but **before** it is booted:
 
     $app->register(new Acme\DatabaseServiceProvider(), array(
         'database.dsn'      => 'mysql:host=localhost;dbname=myapp',


### PR DESCRIPTION
fabpot/Silex@9766faf0616a67cd0ff7437950d5453deebac9c4
