### PR TITLE
Fixed namespace issue with docblock defined functions

### DIFF
--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -19,14 +19,14 @@ use Silex\Exception\ControllerFrozenException;
  * __call() forwards method-calls to Route, but returns instance of Controller
  * listing Route's methods below, so that IDEs know they are valid
  *
- * @method \Silex\Controller assert(string $variable, string $regexp)
- * @method \Silex\Controller value(string $variable, mixed $default)
- * @method \Silex\Controller convert(string $variable, mixed $callback)
- * @method \Silex\Controller method(string $method)
+ * @method \Silex\Controller assert(\string $variable, \string $regexp)
+ * @method \Silex\Controller value(\string $variable, \mixed $default)
+ * @method \Silex\Controller convert(\string $variable, \mixed $callback)
+ * @method \Silex\Controller method(\string $method)
  * @method \Silex\Controller requireHttp()
  * @method \Silex\Controller requireHttps()
- * @method \Silex\Controller before(mixed $callback)
- * @method \Silex\Controller after(mixed $callback)
+ * @method \Silex\Controller before(\mixed $callback)
+ * @method \Silex\Controller after(\mixed $callback)
  * @author Igor Wiedler <igor@wiedler.ch>
  */
 class Controller


### PR DESCRIPTION
My IDE was expecting Silex\string instead of regular string. I'm assuming this is because the file has a namespace declaration for Silex and it prepends that. Cannot verify if this is the case for all IDE's however.
