### PR TITLE
Added use statement for HttpExceptionInterface

### DIFF
--- a/src/Silex/ExceptionListenerWrapper.php
+++ b/src/Silex/ExceptionListenerWrapper.php
@@ -12,6 +12,7 @@
 namespace Silex;
 
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;


### PR DESCRIPTION
The Exception Wrapper recent refactoring added a reference to HttpExceptionInterface but not a use statement for it.  This can cause the instance of check in there to fail causing you to always get a 500 error code.
