### PR TITLE
Fix route name in security service doc

### DIFF
--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -269,7 +269,7 @@ are replaced with ``_`` and the leading ``/`` is stripped):
 
 .. code-block:: jinja
 
-    <a href="{{ path('logout') }}">Logout</a>
+    <a href="{{ path('admin_logout') }}">Logout</a>
 
 Allowing Anonymous Users
 ~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Fix a little bit confusing mistake in security doc.
