### PR TITLE
Adding '_route' key to RedirectableUrlMatcher::redirect return value

### DIFF
--- a/src/Silex/RedirectableUrlMatcher.php
+++ b/src/Silex/RedirectableUrlMatcher.php
@@ -49,6 +49,7 @@ class RedirectableUrlMatcher extends BaseRedirectableUrlMatcher
 
         return array(
             '_controller' => function ($url) { return new RedirectResponse($url, 301); },
+            '_route' => null,
             'url' => $url,
         );
     }


### PR DESCRIPTION
When there is a logger, the Symfony\Compoment\HttpKernel\EventListener\RouterListener class expects the '_route' key to exist in order to log the matched route and issues a PHP Notice
