### PR TITLE
Register event listeners in service definition (not part of the boot)

### DIFF
--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -62,10 +62,7 @@ class MonologServiceProvider implements ServiceProviderInterface
         };
 
         $app['monolog.name'] = 'myapp';
-    }
 
-    public function boot(Application $app)
-    {
         $app->before(function (Request $request) use ($app) {
             $app['monolog']->addInfo('> '.$request->getMethod().' '.$request->getRequestUri());
         });
@@ -82,5 +79,9 @@ class MonologServiceProvider implements ServiceProviderInterface
         $app->after(function (Request $request, Response $response) use ($app) {
             $app['monolog']->addInfo('< '.$response->getStatusCode());
         });
+    }
+
+    public function boot(Application $app)
+    {
     }
 }

--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -82,10 +82,7 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface
         $app['swiftmailer.transport.eventdispatcher'] = $app->share(function () {
             return new \Swift_Events_SimpleEventDispatcher();
         });
-    }
 
-    public function boot(Application $app)
-    {
         $app->finish(function () use ($app) {
             // To speed things up (by avoiding Swift Mailer initialization), flush
             // messages only if our mailer has been created (potentially used)
@@ -93,5 +90,9 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface
                 $app['swiftmailer.spooltransport']->getSpool()->flushQueue($app['swiftmailer.transport']);
             }
         });
+    }
+
+    public function boot(Application $app)
+    {
     }
 }


### PR DESCRIPTION
Since #705, listener declarations are part of the "service definition" as the service `dispatcher` is extended instead if being instanced. I removed the listener declarations from the `boot` method to put them in the `register` method.

That might avoid issues like what I described here: https://github.com/fabpot/Silex/pull/705#issuecomment-17969365 if the `kernel` is instanced (with the dispatcher injected) during the boot.
