### PR TITLE
[Security] Rename authentication_provider services to avoid name conflict

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -137,12 +137,13 @@ class SecurityServiceProvider implements ServiceProviderInterface
                     $app['security.authentication_listener.'.$name.'.'.$type] = $app['security.authentication_listener.'.$type.'._proto']($name, $options);
                 }
 
-                if (!isset($app['security.authentication_provider.'.$name])) {
-                    $app['security.authentication_provider.'.$name] = $app['security.authentication_provider.'.('anonymous' == $name ? 'anonymous' : 'dao').'._proto']($name);
+                $provider = 'anonymous' === $type ? 'anonymous' : 'dao';
+                if (!isset($app['security.authentication_provider.'.$name.'.'.$provider])) {
+                    $app['security.authentication_provider.'.$name.'.'.$provider] = $app['security.authentication_provider.'.$provider.'._proto']($name);
                 }
 
                 return array(
-                    'security.authentication_provider.'.$name,
+                    'security.authentication_provider.'.$name.'.'.$provider,
                     'security.authentication_listener.'.$name.'.'.$type,
                     $entryPoint ? 'security.entry_point.'.$name.'.'.$entryPoint : null,
                     $type


### PR DESCRIPTION
When using both anonymous and form authentication providers, they share the same service name whereas they use totally different classes.

Before : `security.authentication_provider.myfirewall`
After : `security.authentication_provider.myfirewall.dao` and `security.authentication_provider.myfirewall.anonymous`

The naming follows the recommendation for custom auth providers.
http://silex.sensiolabs.org/doc/providers/security.html#defining-a-custom-authentication-provider
