### PR TITLE
Suggest removing the minimum-stability flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,8 @@ composer](http://getcomposer.org). Just create a `composer.json` file and
 run the `php composer.phar install` command to install it:
 
     {
-        "minimum-stability": "dev",
         "require": {
-            "silex/silex": "1.0.*"
+            "silex/silex": "1.0.*@dev"
         }
     }
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -25,7 +25,7 @@ If you want more flexibility, use Composer instead. Create a
 
     {
         "require": {
-            "silex/silex": "1.0.*"
+            "silex/silex": "1.0.*@dev"
         }
     }
 


### PR DESCRIPTION
Silex can be installed with stable versions of the Symfony2 components.
Users should not be encouraged to set the minimum-stability flag to dev.

https://groups.google.com/forum/?fromgroups=#!topic/silex-php/vPwMs7CMMT0
