### PR TITLE
Support 'security' and 'stateless' flags in security config

### DIFF
--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -247,6 +247,21 @@ The order of the firewall configurations is significant as the first one to
 match wins. The above configuration first ensures that the ``/login`` URL is
 not secured (no authentication settings), and then it secures all other URLs.
 
+.. tip::
+
+    You can toggle all registered authentication mechanisms for a particular
+    area on and off with the ``security`` flag::
+
+        $app['security.firewalls'] = array(
+            'api' => array(
+                'pattern' => '^/api',
+                'security' => $app['debug'] ? false : true,
+                'wsse' => true,
+
+                // ...
+            ),
+        );
+
 Adding a Logout
 ~~~~~~~~~~~~~~~
 
@@ -560,6 +575,23 @@ argument of your authentication factory (see above).
 
 This example uses the authentication provider classes as described in the
 Symfony `cookbook`_.
+
+Stateless Authentication
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, a session cookie is created to persist the security context of
+the user. However, if you use certificates, HTTP authentication, WSSE and so
+on, the credentials are sent for each request. In that case, you can turn off
+persistence by activating the ``stateless`` authentication flag::
+
+    $app['security.firewalls'] = array(
+        'default' => array(
+            'stateless' => true,
+            'wsse' => true,
+
+            // ...
+        ),
+    );
 
 Traits
 ------

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -158,9 +158,11 @@ class SecurityServiceProvider implements ServiceProviderInterface
                 $entryPoint = null;
                 $pattern = isset($firewall['pattern']) ? $firewall['pattern'] : null;
                 $users = isset($firewall['users']) ? $firewall['users'] : array();
-                unset($firewall['pattern'], $firewall['users']);
+                $security = isset($firewall['security']) ? (Boolean) $firewall['security'] : true;
+                $stateless = isset($firewall['stateless']) ? (Boolean) $firewall['stateless'] : false;
+                unset($firewall['pattern'], $firewall['users'], $firewall['security'], $firewall['stateless']);
 
-                $protected = count($firewall);
+                $protected = false === $security ? false : count($firewall);
 
                 $listeners = array('security.channel_listener');
 
@@ -173,7 +175,9 @@ class SecurityServiceProvider implements ServiceProviderInterface
                         $app['security.context_listener.'.$name] = $app['security.context_listener._proto']($name, array($app['security.user_provider.'.$name]));
                     }
 
-                    $listeners[] = 'security.context_listener.'.$name;
+                    if (false === $stateless) {
+                        $listeners[] = 'security.context_listener.'.$name;
+                    }
 
                     $factories = array();
                     foreach ($positions as $position) {


### PR DESCRIPTION
`'security' => false` will disable the firewall (for a particular area) even if there are listeners configured.

`'stateless' => true` will prevent `ContextListener` from getting registered.
