### PR TITLE
add '_route' key to RedirectableUrlMatcher::redirect

### DIFF
--- a/src/Silex/RedirectableUrlMatcher.php
+++ b/src/Silex/RedirectableUrlMatcher.php
@@ -54,6 +54,7 @@ class RedirectableUrlMatcher extends BaseRedirectableUrlMatcher
 
         return array(
             '_controller' => function ($url) { return new RedirectResponse($url, 301); },
+            '_route' => null,
             'url' => $url,
         );
     }


### PR DESCRIPTION
When there is a logger, the Symfony\Compoment\HttpKernel\EventListener\RouterListener::onKernelRequest method expects the '_route' key to exist in order to log the matched route and issues a PHP Notice

```
<?php
date_default_timezone_set('America/Los_Angeles');

require_once __DIR__ . '/../vendor/autoload.php';
Symfony\Component\HttpKernel\Debug\ErrorHandler::register();
$app = new Silex\Application();
$app['debug'] = true;
$app['monolog.logfile'] = 'C:/TEMP/log.log';
$app->register(new \Silex\Provider\MonologServiceProvider());
$app->get('/a/', function() {
    return 'done';
});

$app->run();
```

_[url]/a_ issues the notice before redirecting to _/a/_
