### PR TITLE
Drop minimum-stability from composer.json.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,4 @@
 {
-    "minimum-stability": "dev",
     "name": "silex/silex",
     "description": "The PHP micro-framework based on the Symfony2 Components",
     "keywords": ["microframework"],


### PR DESCRIPTION
Drop the minimum stability of dev as 2.3 is now stable and should it is not needed anymore.
