### PR TITLE
Workaround for OptionsResolver validating options

### DIFF
--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -17,7 +17,6 @@ use Silex\Provider\FormServiceProvider;
 use Symfony\Component\Validator\Constraints as Assert;
 use Silex\Tests\Provider\ValidatorServiceProviderTest\Constraint\Custom;
 use Silex\Tests\Provider\ValidatorServiceProviderTest\Constraint\CustomValidator;
-use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
 
 /**
  * ValidatorServiceProvider


### PR DESCRIPTION
Couldn't think of anyway to determine which version of the form component was being used, so went with the the suck it and see.
