### PR TITLE
fixed translator locale management

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 1.1.3 (2013-XX-XX)
 ------------------
 
-* n/a
+* Fixed translator locale management
 
 1.1.2 (2013-10-30)
 ------------------

--- a/src/Silex/Provider/TranslationServiceProvider.php
+++ b/src/Silex/Provider/TranslationServiceProvider.php
@@ -13,8 +13,7 @@ namespace Silex\Provider;
 
 use Silex\Application;
 use Silex\ServiceProviderInterface;
-
-use Symfony\Component\Translation\Translator;
+use Silex\Translator;
 use Symfony\Component\Translation\MessageSelector;
 use Symfony\Component\Translation\Loader\ArrayLoader;
 use Symfony\Component\Translation\Loader\XliffFileLoader;
@@ -29,7 +28,7 @@ class TranslationServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['translator'] = $app->share(function ($app) {
-            $translator = new Translator($app['locale'], $app['translator.message_selector']);
+            $translator = new Translator($app, $app['translator.message_selector']);
 
             // Handle deprecated 'locale_fallback'
             if (isset($app['locale_fallback'])) {

--- a/src/Silex/Translator.php
+++ b/src/Silex/Translator.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex;
+
+use Symfony\Component\Translation\Translator as BaseTranslator;
+use Symfony\Component\Translation\MessageSelector;
+
+/**
+ * Translator that gets the current locale from the Silex application.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class Translator extends BaseTranslator
+{
+    protected $app;
+
+    public function __construct(Application $app, MessageSelector $selector)
+    {
+        $this->app = $app;
+
+        parent::__construct(null, $selector);
+    }
+
+    public function getLocale()
+    {
+        return $this->app['locale'];
+    }
+}

--- a/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
@@ -125,4 +125,15 @@ class TranslationServiceProviderTest extends \PHPUnit_Framework_TestCase
         $result = $app['translator']->trans('key1', array(), null, 'ru');
         $this->assertEquals('The german translation', $result);
     }
+
+    public function testChangingLocale()
+    {
+        $app = $this->getPreparedApp();
+
+        $this->assertEquals('The translation', $app['translator']->trans('key1'));
+
+        $app['locale'] = 'de';
+
+        $this->assertEquals('The german translation', $app['translator']->trans('key1'));
+    }
 }


### PR DESCRIPTION
The locale used by the translator was set the first time the translator was instantiated. That's a problem for several reasons:
- changing the locale via `$app['locale']` would not change the locale used by the translator;
- when using fragments, the locale was not updated correctly;
- also, when using the web profiler, the translator is created early on (before the handling of a request), and so the locale was always `en` (see silexphp/Silex-WebProfiler#23).
