### PR TITLE
Fix test on RememberMeServiceProvider broken by update on symfony 2.1

### DIFF
--- a/src/Silex/Provider/RememberMeServiceProvider.php
+++ b/src/Silex/Provider/RememberMeServiceProvider.php
@@ -64,7 +64,7 @@ class RememberMeServiceProvider implements ServiceProviderInterface
                     'name'                  => 'REMEMBERME',
                     'lifetime'              => 31536000,
                     'path'                  => '/',
-                    'domain'                => null,
+                    'domain'                => '',
                     'secure'                => false,
                     'httponly'              => true,
                     'always_remember_me'    => false,

--- a/tests/Silex/Tests/Provider/RememberMeServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/RememberMeServiceProviderTest.php
@@ -37,7 +37,7 @@ class RememberMeServiceProviderTest extends WebTestCase
         $client->followRedirect();
         $this->assertEquals('AUTHENTICATED_FULLY', $client->getResponse()->getContent());
 
-        $this->assertNotNull($client->getCookiejar()->get('REMEMBERME'), 'The REMEMBERME cookie is set');
+        $this->assertNotNull($client->getCookiejar()->get('REMEMBERME', '/', 'localhost'), 'The REMEMBERME cookie is set');
 
         $client->getCookiejar()->expire('MOCKSESSID', '/', 'localhost');
 


### PR DESCRIPTION
The test has been broken by this commit on symfony 2.1: https://github.com/symfony/symfony/commit/c2bc707a4de91f9ca609a170176eb30e3e45cb10
