### PR TITLE
Bad doc link : correction of the link to the documentation

### DIFF
--- a/src/Silex/ServiceControllerResolver.php
+++ b/src/Silex/ServiceControllerResolver.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 /**
  * Enables name_of_service:method_name syntax for declaring controllers.
  *
- * @link http://silex.sensiolabs.org/doc/cookbook/controllers_as_services.html
+ * @link http://silex.sensiolabs.org/doc/providers/service_controller.html
  */
 class ServiceControllerResolver implements ControllerResolverInterface
 {


### PR DESCRIPTION
The link to the doc was wrong (404), fixed.
