### PR TITLE
Clarify provider conventions for params

### DIFF
--- a/doc/providers.rst
+++ b/doc/providers.rst
@@ -37,9 +37,13 @@ with providers. Just keep to these rules:
 * Overriding existing services must occur **after** the provider is
   registered.
 
-  *Reason: If the services already exist, the provider will overwrite it.*
+  *Reason: If the service already exists, the provider will overwrite it.*
 
-* You can set parameters any time before the service is accessed.
+* You can set parameters any time **after** the provider is registered, but
+  **before** the service is accessed.
+
+  *Reason: Providers can set default values for parameters. Just like with
+  services, the provider will overwrite existing values.*
 
 Make sure to stick to this behavior when creating your own providers.
 


### PR DESCRIPTION
The current conventions for parameters is outdated. At some point we
decided that providers can define default values for params. Therefore
parameters must be registered _after_ the extension is registered.

Related commit: 9766faf0616a67cd0ff7437950d5453deebac9c4
