### PR TITLE
Add logger and stopwatch for Doctrine queries

### DIFF
--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -16,6 +16,7 @@ use Silex\ServiceProviderInterface;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Configuration;
 use Doctrine\Common\EventManager;
+use Symfony\Bridge\Doctrine\Logger\DbalLogger;
 
 /**
  * Doctrine DBAL Provider.
@@ -84,6 +85,10 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             $configs = new \Pimple();
             foreach ($app['dbs.options'] as $name => $options) {
                 $configs[$name] = new Configuration();
+
+                if (isset($app['logger']) && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger')) {
+                    $configs[$name]->setSQLLogger(new DbalLogger($app['logger'], isset($app['stopwatch']) ? $app['stopwatch'] : null));
+                }
             }
 
             return $configs;


### PR DESCRIPTION
Add SQL queries to the logs using the DbalLogger of the DoctrineBridge.

In addition, if the WebprofilerServiceProvider is registered (stopwatch service set), the timeline show doctrine queries.

![Profiler](https://f.cloud.github.com/assets/400034/152414/877dc396-75c4-11e2-96df-6dde93c7d86e.png)
