### PR TITLE
Updated docs to include _method and enableHttpMethodParameterOverride()

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -232,7 +232,10 @@ methods on your application: ``get``, ``post``, ``put``, ``delete``::
 
 .. tip::
 
-    Forms in most web browsers do not directly support the use of other HTTP methods. To use methods other than GET and POST you can utilize a special form field with a name of ``_method``. The form's ``method`` attribute must be set to POST when using this field::
+    Forms in most web browsers do not directly support the use of other HTTP 
+    methods. To use methods other than GET and POST you can utilize a special 
+    form field with a name of ``_method``. The form's ``method`` attribute must 
+    be set to POST when using this field::
 
         <form action="/my/target/route/" method="post">
             ...
@@ -241,7 +244,8 @@ methods on your application: ``get``, ``post``, ``put``, ``delete``::
 
 .. note::
 
-    If using Symfony Components >= 2.2.0 you will need to explicitly enable this method override::
+    If using Symfony Components >= 2.2.0 you will need to explicitly enable this
+     method override::
 
         use Symfony\Component\HttpFoundation\Request;
 


### PR DESCRIPTION
Should be self explanatory. Small addition to the docs to explain about the _method form value and also to advise abut the explicit enableHttpMethodParameterOverride() call required with Symfony 2.2.0 and later.
