### PR TITLE
Escape @method type hints for docblock in Silex/Controller.

### DIFF
--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -19,14 +19,14 @@ use Silex\Exception\ControllerFrozenException;
  * __call() forwards method-calls to Route, but returns instance of Controller
  * listing Route's methods below, so that IDEs know they are valid
  *
- * @method \Silex\Controller assert(string $variable, string $regexp)
- * @method \Silex\Controller value(string $variable, mixed $default)
- * @method \Silex\Controller convert(string $variable, mixed $callback)
- * @method \Silex\Controller method(string $method)
+ * @method \Silex\Controller assert(\string $variable, \string $regexp)
+ * @method \Silex\Controller value(\string $variable, \mixed $default)
+ * @method \Silex\Controller convert(\string $variable, \mixed $callback)
+ * @method \Silex\Controller method(\string $method)
  * @method \Silex\Controller requireHttp()
  * @method \Silex\Controller requireHttps()
- * @method \Silex\Controller before(mixed $callback)
- * @method \Silex\Controller after(mixed $callback)
+ * @method \Silex\Controller before(\mixed $callback)
+ * @method \Silex\Controller after(\mixed $callback)
  * @author Igor Wiedler <igor@wiedler.ch>
  */
 class Controller


### PR DESCRIPTION
The current docblock makes some IDEs (like PhpStorm) interpret the
type hints as belonging to the `Silex` namespace, causing warnings
in the IDE when methods are used.
