### PR TITLE
Make reason of prenatal code visible.

### DIFF
--- a/src/Silex/Util/Compiler.php
+++ b/src/Silex/Util/Compiler.php
@@ -82,7 +82,8 @@ class Compiler
 
         $phar->stopBuffering();
 
-        // $phar->compressFiles(\Phar::GZ);
+        // FIXME: phar compression feature is not yet implemented
+        //$phar->compressFiles(\Phar::GZ);
 
         unset($phar);
     }


### PR DESCRIPTION
Code is commented since ages, the reason is missing (because there is a reason).

See #594
