### PR TITLE
fixed order of route registration for mounted controllers

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (2013-XX-XX)
 ------------------
 
+* [BC BREAK] Routes are now always added in the order of their registration (even for mounted routes)
 * Added run() on Route to be able to define the controller code
 * Deprecated TwigCoreExtension (register the new HttpFragmentServiceProvider instead)
 * Added HttpFragmentServiceProvider

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -473,7 +473,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
             throw new \LogicException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
         }
 
-        $this['routes']->addCollection($controllers->flush($prefix));
+        $this['controllers']->mount($prefix, $controllers);
 
         return $this;
     }

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -489,6 +489,20 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($app, $app->mount('/hello', $mounted));
     }
 
+    public function testMountPreservesOrder()
+    {
+        $app = new Application();
+        $mounted = new ControllerCollection(new Route());
+        $mounted->get('/mounted')->bind('second');
+
+        $app->get('/before')->bind('first');
+        $app->mount('/', $mounted);
+        $app->get('/after')->bind('third');
+        $app->flush();
+
+        $this->assertEquals(array('first', 'second', 'third'), array_keys(iterator_to_array($app['routes'])));
+    }
+
     public function testSendFile()
     {
         $app = new Application();


### PR DESCRIPTION
simpler alternative for #736 in order to fix #716
