### PR TITLE
Removed unused use statement from the sample code

### DIFF
--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -166,7 +166,6 @@ Here is an example of such a provider::
 
     use Silex\Application;
     use Silex\ControllerProviderInterface;
-    use Silex\ControllerCollection;
 
     class HelloControllerProvider implements ControllerProviderInterface
     {


### PR DESCRIPTION
The sample code changed to not need the ControllerCollection anyone but the use statement was left in.
