### PR TITLE
Make clear that twig-bridge is required to use path and url in Twig

### DIFF
--- a/doc/providers/url_generator.rst
+++ b/doc/providers/url_generator.rst
@@ -54,7 +54,7 @@ When using Twig, the service can be used like this:
 
     {{ app.url_generator.generate('homepage') }}
 
-Moreover, if you use Twig, you will have access to the ``path()`` and
+Moreover, if you have ``twig-bridge`` in your ``composer.json``, you will have access to the ``path()`` and
 ``url()`` functions:
 
 .. code-block:: jinja


### PR DESCRIPTION
Not sure what the best way is to make this explicit, but twig-bridge is required to use path() and url() in Twig. Just having Twig alone is not enough.
