### PR TITLE
Add stability to dev for archive skeletons (fix GH-489)

### DIFF
--- a/bin/skeleton/fat_composer.json
+++ b/bin/skeleton/fat_composer.json
@@ -1,6 +1,6 @@
 {
     "require": {
-        "silex/silex": "1.0.*",
+        "silex/silex": "1.0.*@dev",
         "symfony/browser-kit": "2.1.*",
         "symfony/console": "2.1.*",
         "symfony/css-selector": "2.1.*",

--- a/bin/skeleton/slim_composer.json
+++ b/bin/skeleton/slim_composer.json
@@ -1,5 +1,5 @@
 {
     "require": {
-        "silex/silex": "1.0.*"
+        "silex/silex": "1.0.*@dev"
     }
 }


### PR DESCRIPTION
The Silex archives are not correctly built since the minimum-stability option was removed from composer files : a189265aa7ac2d2417f316286410f416139b6778

There is no stable version of Silex available yet.

Fix GH-489
