### PR TITLE
fixed converters

### DIFF
--- a/src/Silex/EventListener/ConverterListener.php
+++ b/src/Silex/EventListener/ConverterListener.php
@@ -48,8 +48,9 @@ class ConverterListener implements EventSubscriberInterface
         $request = $event->getRequest();
         $route = $this->routes->get($request->attributes->get('_route'));
         if ($route && $converters = $route->getOption('_converters')) {
+            $parameters = $this->getControllerArgumentNames($event->getController());
             foreach ($converters as $name => $callback) {
-                if ($request->attributes->has($name)) {
+                if (isset($parameters[$name])) {
                     $callback = $this->callbackResolver->isValid($callback) ? $this->callbackResolver->getCallback($callback) : $callback;
                     $request->attributes->set($name, call_user_func($callback, $request->attributes->get($name), $request));
                 }
@@ -62,5 +63,24 @@ class ConverterListener implements EventSubscriberInterface
         return array(
             KernelEvents::CONTROLLER => 'onKernelController',
         );
+    }
+
+    private function getControllerArgumentNames($controller)
+    {
+        if (is_array($controller)) {
+            $r = new \ReflectionMethod($controller[0], $controller[1]);
+        } elseif (is_object($controller) && !$controller instanceof \Closure) {
+            $r = new \ReflectionObject($controller);
+            $r = $r->getMethod('__invoke');
+        } else {
+            $r = new \ReflectionFunction($controller);
+        }
+
+        $names = array();
+        foreach ($r->getParameters() as $parameter) {
+            $names[$parameter->getName()] = true;
+        }
+
+        return $names;
     }
 }

--- a/tests/Silex/Tests/ConverterTest.php
+++ b/tests/Silex/Tests/ConverterTest.php
@@ -21,20 +21,26 @@ use Symfony\Component\HttpFoundation\Request;
  */
 class ConverterTest extends \PHPUnit_Framework_TestCase
 {
-    public function testConvertingNonExistentAttributeShouldNotCallConverter()
+    public function test()
     {
-        $called = false;
-        $converter = function () use (&$called) {
-            $called = true;
-        };
+        $called = array();
+        $globalFooConverter = function () use (&$called) { $called[] = 'global_foo'; };
+        $globalBarConverter = function () use (&$called) { $called[] = 'global_bar'; };
+        $fooConverter = function () use (&$called) { $called[] = 'foo'; };
+        $barConverter = function () use (&$called) { $called[] = 'bar'; };
 
         $app = new Application();
-        $app->get('/', function () { return 'hallo'; });
-        $app['controllers']->convert('foo', $converter);
+        $app
+            ->get('/', function ($foo, $globalBar) { return 'hallo'; })
+            ->convert('foo', $fooConverter)
+            ->convert('bar', $barConverter)
+        ;
+        $app['controllers']->convert('globalFoo', $globalFooConverter);
+        $app['controllers']->convert('globalBar', $globalBarConverter);
 
         $request = Request::create('/');
         $app->handle($request);
 
-        $this->assertFalse($called);
+        $this->assertEquals(array('foo', 'global_bar'), $called);
     }
 }


### PR DESCRIPTION
In #769, the converters applied to a controller are only applied if the name is part of the route placeholders. It was done to avoid executing converters on all controllers when applied to a controller collection.

That breaks BC (see #806) as the usual use case is now broken.

Instead of reverting #769, I propose to only execute converters when the converter name is an argument of the controller itself. That solves both problem: you can have global converters that are only applied when there is a matching argument in the controller, and you are not forced to use an existing route placeholder name for the controller argument name.
