### PR TITLE
Update Symfony and Twig deps versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,33 +17,33 @@
     "require": {
         "php": ">=5.3.3",
         "pimple/pimple": "1.*",
-        "symfony/event-dispatcher": ">=2.1,<2.3-dev",
-        "symfony/http-foundation": ">=2.1,<2.3-dev",
-        "symfony/http-kernel": ">=2.1,<2.3-dev",
-        "symfony/routing": ">=2.1,<2.3-dev"
+        "symfony/event-dispatcher": "~2.1",
+        "symfony/http-foundation": "~2.1",
+        "symfony/http-kernel": "~2.1",
+        "symfony/routing": "~2.1"
     },
     "require-dev": {
-        "symfony/security": ">=2.1,<2.3-dev",
-        "symfony/config": ">=2.1,<2.3-dev",
-        "symfony/locale": ">=2.1,<2.3-dev",
-        "symfony/form": ">=2.1,<2.3-dev",
+        "symfony/security": "~2.1",
+        "symfony/config": "~2.1",
+        "symfony/locale": "~2.1",
+        "symfony/form": "~2.1",
         "monolog/monolog": ">=1.0.0,<1.2-dev",
-        "symfony/browser-kit": ">=2.1,<2.3-dev",
-        "symfony/css-selector": ">=2.1,<2.3-dev",
-        "symfony/finder": ">=2.1,<2.3-dev",
-        "symfony/monolog-bridge": ">=2.1,<2.3-dev",
-        "symfony/process": ">=2.1,<2.3-dev",
-        "symfony/translation": ">=2.1,<2.3-dev",
-        "symfony/twig-bridge": ">=2.1,<2.3-dev",
-        "symfony/validator": ">=2.1,<2.3-dev",
-        "twig/twig": ">=1.8.0,<2.0-dev",
+        "symfony/browser-kit": "~2.1",
+        "symfony/css-selector": "~2.1",
+        "symfony/finder": "~2.1",
+        "symfony/monolog-bridge": "~2.1",
+        "symfony/process": "~2.1",
+        "symfony/translation": "~2.1",
+        "symfony/twig-bridge": "~2.1",
+        "symfony/validator": "~2.1",
+        "twig/twig": "~1.8",
         "doctrine/dbal": ">=2.2.0,<2.4.0-dev",
         "swiftmailer/swiftmailer": "4.2.*"
     },
     "suggest": {
-        "symfony/browser-kit": ">=2.1,<2.3-dev",
-        "symfony/css-selector": ">=2.1,<2.3-dev",
-        "symfony/dom-crawler": ">=2.1,<2.3-dev"
+        "symfony/browser-kit": "~2.1",
+        "symfony/css-selector": "~2.1",
+        "symfony/dom-crawler": "~2.1"
     },
     "autoload": {
         "psr-0": { "Silex": "src/" }


### PR DESCRIPTION
Slowly starting to update deps to ~ syntax where it makes sense. Symfony and Twig ones looked like they would be a good fit but not sure how specific the Doctrine and Monolog deps need to be set. They look pretty specific.
