### PR TITLE
Move query string hack for request context to listener

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -104,7 +104,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
             $dispatcher->addSubscriber(new MiddlewareListener($app));
             $dispatcher->addSubscriber(new ConverterListener($app['routes']));
             $dispatcher->addSubscriber(new StringToResponseListener());
-            $dispatcher->addSubscriber(new RequestContextQueryStringListener($app));
+            $dispatcher->addSubscriber(new RequestContextQueryStringListener($app['request_context']));
 
             return $dispatcher;
         });

--- a/src/Silex/EventListener/RequestContextQueryStringListener.php
+++ b/src/Silex/EventListener/RequestContextQueryStringListener.php
@@ -11,11 +11,10 @@
 
 namespace Silex\EventListener;
 
-use Silex\Application;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
-use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\RequestContext;
 
 /**
  * Inject the query string into the RequestContext for Symfony versions <= 2.2
@@ -24,11 +23,11 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class RequestContextQueryStringListener implements EventSubscriberInterface
 {
-    private $app;
+    private $context;
 
-    public function __construct(Application $app)
+    public function __construct(RequestContext $context)
     {
-        $this->app = $app;
+        $this->context = $context;
     }
 
     public function onKernelRequest(GetResponseEvent $event)
@@ -39,7 +38,7 @@ class RequestContextQueryStringListener implements EventSubscriberInterface
 
         $request = $event->getRequest();
         if ($request->server->get('QUERY_STRING') !== '') {
-            $this->app['request_context']->setParameter('QUERY_STRING', $request->server->get('QUERY_STRING'));
+            $this->context->setParameter('QUERY_STRING', $request->server->get('QUERY_STRING'));
         }
     }
 


### PR DESCRIPTION
Currently the UrlMatcher depends on the request context which leads to all
kinds of funky problems. Including failing tests in the current test suite.

The solution is to have the request context no longer directly depend on
the request, but instead populate the required information from a request
listener.

Better names for the listener are welcome.

PS: This solution feels kind of off to me. Shouldn't this case be handled by symfony/routing's `RequestContext::fromRequest()` directly? And if not, why?
