### PR TITLE
[Security] Make fake routes dumpable by setting NULL as controller

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -541,7 +541,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
         foreach ($this->fakeRoutes as $route) {
             list($method, $pattern, $name) = $route;
 
-            $app->$method($pattern, function() {})->bind($name);
+            $app->$method($pattern, null)->bind($name);
         }
     }
 


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #774 |
| License | MIT |

By setting `NULL` as controller, the route will end in 404 if it's not bypassed by a security listener.
