### PR TITLE
Added Teapot status codes to improve verbosity

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,8 @@
         "symfony/event-dispatcher": ">=2.3,<2.4-dev",
         "symfony/http-foundation": ">=2.3,<2.4-dev",
         "symfony/http-kernel": ">=2.3,<2.4-dev",
-        "symfony/routing": ">=2.3,<2.4-dev"
+        "symfony/routing": ">=2.3,<2.4-dev",
+        "teapot/status": ">=1.0"
     },
     "require-dev": {
         "symfony/security": ">=2.3,<2.4-dev",

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -33,6 +33,7 @@ use Silex\EventListener\LocaleListener;
 use Silex\EventListener\MiddlewareListener;
 use Silex\EventListener\ConverterListener;
 use Silex\EventListener\StringToResponseListener;
+use Teapot\HttpResponse\Status\StatusCode;
 
 /**
  * The Silex framework class.
@@ -377,7 +378,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      *
      * @return RedirectResponse
      */
-    public function redirect($url, $status = 302)
+    public function redirect($url, $status = StatusCode::FOUND)
     {
         return new RedirectResponse($url, $status);
     }
@@ -391,7 +392,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      *
      * @return StreamedResponse
      */
-    public function stream($callback = null, $status = 200, $headers = array())
+    public function stream($callback = null, $status = StatusCode::OK, $headers = array())
     {
         return new StreamedResponse($callback, $status, $headers);
     }
@@ -420,7 +421,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      *
      * @return JsonResponse
      */
-    public function json($data = array(), $status = 200, $headers = array())
+    public function json($data = array(), $status = StatusCode::OK, $headers = array())
     {
         return new JsonResponse($data, $status, $headers);
     }
@@ -437,7 +438,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      *
      * @throws \RuntimeException When the feature is not supported, before http-foundation v2.2
      */
-    public function sendFile($file, $status = 200, $headers = array(), $contentDisposition = null)
+    public function sendFile($file, $status = StatusCode::OK, $headers = array(), $contentDisposition = null)
     {
         return new BinaryFileResponse($file, $status, $headers, true, $contentDisposition);
     }

--- a/src/Silex/ExceptionListenerWrapper.php
+++ b/src/Silex/ExceptionListenerWrapper.php
@@ -17,6 +17,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
 use Silex\Application;
+use Teapot\HttpResponse\Status\StatusCode;
 
 /**
  * Wraps exception listeners.
@@ -47,7 +48,7 @@ class ExceptionListenerWrapper
             return;
         }
 
-        $code = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
+        $code = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : StatusCode::INTERNAL_SERVER_ERROR;
 
         $response = call_user_func($this->callback, $exception, $code);
 

--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Bridge\Monolog\Handler\DebugHandler;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
-
+use Teapot\HttpResponse\Status\StatusCode;
 /**
  * Monolog Provider.
  *
@@ -72,7 +72,7 @@ class MonologServiceProvider implements ServiceProviderInterface
 
         $app->error(function (\Exception $e) use ($app) {
             $message = sprintf('%s: %s (uncaught exception) at %s line %s', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
-            if ($e instanceof HttpExceptionInterface && $e->getStatusCode() < 500) {
+            if ($e instanceof HttpExceptionInterface && $e->getStatusCode() < StatusCode::INTERNAL_SERVER_ERROR) {
                 $app['monolog']->addError($message, array('exception' => $e));
             } else {
                 $app['monolog']->addCritical($message, array('exception' => $e));

--- a/src/Silex/RedirectableUrlMatcher.php
+++ b/src/Silex/RedirectableUrlMatcher.php
@@ -14,6 +14,7 @@ namespace Silex;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\Routing\Matcher\RedirectableUrlMatcher as BaseRedirectableUrlMatcher;
 use Symfony\Component\Routing\Matcher\RedirectableUrlMatcherInterface;
+use Teapot\HttpResponse\Status\StatusCode;
 
 /**
  * Implements the RedirectableUrlMatcherInterface for Silex.
@@ -48,7 +49,7 @@ class RedirectableUrlMatcher extends BaseRedirectableUrlMatcher
         }
 
         return array(
-            '_controller' => function ($url) { return new RedirectResponse($url, 301); },
+            '_controller' => function ($url) { return new RedirectResponse($url, StatusCode::MOVED_PERMANENTLY); },
             'url' => $url,
         );
     }

--- a/tests/Silex/Tests/Application/TwigTraitTest.php
+++ b/tests/Silex/Tests/Application/TwigTraitTest.php
@@ -15,7 +15,7 @@ use Silex\Application;
 use Silex\Provider\TwigServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
-
+use Teapot\HttpResponse\Status\StatusCode;
 /**
  * TwigTrait test cases.
  *
@@ -44,8 +44,8 @@ class TwigTraitTest extends \PHPUnit_Framework_TestCase
         $app['twig'] = $mailer = $this->getMockBuilder('Twig_Environment')->disableOriginalConstructor()->getMock();
         $mailer->expects($this->once())->method('render')->will($this->returnValue('foo'));
 
-        $response = $app->render('view', array(), new Response('', 404));
-        $this->assertEquals(404, $response->getStatusCode());
+        $response = $app->render('view', array(), new Response('', StatusCode::NOT_FOUND));
+        $this->assertEquals(StatusCode::NOT_FOUND, $response->getStatusCode());
     }
 
     public function testRenderForStream()

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -22,6 +22,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\EventDispatcher\Event;
+use Teapot\HttpResponse\Status\StatusCode;
 
 /**
  * Application test cases.
@@ -141,10 +142,10 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $app = new Application();
 
         try {
-            $app->abort(404);
+            $app->abort(StatusCode::NOT_FOUND);
             $this->fail();
         } catch (HttpException $e) {
-            $this->assertEquals(404, $e->getStatusCode());
+            $this->assertEquals(StatusCode::NOT_FOUND, $e->getStatusCode());
         }
     }
 

--- a/tests/Silex/Tests/ExceptionHandlerTest.php
+++ b/tests/Silex/Tests/ExceptionHandlerTest.php
@@ -16,7 +16,7 @@ use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-
+use Teapot\HttpResponse\Status\StatusCode;
 /**
  * Error handler test cases.
  *
@@ -36,7 +36,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo');
         $response = $app->handle($request);
         $this->assertContains('<h1>Whoops, looks like something went wrong.</h1>', $response->getContent());
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals(StatusCode::INTERNAL_SERVER_ERROR, $response->getStatusCode());
     }
 
     public function testExceptionHandlerExceptionDebug()
@@ -52,7 +52,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         $response = $app->handle($request);
 
         $this->assertContains('foo exception', $response->getContent());
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals(StatusCode::INTERNAL_SERVER_ERROR, $response->getStatusCode());
     }
 
     public function testExceptionHandlerNotFoundNoDebug()
@@ -63,7 +63,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo');
         $response = $app->handle($request);
         $this->assertContains('<h1>Sorry, the page you are looking for could not be found.</h1>', $response->getContent());
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(StatusCode::NOT_FOUND, $response->getStatusCode());
     }
 
     public function testExceptionHandlerNotFoundDebug()
@@ -74,7 +74,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo');
         $response = $app->handle($request);
         $this->assertContains('No route found for "GET /foo"', $response->getContent());
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(StatusCode::NOT_FOUND, $response->getStatusCode());
     }
 
     public function testExceptionHandlerMethodNotAllowedNoDebug()
@@ -87,7 +87,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo', 'POST');
         $response = $app->handle($request);
         $this->assertContains('<h1>Whoops, looks like something went wrong.</h1>', $response->getContent());
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertEquals(StatusCode::METHOD_NOT_ALLOWED, $response->getStatusCode());
         $this->assertEquals('GET', $response->headers->get('Allow'));
     }
 
@@ -101,7 +101,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo', 'POST');
         $response = $app->handle($request);
         $this->assertContains('No route found for "POST /foo": Method Not Allowed (Allow: GET)', $response->getContent());
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertEquals(StatusCode::METHOD_NOT_ALLOWED, $response->getStatusCode());
         $this->assertEquals('GET', $response->headers->get('Allow'));
     }
 
@@ -142,13 +142,13 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         });
 
         $response = $this->checkRouteResponse($app, '/500', 'foo exception handler');
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals(StatusCode::INTERNAL_SERVER_ERROR, $response->getStatusCode());
 
         $response = $app->handle(Request::create('/404'));
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(StatusCode::NOT_FOUND, $response->getStatusCode());
 
         $response = $app->handle(Request::create('/405', 'POST'));
-        $this->assertEquals(405, $response->getStatusCode());
+        $this->assertEquals(StatusCode::METHOD_NOT_ALLOWED, $response->getStatusCode());
         $this->assertEquals('GET', $response->headers->get('Allow'));
     }
 
@@ -283,13 +283,13 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
         });
 
         $app->error(function (\Exception $e) {
-            return new Response("Exception thrown", 500);
+            return new Response("Exception thrown", StatusCode::INTERNAL_SERVER_ERROR);
         });
 
         $request = Request::create('/foo');
         $response = $app->handle($request);
         $this->assertContains('Exception thrown', $response->getContent());
-        $this->assertEquals(500, $response->getStatusCode());
+        $this->assertEquals(StatusCode::INTERNAL_SERVER_ERROR, $response->getStatusCode());
     }
 
     public function testExceptionHandlerWithStandardException()

--- a/tests/Silex/Tests/MiddlewareTest.php
+++ b/tests/Silex/Tests/MiddlewareTest.php
@@ -15,6 +15,7 @@ use Silex\Application;
 
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Teapot\HttpResponse\Status\StatusCode;
 
 /**
  * Middleware test cases.
@@ -185,7 +186,7 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $app->before(function () { throw new \RuntimeException(''); });
 
         // even if the before filter throws an exception, we must have the 404
-        $this->assertEquals(404, $app->handle(Request::create('/'))->getStatusCode());
+        $this->assertEquals(StatusCode::NOT_FOUND, $app->handle(Request::create('/'))->getStatusCode());
     }
 
     public function testRequestShouldBePopulatedOnBefore()

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
@@ -18,6 +18,7 @@ use Silex\Provider\SessionServiceProvider;
 use Silex\Provider\ValidatorServiceProvider;
 use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\HttpFoundation\Request;
+use Teapot\HttpResponse\Status\StatusCode;
 
 /**
  * SecurityServiceProvider
@@ -67,23 +68,23 @@ class SecurityServiceProviderTest extends WebTestCase
         $client->request('get', '/');
         $this->assertEquals('fabienAUTHENTICATED', $client->getResponse()->getContent());
         $client->request('get', '/admin');
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertEquals(StatusCode::FORBIDDEN, $client->getResponse()->getStatusCode());
 
         $client->request('get', '/logout');
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertEquals(StatusCode::FOUND, $client->getResponse()->getStatusCode());
         $this->assertEquals('http://localhost/', $client->getResponse()->getTargetUrl());
 
         $client->request('get', '/');
         $this->assertEquals('ANONYMOUS', $client->getResponse()->getContent());
 
         $client->request('get', '/admin');
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertEquals(StatusCode::FOUND, $client->getResponse()->getStatusCode());
         $this->assertEquals('http://localhost/login', $client->getResponse()->getTargetUrl());
 
         $client->request('post', '/login_check', array('_username' => 'admin', '_password' => 'foo'));
         $this->assertEquals('', $app['security.last_error']($client->getRequest()));
         $client->getRequest()->getSession()->save();
-        $this->assertEquals(302, $client->getResponse()->getStatusCode());
+        $this->assertEquals(StatusCode::FOUND, $client->getResponse()->getStatusCode());
         $this->assertEquals('http://localhost/admin', $client->getResponse()->getTargetUrl());
 
         $client->request('get', '/');
@@ -99,18 +100,18 @@ class SecurityServiceProviderTest extends WebTestCase
         $client = new Client($app);
 
         $client->request('get', '/');
-        $this->assertEquals(401, $client->getResponse()->getStatusCode());
+        $this->assertEquals(StatusCode::UNAUTHORIZED, $client->getResponse()->getStatusCode());
         $this->assertEquals('Basic realm="Secured"', $client->getResponse()->headers->get('www-authenticate'));
 
         $client->request('get', '/', array(), array(), array('PHP_AUTH_USER' => 'dennis', 'PHP_AUTH_PW' => 'foo'));
         $this->assertEquals('dennisAUTHENTICATED', $client->getResponse()->getContent());
         $client->request('get', '/admin');
-        $this->assertEquals(403, $client->getResponse()->getStatusCode());
+        $this->assertEquals(StatusCode::FORBIDDEN, $client->getResponse()->getStatusCode());
 
         $client->restart();
 
         $client->request('get', '/');
-        $this->assertEquals(401, $client->getResponse()->getStatusCode());
+        $this->assertEquals(StatusCode::UNAUTHORIZED, $client->getResponse()->getStatusCode());
         $this->assertEquals('Basic realm="Secured"', $client->getResponse()->headers->get('www-authenticate'));
 
         $client->request('get', '/', array(), array(), array('PHP_AUTH_USER' => 'admin', 'PHP_AUTH_PW' => 'foo'));

--- a/tests/Silex/Tests/Route/SecurityTraitTest.php
+++ b/tests/Silex/Tests/Route/SecurityTraitTest.php
@@ -14,6 +14,7 @@ namespace Silex\Tests\Route;
 use Silex\Application;
 use Silex\Provider\SecurityServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
+use Teapot\HttpResponse\Status\StatusCode;
 
 /**
  * SecurityTrait test cases.
@@ -45,12 +46,12 @@ class SecurityTraitTest extends \PHPUnit_Framework_TestCase
 
         $request = Request::create('/');
         $response = $app->handle($request);
-        $this->assertEquals(401, $response->getStatusCode());
+        $this->assertEquals(StatusCode::UNAUTHORIZED, $response->getStatusCode());
 
         $request = Request::create('/');
         $request->headers->set('PHP_AUTH_USER', 'fabien');
         $request->headers->set('PHP_AUTH_PW', 'foo');
         $response = $app->handle($request);
-        $this->assertEquals(200, $response->getStatusCode());
+        $this->assertEquals(StatusCode::OK, $response->getStatusCode());
     }
 }

--- a/tests/Silex/Tests/RouterTest.php
+++ b/tests/Silex/Tests/RouterTest.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-
+use Teapot\HttpResponse\Status\StatusCode;
 /**
  * Router test cases.
  *
@@ -51,28 +51,28 @@ class RouterTest extends \PHPUnit_Framework_TestCase
         $app = new Application();
 
         $app->put('/created', function () {
-            return new Response('', 201);
+            return new Response('', StatusCode::CREATED);
         });
 
         $app->match('/forbidden', function () {
-            return new Response('', 403);
+            return new Response('', StatusCode::FORBIDDEN);
         });
 
         $app->match('/not_found', function () {
-            return new Response('', 404);
+            return new Response('', StatusCode::NOT_FOUND);
         });
 
         $request = Request::create('/created', 'put');
         $response = $app->handle($request);
-        $this->assertEquals(201, $response->getStatusCode());
+        $this->assertEquals(StatusCode::CREATED, $response->getStatusCode());
 
         $request = Request::create('/forbidden');
         $response = $app->handle($request);
-        $this->assertEquals(403, $response->getStatusCode());
+        $this->assertEquals(StatusCode::FORBIDDEN, $response->getStatusCode());
 
         $request = Request::create('/not_found');
         $response = $app->handle($request);
-        $this->assertEquals(404, $response->getStatusCode());
+        $this->assertEquals(StatusCode::NOT_FOUND, $response->getStatusCode());
     }
 
     public function testRedirect()


### PR DESCRIPTION
A conceit, not necessary, but hopefully increases verbosity in the code and makes every status code abundantly clear to the user without having to remember them all.
