### PR TITLE
Allowing Traversable objects as Application and Provider configurations

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -57,9 +57,14 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      *
      * @param array $values The parameters or objects.
      */
-    public function __construct(array $values = array())
+    public function __construct($values = array())
     {
         parent::__construct();
+
+        if (!$this->isTraversable($values)) {
+            $message = 'The configuration value passed to %s must be traversable';
+            throw new \InvalidArgumentException(\sprintf($message, __METHOD__));
+        }
 
         $app = $this;
 
@@ -160,8 +165,13 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      *
      * @return Application
      */
-    public function register(ServiceProviderInterface $provider, array $values = array())
+    public function register(ServiceProviderInterface $provider, $values = array())
     {
+        if (!$this->isTraversable($values)) {
+            $message = 'The configuration value passed to %s must be traversable';
+            throw new \InvalidArgumentException(\sprintf($message, __METHOD__));
+        }
+
         $this->providers[] = $provider;
 
         $provider->register($this);
@@ -171,6 +181,18 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
         }
 
         return $this;
+    }
+
+    /**
+     * Determines whether or not a value can be supplied to foreach without triggering
+     * a warning.
+     *
+     * @param mixed $var
+     * @return boolean
+     */
+    private function isTraversable($var)
+    {
+        return (\is_array($var) || $var instanceof \Traversable || $var instanceof \stdClass);
     }
 
     /**

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -515,6 +515,56 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $response = $app->handle(Request::create('/foo'));
         $this->assertEquals(301, $response->getStatusCode());
     }
+
+    public function testPassingConfigObjectToApplicationConstructor()
+    {
+        $config = new \ArrayObject();
+        $config['foo'] = 'bar';
+        $config['bar'] = 'foo';
+
+        $app = new Application($config);
+
+        $this->assertSame('bar', $app['foo']);
+        $this->assertsame('foo', $app['bar']);
+    }
+
+    public function testRegisteringServiceProviderConfigWithTraversableObject()
+    {
+        $app = new Application();
+
+        $config = new \ArrayObject();
+        $config['foo'] = 'bar';
+        $config['bar'] = 'foo';
+
+        $provider = $this->getMock('\\Silex\\ServiceProviderInterface');
+
+        $app->register($provider, $config);
+
+        $this->assertSame('bar', $app['foo']);
+        $this->assertSame('foo', $app['bar']);
+    }
+
+    public function testPassingConfigToConstructorNotTraversableThrowsException()
+    {
+        $config = 'i trigger a foreach warning';
+
+        $message = 'The configuration value passed to Silex\\Application::__construct must be traversable';
+        $this->setExpectedException('\\InvalidArgumentException', $message);
+        $app = new Application($config);
+    }
+
+    public function testPassingConfigToRegisterProviderNotTraversableThrowsException()
+    {
+        $config = 'i trigger a foreach warning';
+        $provider = $this->getMock('\\Silex\\ServiceProviderInterface');
+
+        $app = new Application();
+
+        $message = 'The configuration value passed to Silex\\Application::register must be traversable';
+        $this->setExpectedException('\\InvalidArgumentException', $message);
+        $app->register($provider, $config);
+    }
+
 }
 
 class FooController


### PR DESCRIPTION
## Overview

This pull request lifts the restrictions on arrays being passed as configuration values to `Application::__construct()` and `Application::register()` In its place we check for whether or not the value passed can be iterated over with foreach without causing a warning. If the configuration value is not traversable (see new private method below) an `InvalidArgumentException` is thrown stating that a traversable value must be passed to the appropriate method.
### Use Cases

The primary use case for this would be utilizing an immutable object as a configuration store.
### Added Methods

`Application::isTraversable($var)` is a private method that determines whether or not the value can be iterated over by checking if the value is (1) an array OR (2) it is of type Traversable OR (3) it is of type stdClass.

---

As far as I can tell this introduces no backwards compatibility breaks.

Let me know if I need to add some test cases for the check for stdClass or if there's something else I can do to get this merged in.

Thanks for creating a project that's easy to contribute to.
`
`
