### PR TITLE
Use addPrefix to avoid deprecated calls in >2.2.0

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -364,7 +364,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      */
     public function flush($prefix = '')
     {
-        $this['routes']->addCollection($this['controllers']->flush($prefix), $prefix);
+        $this['routes']->addCollection($this['controllers']->flush($prefix));
     }
 
     /**
@@ -462,7 +462,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
             throw new \LogicException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
         }
 
-        $this['routes']->addCollection($controllers->flush($prefix), $prefix);
+        $this['routes']->addCollection($controllers->flush($prefix));
 
         return $this;
     }

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -148,6 +148,8 @@ class ControllerCollection
             $controller->freeze();
         }
 
+        $routes->addPrefix($prefix);
+
         $this->controllers = array();
 
         return $routes;


### PR DESCRIPTION
I think this should take care of #642
