### PR TITLE
Fix code completion in phpStorm

### DIFF
--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -19,14 +19,14 @@ use Silex\Exception\ControllerFrozenException;
  * __call() forwards method-calls to Route, but returns instance of Controller
  * listing Route's methods below, so that IDEs know they are valid
  *
- * @method \Silex\Controller assert(string $variable, string $regexp)
- * @method \Silex\Controller value(string $variable, mixed $default)
- * @method \Silex\Controller convert(string $variable, mixed $callback)
- * @method \Silex\Controller method(string $method)
+ * @method \Silex\Controller assert(\string $variable, \string $regexp)
+ * @method \Silex\Controller value(\string $variable, \mixed $default)
+ * @method \Silex\Controller convert(\string $variable, \mixed $callback)
+ * @method \Silex\Controller method(\string $method)
  * @method \Silex\Controller requireHttp()
  * @method \Silex\Controller requireHttps()
- * @method \Silex\Controller before(mixed $callback)
- * @method \Silex\Controller after(mixed $callback)
+ * @method \Silex\Controller before(\mixed $callback)
+ * @method \Silex\Controller after(\mixed $callback)
  * @author Igor Wiedler <igor@wiedler.ch>
  */
 class Controller


### PR DESCRIPTION
I'm not sure how other editors handle the @method phpDoc, but phpStorm parses namespace + type which for the controller ends up in "\Silex\string" and "\Silex\mixed". Prepending a backslash fixes that.

Can somebody test if the fix works(at least not harm) in other IDEs?
