### PR TITLE
Set SCRIPT_FILENAME after including params

### DIFF
--- a/doc/web_servers.rst
+++ b/doc/web_servers.rst
@@ -61,10 +61,10 @@ resources to ``index.php``:
 
         location @site {
             fastcgi_pass   unix:/var/run/php-fpm/www.sock;
+            include fastcgi_params;
             fastcgi_param  SCRIPT_FILENAME $document_root/index.php;
             #uncomment when running via https
             #fastcgi_param HTTPS on;
-            include fastcgi_params;
         }
     }
 


### PR DESCRIPTION
I think that some versions or distributions of nginx set SCRIPT_FILENAME in the
fastcgi_params file (certainly ubuntu/debian), overriding anything previously set.
