### PR TITLE
Suggest using QSA in apache config to get access to query parameters

### DIFF
--- a/doc/web_servers.rst
+++ b/doc/web_servers.rst
@@ -15,7 +15,7 @@ following ``.htaccess`` file:
         RewriteEngine On
         #RewriteBase /path/to/app
         RewriteCond %{REQUEST_FILENAME} !-f
-        RewriteRule ^ index.php [L]
+        RewriteRule ^ index.php [QSA,L]
     </IfModule>
 
 .. note::


### PR DESCRIPTION
A user had hard time finding why OAuth was not working on its Silex application (see https://github.com/GromNaN/FacebookServiceProvider/issues/1#issuecomment-16845793)

For the Apache doc: http://httpd.apache.org/docs/current/rewrite/flags.html#flag_qsa
