### PR TITLE
Update translation.rst

### DIFF
--- a/doc/providers/translation.rst
+++ b/doc/providers/translation.rst
@@ -189,3 +189,9 @@ strings in the Twig way:
     {{ 'translation_key'|trans }}
     {{ 'translation_key'|transchoice }}
     {% trans %}translation_key{% endtrans %}
+
+In order to be able to use these filters directly in the twig templates, you must also include the extension:
+
+.. code-block:: php
+
+    $app['twig']->addExtension(new Symfony\Bridge\Twig\Extension\TranslationExtension($app['translator'])); 


### PR DESCRIPTION
when trying to use the "trans" filters directly in twig templates, it did not work until i added

``` php
$app['twig']->addExtension(new Symfony\Bridge\Twig\Extension\TranslationExtension($app['translator']));
```

This is not documented.
