### PR TITLE
Fixed testing doc

### DIFF
--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -99,7 +99,6 @@ executed before every test.
         {
             $app = require __DIR__.'/path/to/app.php';
             $app['debug'] = true;
-            $app['exception_handler']->disable();
 
             return $app;
         }


### PR DESCRIPTION
- If you leave `debug=true` and disable `exception_handler` => if your controller throw a 404, the test fail
- If you set `debug=false` => It is not easy to debug when something wrong happen
- If you set `debug=true` and remove the `exception_handler` you have the best of both world.
