### PR TITLE
New feature: You can have multiple template providers each one with it's own configuration 

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -42,7 +42,7 @@ class TwigServiceProvider implements ServiceProviderInterface
         $app[$providerName.'.path'] = array();
         $app[$providerName.'.templates'] = array();
 
-        $app[$providerName] = $app->share(function ($app ) use ( $providerName ) {
+        $app[$providerName] = $app->share(function ($app) use ($providerName) {
             $app[$providerName.'.options'] = array_replace(
                 array(
                      'charset'          => $app['charset'],


### PR DESCRIPTION
Now you can specify a name for the service being registered, instead to be forced to use the default 'twig'

$app->register( new TwigServiceProvider('myTwig'), array( myTwigInstanceConfig );

You can found more info why it is useful at :
https://github.com/colegatron/SilexMultipleTwigServiceRepository
