### PR TITLE
Updated http cache docs to use setTtl

### DIFF
--- a/doc/providers/http_cache.rst
+++ b/doc/providers/http_cache.rst
@@ -72,14 +72,12 @@ The provider also provides ESI support::
             'Surrogate-Control' => 'content="ESI/1.0"',
         ));
 
-        $response->setTtl(20);
-        return $response;
+        return $response->setTtl(20);
     });
 
     $app->get('/included', function() {
         $response = new Response('Foo');
-        $response->setTtl(5);
-        return $response;
+        return $response->setTtl(5);
     });
 
     $app['http_cache']->run();


### PR DESCRIPTION
Previous version set Cache-Control s-maxage headers explicitly which is
not enough to trigger ESI caching in the reverse proxy. Using setTtl is
enough to make this work correctly.
