### PR TITLE
note that `mod_rewrite` needs to be enabled

### DIFF
--- a/doc/web_servers.rst
+++ b/doc/web_servers.rst
@@ -4,7 +4,7 @@ Webserver Configuration
 Apache
 ------
 
-If you are using Apache you can use a ``.htaccess`` file for this:
+If you are using Apache, make sure ``mod_rewrite`` is enabled and you can use the following ``.htaccess`` file:
 
 .. code-block:: apache
 


### PR DESCRIPTION
If `mod_rewrite` isn't enabled - like in default Apache installs and WAMP - it will result in 404's. I had this issue with the hello world zip distribution (SO question: http://stackoverflow.com/questions/15498419/why-am-i-getting-these-silex-404s) and it was quite difficult to track down. Almost made me give up on Silex, although this is of course not a Silex issue - but it can be challenging for beginners, and if you can't get the hello world to run it kinda takes the wind out of your sails.
