### PR TITLE
Updated doc/providers/form.rst

### DIFF
--- a/doc/providers/form.rst
+++ b/doc/providers/form.rst
@@ -169,7 +169,7 @@ Traits
 
 .. code-block:: php
 
-    $app->form('form', $data);
+    $app->form($data);
 
 For more information, consult the `Symfony2 Forms documentation
 <http://symfony.com/doc/2.1/book/forms.html>`_.


### PR DESCRIPTION
Hello,

Only one line changed. FormTrait adds `function form($data, $options)` to \Silex\Application, not `form($name, $data, $options)` like createBuilder; this example in docs was throwing exception.

(this is my first pull request and now I see I should have done it in separate branch; sorry. I hope I didn't broke anything)
