### PR TITLE
Enabled setting of $app['session.test']

### DIFF
--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -37,7 +37,7 @@ class SessionServiceProvider implements ServiceProviderInterface
     {
         $this->app = $app;
 
-        $app['session.test'] = false;
+        $app['session.test'] = (isset($app['session.test'])?$app['session.test']:false);
 
         $app['session'] = $app->share(function ($app) {
             if (!isset($app['session.storage'])) {


### PR DESCRIPTION
$app['session.test'] was hard coded to false and prevented ability to run provider in test mode.
