### PR TITLE
Make test ignore JSON semantics

### DIFF
--- a/tests/Silex/Tests/JsonTest.php
+++ b/tests/Silex/Tests/JsonTest.php
@@ -26,7 +26,8 @@ class JsonTest extends \PHPUnit_Framework_TestCase
 
         $response = $app->json();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\JsonResponse', $response);
-        $this->assertSame('{}', $response->getContent());
+        $response = json_decode($response->getContent(), true);
+        $this->assertSame(array(), $response);
     }
 
     public function testJsonUsesData()


### PR DESCRIPTION
One fix for Symfony 2.2, related to #607 and symfony/symfony#5506
