### PR TITLE
Mounted controllers are staged until application's flush

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -452,15 +452,9 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      */
     public function mount($prefix, $controllers)
     {
-        if ($controllers instanceof ControllerProviderInterface) {
-            $controllers = $controllers->connect($this);
-        }
+        
 
-        if (!$controllers instanceof ControllerCollection) {
-            throw new \LogicException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
-        }
-
-        $this['routes']->addCollection($controllers->flush($prefix));
+        $this['controllers']->mount($prefix, $controllers);
 
         return $this;
     }

--- a/src/Silex/AttachableControllerInterface.php
+++ b/src/Silex/AttachableControllerInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Marcin Chwedziak <marcin@chwedziak.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex;
+
+use Symfony\Component\Routing\RouteCollection;
+
+interface AttachableControllerInterface
+{
+    /**
+     * Attaches given controller to a collection of routes
+     *
+     * @param RouteCollection $routes Collection to which you want to attach the controller
+     * @param string $prefix
+     *
+     * @return AttachableControllerInterface
+     */
+    function attach(RouteCollection $routes, $prefix = '');
+}

--- a/src/Silex/MountController.php
+++ b/src/Silex/MountController.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Marcin Chwedziak <marcin@chwedziak.pl>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex;
+
+use Symfony\Component\Routing\RouteCollection;
+
+class MountController implements AttachableControllerInterface
+{
+    protected $prefix = '';
+    protected $controllers = null;
+
+    public function __construct($prefix, $controllers)
+    {
+        if ($controllers instanceof ControllerProviderInterface) {
+            $controllers = $controllers->connect($this);
+        }
+
+        if (!$controllers instanceof ControllerCollection) {
+            throw new \LogicException('The "MountController" instance constructor takes either a ControllerCollection or a ControllerProviderInterface instance.');
+        }
+
+        $this->prefix = $prefix;
+        $this->controllers = $controllers;
+    }
+
+    public function attach(RouteCollection $routes, $prefix = '')
+    {
+        $routes->addCollection($this->controllers->flush($this->prefix));
+
+        return $this;
+    }
+}

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -488,6 +488,19 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($app, $app->mount('/hello', $mounted));
     }
 
+    public function testMountIsStagedUntilFlush()
+    {
+        $app = new Application();
+        $mounted = new ControllerCollection(new Route());
+        $mounted->get('/{name}', function($name) { return new Response($name); });
+
+        $app->mount('/', $mounted);
+        $this->assertCount(0, $app['routes']->all());
+
+        $app->flush();
+        $this->assertCount(1, $app['routes']->all());
+    }
+
     public function testSendFile()
     {
         $app = new Application();


### PR DESCRIPTION
Probably a better solution for #716 than the one proposed in #734. License is MIT of course.

This PR changed the way the mount works. All mounted controllers get staged (under `MountController` instance) until you call `flush()` on the application. This way, the order in which you add routes is always known to the user.

I didn't want to use `if...else` in `flush()` so I decided to introduce a new interface and move attach logic from ControllerCollection to Controller.

I am not sure if this is the right direction so please give me the feedback.

There is a test case to check if staging works fine.
