### PR TITLE
Update src/Silex/Application.php

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -179,11 +179,11 @@ class Application extends \Pimple implements HttpKernelInterface, EventSubscribe
     {
         $this->providers[] = $provider;
 
-        $provider->register($this);
-
         foreach ($values as $key => $value) {
             $this[$key] = $value;
         }
+
+        $provider->register($this);
     }
 
     /**


### PR DESCRIPTION
According to documentation:

"You can also provide some parameters as a second argument. These will be set before the provider is registered:"

http://silex.sensiolabs.org/doc/providers.html#loading-providers

Values from second parametr should be set before provider's registration.
