### PR TITLE
Added configuration example for external server

### DIFF
--- a/doc/providers/swiftmailer.rst
+++ b/doc/providers/swiftmailer.rst
@@ -14,6 +14,7 @@ Parameters
   configuration.
 
   The following options can be set:
+
   * **host**: SMTP hostname, defaults to 'localhost'.
   * **port**: SMTP port, defaults to 25.
   * **username**: SMTP username, defaults to an empty string.


### PR DESCRIPTION
Just added an example of how to configure an external smtp server for newbie users which don't know where to set it up.
