### PR TITLE
Possibility to change forms layout path

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -33,6 +33,11 @@ class TwigServiceProvider implements ServiceProviderInterface
     {
         $app['twig.options'] = array();
         $app['twig.form.templates'] = array('form_div_layout.html.twig');
+        $app['twig.form.templates.paths'] = $app->share(function ($app) {
+            // add loader for Symfony built-in form templates
+            $reflected = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
+            return array(dirname($reflected->getFileName()).'/../Resources/views/Form');
+        });
         $app['twig.path'] = array();
         $app['twig.templates'] = array();
 
@@ -85,10 +90,7 @@ class TwigServiceProvider implements ServiceProviderInterface
 
                     $twig->addExtension(new FormExtension($app['twig.form.renderer']));
 
-                    // add loader for Symfony built-in form templates
-                    $reflected = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');
-                    $path = dirname($reflected->getFileName()).'/../Resources/views/Form';
-                    $app['twig.loader']->addLoader(new \Twig_Loader_Filesystem($path));
+                    $app['twig.loader']->addLoader(new \Twig_Loader_Filesystem($app['twig.form.templates.paths']));
                 }
             }
 


### PR DESCRIPTION
Currently I found no nice way to have my own form layout files.
Of course I can overwrite the form-blocks inside of templates, but that was not satisfying for our use case. We wanted to overwrite a form-block for the whole application.

This change allows to specify an additional path for the form layout, or if someone really wants overwrite the default symfony resource folder and use their own layout path.

An other way would have been to register an additional Twig_Loader_Filesystem for my path, but in my opinion this change is more elegant and does not require an additional loader.

No BC breaks.
