### PR TITLE
Fixed MD

### DIFF
--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -19,10 +19,10 @@ use Silex\Exception\ControllerFrozenException;
  * __call() forwards method-calls to Route, but returns instance of Controller
  * listing Route's methods below, so that IDEs know they are valid
  *
- * @method \Silex\Controller assert(string $variable, string $regexp)
- * @method \Silex\Controller value(string $variable, mixed $default)
- * @method \Silex\Controller convert(string $variable, mixed $callback)
- * @method \Silex\Controller method(string $method)
+ * @method \Silex\Controller assert(\string $variable, \string $regexp)
+ * @method \Silex\Controller value(\string $variable, mixed $default)
+ * @method \Silex\Controller convert(\string $variable, mixed $callback)
+ * @method \Silex\Controller method(\string $method)
  * @method \Silex\Controller requireHttp()
  * @method \Silex\Controller requireHttps()
  * @method \Silex\Controller before(mixed $callback)


### PR DESCRIPTION
```
Parameter [...] type is not compatible with declaration
Expected Silex\string, got string
```

I'm getting this from Mess Detector for following code (for `method()`):

```
/** @var $api ControllerCollection */
$api = $app['controllers_factory'];
$api
    ->match($route['path'], sprintf("%sController:%sAction", $controllerName, $route['action']))
    ->method(!empty($route['method']) ? $route['method'] : 'GET');
```
