### PR TITLE
restricted the HTTP fragment service provider to Symfony 2.4+

### DIFF
--- a/src/Silex/Provider/HttpFragmentServiceProvider.php
+++ b/src/Silex/Provider/HttpFragmentServiceProvider.php
@@ -23,21 +23,20 @@ use Symfony\Component\HttpKernel\UriSigner;
 /**
  * HttpKernel Fragment integration for Silex.
  *
+ * This service provider requires Symfony 2.4+.
+ *
  * @author Fabien Potencier <fabien@symfony.com>
  */
 class HttpFragmentServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
+        if (!class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            throw new \LogicException('The HTTP Fragment service provider only works with Symfony 2.4+.');
+        }
+
         $app['fragment.handler'] = $app->share(function ($app) {
-            $handler = new FragmentHandler($app['fragment.renderers'], $app['debug'], $app['request_stack']);
-
-            // to be removed when 2.3 is not supported anymore
-            if (null === $app['request_stack']) {
-                $handler->setRequest($app['request']);
-            }
-
-            return $handler;
+            return new FragmentHandler($app['fragment.renderers'], $app['debug'], $app['request_stack']);
         });
 
         $app['fragment.renderer.inline'] = $app->share(function ($app) {

--- a/tests/Silex/Tests/Provider/HttpFragmentServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/HttpFragmentServiceProviderTest.php
@@ -21,6 +21,10 @@ class HttpFragmentServiceProviderTest extends \PHPUnit_Framework_TestCase
 {
     public function testRenderFunction()
     {
+        if (!class_exists('Symfony\Component\HttpFoundation\RequestStack')) {
+            $this->markTestSkipped('HttpFragmentServiceProvider is not available on Symfony <2.4');
+        }
+
         $app = new Application();
 
         $app->register(new HttpFragmentServiceProvider());


### PR DESCRIPTION
The HTTP fragment service provider cannot work on Symfony 2.3+ (see #819)
