### PR TITLE
render_route() twig function for rendering named routes

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,6 +1,20 @@
 Changelog
 =========
 
+* **2012-11-04**: Made the TwigServiceProvider ``render`` function prepend the
+  base URL to the path. This makes it behave consistently when a base URL is
+  present. If you were using ``render`` in combination with ``path``, you
+  should use the newly introduced ``render_route`` function instead:
+
+    Before::
+
+        {{ render(path('foo', { id: foo.id })) }}
+
+    After::
+
+        {{ render_route('foo', { id: foo.id }) }}
+
+
 * **2012-07-15**: removed the ``monolog.configure`` service. Use the
   ``extend`` method instead:
 

--- a/doc/providers/twig.rst
+++ b/doc/providers/twig.rst
@@ -117,8 +117,14 @@ from a template:
 
     {{ render('/sidebar') }}
 
-    {# or if you are also using UrlGeneratorServiceProvider with the SymfonyBridgesServiceProvider #}
-    {{ render(path('sidebar')) }}
+If you are using named routes you can use the ``render_route`` function. Note
+that you will need to have the ``symfony/routing`` package installed for this
+to work.
+
+.. code-block:: jinja
+
+    {{ render_route('sidebar') }}
+    {{ render_route('hello', { name: 'igor' }) }}
 
 Traits
 ------

--- a/src/Silex/Provider/TwigCoreExtension.php
+++ b/src/Silex/Provider/TwigCoreExtension.php
@@ -11,8 +11,11 @@
 
 namespace Silex\Provider;
 
+use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
+use Symfony\Component\Routing\Generator\UrlGenerator;
+use Symfony\Component\Routing\RequestContext;
 
 /**
  * Twig extension.
@@ -24,31 +27,58 @@ class TwigCoreExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            'render' => new \Twig_Function_Method($this, 'render', array('needs_environment' => true, 'is_safe' => array('html'))),
+            'render'        => new \Twig_Function_Method($this, 'render', array('needs_environment' => true, 'is_safe' => array('html'))),
+            'render_route'  => new \Twig_Function_Method($this, 'renderRoute', array('needs_environment' => true, 'is_safe' => array('html'))),
         );
     }
 
     public function render(\Twig_Environment $twig, $uri)
     {
         $globals = $twig->getGlobals();
-        $request = $globals['app']['request'];
+        $app = $globals['app'];
+        $request = $app['request'];
+
+        $uri = $request->getBaseUrl().$uri;
+        $subRequest = Request::create($uri, 'get', array(), $request->cookies->all(), array(), $request->server->all());
+
+        return $this->handleSubRequest($app, $request, $subRequest);
+    }
+
+    public function renderRoute(\Twig_Environment $twig, $routeName, $parameters)
+    {
+        if (!class_exists('Symfony\Component\Routing\Generator\UrlGenerator')) {
+            throw new \RuntimeException('You cannot use render_route without the Symfony2 Routing component.');
+        }
+
+        $globals = $twig->getGlobals();
+        $app = $globals['app'];
+        $request = $app['request'];
+
+        $generator = new UrlGenerator($app['routes'], $app['request_context']);
+        $uri = $generator->generate($routeName, $parameters);
 
         $subRequest = Request::create($uri, 'get', array(), $request->cookies->all(), array(), $request->server->all());
+
+        return $this->handleSubRequest($app, $request, $subRequest);
+    }
+
+    public function getName()
+    {
+        return 'silex';
+    }
+
+    private function handleSubRequest(Application $app, Request $request, Request $subRequest)
+    {
         if ($request->getSession()) {
             $subRequest->setSession($request->getSession());
         }
 
-        $response = $globals['app']->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
+        $response = $app->handle($subRequest, HttpKernelInterface::SUB_REQUEST, false);
 
         if (!$response->isSuccessful()) {
             throw new \RuntimeException(sprintf('Error when rendering "%s" (Status code is %s).', $request->getUri(), $response->getStatusCode()));
         }
 
         return $response->getContent();
-    }
-
-    public function getName()
-    {
-        return 'silex';
     }
 }


### PR DESCRIPTION
Using something like this causes issues:

```
{{ render('/cart') }}
```

Because the render() function depends on the baseUrl being present. This patch fixes that issue, but that fix causes a new issue. Since we are always prepending the baseUrl, we can no longer use:

```
{{ render(path('/cart')) }}
```

Because if render() always prepends the baseUrl and the result of path() already includes the baseUrl, then we get a double baseUrl. To resolve that issue, there is a new `render_route` function which does not prepend the baseUrl.
