### PR TITLE
Doc: trustProxyData() is now replaced by setTrustedProxies().

### DIFF
--- a/doc/providers/http_cache.rst
+++ b/doc/providers/http_cache.rst
@@ -53,11 +53,12 @@ setting Response HTTP cache headers::
 .. tip::
 
     If you want Silex to trust the ``X-Forwarded-For*`` headers from your
-    reverse proxy, you will need to run your application like this::
+    reverse proxy at address $ip, you will need to run your application like
+    this::
 
         use Symfony\Component\HttpFoundation\Request;
 
-        Request::trustProxyData();
+        Request::setTrustedProxies(array($ip));
         $app->run();
 
 This provider allows you to use the Symfony2 reverse proxy natively with

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -79,13 +79,13 @@ Then, you have to configure your web server (read the :doc:`dedicated chapter
 
 .. tip::
 
-    If your application is hosted behind a reverse proxy and you want Silex to
-    trust the ``X-Forwarded-For*`` headers, you will need to run your
-    application like this::
+    If your application is hosted behind a reverse proxy at address $ip, and you 
+    want Silex to trust the ``X-Forwarded-For*`` headers, you will need to run 
+    your application like this::
 
         use Symfony\Component\HttpFoundation\Request;
 
-        Request::trustProxyData();
+        Request::setTrustedProxies(array($ip));
         $app->run();
 
 Routing


### PR DESCRIPTION
Although trustProxyData() is deprecated, the documentation still refers to it, causing deprecation warnings. This patch suggested an updated wording.
