### PR TITLE
getFormat() => getRequestFormat()

### DIFF
--- a/doc/providers/serializer.rst
+++ b/doc/providers/serializer.rst
@@ -51,7 +51,7 @@ The ``SerializerServiceProvider`` provider provides a ``serializer`` service:
         // assume a page_repository service exists that returns Page objects. The
         // object returned has getters and setters exposing the state.
         $page = $app['page_repository']->find($id);
-        $format = $app['request']->getFormat();
+        $format = $app['request']->getRequestFormat();
     
         if (!$page instanceof Page) {
             $app->abort("No page found for id: $id");


### PR DESCRIPTION
The `getFormat()` method is not the one used to get the request format.
