### PR TITLE
Suggest php54

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "monolog/monolog": "~1.4,>=1.4.1"
     },
     "suggest": {
-        "php": ">=5.4.1",
+        "php": "~5.4",
         "symfony/browser-kit": ">=2.3,<2.4-dev",
         "symfony/css-selector": ">=2.3,<2.4-dev",
         "symfony/dom-crawler": ">=2.3,<2.4-dev",


### PR DESCRIPTION
Silex has Traits, and encourages usage of 5.4 (inferred by displaying examples of how to use the Traits to extend Silex\Application). It would make sense for 5.4 to be suggested, as this is advisory only but would provide the developer with more features from the framework if they do.
