### PR TITLE
Require the debug component from symfony/http-kernel:2.3 onwards

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "symfony/translation": ">=2.1,<2.4-dev",
         "symfony/twig-bridge": ">=2.1,<2.4-dev",
         "symfony/validator": ">=2.1,<2.4-dev",
+        "symfony/debug": ">=2.3,<2.4-dev",
         "twig/twig": ">=1.8.0,<2.0-dev",
         "doctrine/dbal": ">=2.2.0,<2.4.0-dev",
         "swiftmailer/swiftmailer": "4.2.*",
@@ -47,7 +48,8 @@
         "symfony/browser-kit": ">=2.1,<2.4-dev",
         "symfony/css-selector": ">=2.1,<2.4-dev",
         "symfony/dom-crawler": ">=2.1,<2.4-dev",
-        "symfony/form": ">= 2.1.4,<2.4-dev"
+        "symfony/form": ">=2.1.4,<2.4-dev",
+        "symfony/debug": ">=2.3,<2.4-dev"
     },
     "autoload": {
         "psr-0": { "Silex": "src/" }

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -12,6 +12,7 @@
 namespace Silex;
 
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
@@ -61,6 +62,10 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
     public function __construct(array $values = array())
     {
         parent::__construct();
+
+        if (version_compare(strtolower(Kernel::VERSION), '2.3.0-dev', '>=') && !class_exists('Symfony\Component\Debug\ExceptionHandler')) {
+            throw new \RuntimeException('In order to use Silex with Symfony 2.3, you must install symfony/debug 2.3.');
+        }
 
         $app = $this;
 


### PR DESCRIPTION
This is my proposed fix for #687.
