### PR TITLE
Make default route in ControllerCollection constructor optional

### DIFF
--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -32,8 +32,11 @@ class ControllerCollection
     /**
      * Constructor.
      */
-    public function __construct(Route $defaultRoute)
+    public function __construct(Route $defaultRoute = null)
     {
+        if (null === $defaultRoute) {
+            $defaultRoute = new Route();
+        }
         $this->defaultRoute = $defaultRoute;
     }
 


### PR DESCRIPTION
There is no need for the default route parameter in the constructor for ControllerCollection to be required. This change initializes the default route as a new Route using all of the default parameter values for Route if the default route parameter is not provided.
