### PR TITLE
Inject $app into controller constructor

### DIFF
--- a/src/Silex/ControllerResolver.php
+++ b/src/Silex/ControllerResolver.php
@@ -47,6 +47,17 @@ class ControllerResolver extends BaseControllerResolver
             }
         }
 
+        foreach ($controller as $object)
+        {
+            if (is_object($object))
+            {
+                if (method_exists($object, 'setPimple'))
+                {
+                    $object->setPimple($this->app);
+                }
+            }
+        }
+
         return parent::doGetArguments($request, $controller, $parameters);
     }
 }


### PR DESCRIPTION
I've recently been using controllers as services and ran into a bit of an issue with not being able to the $app from within. Below is the documented way of doing this:

``` php
public function action (Application $app) {
    // acton code
}
```

This works great until I want to extend from a base controller. I use this for various helper commands for rending twig templates or ouputting/logging errors from within the application. The only way I can see how to do this is like below:

``` php
public function action1 (Application $app) {
    $this->app = $app;
    // rest of action code
}
// ... more actions in controller, each needing that top line
```

To avoid having to do this in every action, as there may be many I added this snippet which is taken from the symfony http-kernel component. It basically just passes $app to the constructor, then the base controller can set `$this->app` from it's constructor for all of the actions (and base helper functions) to access.

Apologies if I've overlooked a better way of doing this.

Thanks
/Marc
