### PR TITLE
Add note on how to handle fatal errors

### DIFF
--- a/doc/cookbook/error_handler.rst
+++ b/doc/cookbook/error_handler.rst
@@ -29,8 +29,19 @@ You register it by calling the static ``register`` method::
 It is recommended that you do this in your front controller, i.e.
 ``web/index.php``.
 
-.. note::
+Handling fatal errors
+---------------------
 
-    The ``ErrorHandler`` has nothing to do with the ``ExceptionHandler``. The
-    ``ExceptionHandler`` is responsible for displaying caught exceptions
-    nicely.
+To handle fatal errors, you can additionally register a global
+``ExceptionHandler``::
+
+    use Symfony\Component\HttpKernel\Debug\ExceptionHandler;
+
+    ExceptionHandler::register();
+
+In production you may want to disable the debug output by passing ``false`` as
+the ``$debug`` argument::
+
+    use Symfony\Component\HttpKernel\Debug\ExceptionHandler;
+
+    ExceptionHandler::register(false);


### PR DESCRIPTION
I'm not so happy with this solution from a usability perspective, but I don't want to have global error handlers in silex itself.

An option we could consider is making symfony's ErrorHandler fall back to an internal `ExceptionHandler` for fatal errors. But obviously that is not very elegant either. Ideas welcome.
