### PR TITLE
[docs] Correct form component version in docs

### DIFF
--- a/doc/providers/form.rst
+++ b/doc/providers/form.rst
@@ -55,7 +55,7 @@ Registering
     .. code-block:: json
 
         "require": {
-            "symfony/form": "~2.1.4"
+            "symfony/form": "~2.1"
         }
 
     If you are going to use the validation extension with forms, you must also


### PR DESCRIPTION
Validator ~2.1 pulls in a new version of the validator component where `Symfony\Component\Validator\Mapping\ClassMetaDataFactory` has `getMetaDataFor` instead of `getClassMetaData` - this causes an exception from `Symfony\Component\Form\Extension\Validator`, line 39 - where the 2.1 version pulled in by `~2.1.4` calls getClassMetaData. 

This change has fixed it for me - just depends whether there was a reason for holding the form component at 2.1 ?
