### PR TITLE
Added new redirectRoute method to support redirecting to named routes

### DIFF
--- a/src/Silex/Application/UrlGeneratorTrait.php
+++ b/src/Silex/Application/UrlGeneratorTrait.php
@@ -55,6 +55,6 @@ trait UrlGeneratorTrait
      */
     public function redirectRoute($route, $parameters = array(), $status = 302)
     {
-        return parent::redirect($this->path($route, $parameters), $status);
+        return $this->redirect($this->path($route, $parameters), $status);
     }
 }


### PR DESCRIPTION
As discussed in issues #701 I have added a new method to the `UrlGeneratorTrait` which enables redirecting directly to a named route, as opposed to having to call `$app->path(..)` and pass it into `$app->redirect`.
