### PR TITLE
Use $app['translator']->getLocale(); instead of $app['locale']

### DIFF
--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -65,7 +65,8 @@ class FormServiceProvider implements ServiceProviderInterface
 
                 if (isset($app['translator'])) {
                     $r = new \ReflectionClass('Symfony\Component\Form\Form');
-                    $app['translator']->addResource('xliff', dirname($r->getFilename()).'/Resources/translations/validators.'.$app['locale'].'.xlf', $app['locale'], 'validators');
+                    $locale = $app['translator']->getLocale();
+                    $app['translator']->addResource('xliff', dirname($r->getFilename()).'/Resources/translations/validators.'.$locale.'.xlf', $locale, 'validators');
                 }
             }
 


### PR DESCRIPTION
If you change the locale value in a 'before' middleware:

$app['translator']->setLocale('es');

The $app['locale'] is not updated and the locale keeps the old value.

Using $app['translator']->getLocale() fixes the issue.
