### PR TITLE
Change visibility of `providers` and `booted` to protected

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -48,8 +48,8 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
     const EARLY_EVENT = 512;
     const LATE_EVENT  = -512;
 
-    private $providers = array();
-    private $booted = false;
+    protected $providers = array();
+    protected $booted = false;
 
     /**
      * Instantiate a new Application.


### PR DESCRIPTION
This changes `$providers` and `$booted` in `Application` to protected, which makes it easier to extend.
