### PR TITLE
Remove usage of deprecated function

### DIFF
--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -50,7 +50,7 @@ class ControllerCollection
     public function match($pattern, $to)
     {
         $route = clone $this->defaultRoute;
-        $route->setPattern($pattern);
+        $route->setPath($pattern);
         $route->setDefault('_controller', $to);
 
         $this->controllers[] = $controller = new Controller($route);


### PR DESCRIPTION
Remove usage of deprecated function setPattern() and replace with replacement function setPath().

I was not sure if we also want to rename the variables/arguments $pattern to $path inside silex. For now i haven't touched them.
