### PR TITLE
Add test that shows that `before` middleware is not triggered when route is not found

### DIFF
--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -360,6 +360,35 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame(array('1_routeTriggered', '2_filterAfter', '3_responseSent', '4_filterFinish'), $containerTarget);
     }
 
+    public function testMiddlewaresWithUndefinedRoute()
+    {
+        $containerTarget = array();
+
+        $app = new Application();
+
+        $app->before(function () use (&$containerTarget) {
+            $containerTarget[] = '1_before';
+        });
+        $app->error(function () use (&$containerTarget) {
+
+            return new StreamedResponse(function() use (&$containerTarget) {
+                $containerTarget[] = '3_error';
+            });
+        });
+
+        $app->finish(function () use (&$containerTarget) {
+            $containerTarget[] = '4_finish';
+        });
+
+        $app->after(function () use (&$containerTarget) {
+            $containerTarget[] = '2_after';
+        });
+
+        $app->run(Request::create('/foo'));
+
+        $this->assertSame(array('1_before', '2_after', '3_error', '4_finish'), $containerTarget);
+    }
+
     /**
      * @expectedException RuntimeException
      */


### PR DESCRIPTION
Hello

when requesting an undefined route, the before middleware is not anymore triggered. It was triggered before the latest refactor @fabpot did in the last 7 days.

This is particularly useful for service providers that relies on this middleware (MonologServiceProvider) or custom implementation (Content Negociation and so on...)

I did not found a solution yet, but this test covers the case.

expected result of the test : 

```
Array (
    0 => '1_before'
    1 => '2_after'
    2 => '3_error'
    3 => '4_finish'
)
```

actual result : 

```
Array (
    0 => '2_after'
    1 => '3_error'
    2 => '4_finish'
)
```
