### PR TITLE
improved the performance of the Twig loader by not registering a chain loader if not needed

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -96,8 +96,8 @@ class TwigServiceProvider implements ServiceProviderInterface
 
         $app['twig.loader'] = $app->share(function ($app) {
             return new \Twig_Loader_Chain(array(
-                $app['twig.loader.filesystem'],
                 $app['twig.loader.array'],
+                $app['twig.loader.filesystem'],
             ));
         });
     }

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -63,4 +63,18 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
         $response = $app->handle($request);
         $this->assertEquals('foo', $response->getContent());
     }
+
+    public function testLoaderPriority()
+    {
+        $app = new Application();
+        $app->register(new TwigServiceProvider(), array(
+            'twig.templates'    => array('foo' => 'foo'),
+        ));
+        $loader = $this->getMock('\Twig_LoaderInterface');
+        $loader->expects($this->never())->method('getSource');
+        $app['twig.loader.filesystem'] = $app->share(function ($app) use ($loader) {
+            return $loader;
+        });
+        $this->assertEquals('foo', $app['twig.loader']->getSource('foo'));
+    }
 }


### PR DESCRIPTION
When `twig.templates` is empty, there is no need to register the Twig array loader as it will never be used anyway.
