### PR TITLE
added Application::subscribe() to register an event subscriber from the app

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,6 +4,7 @@ Changelog
 1.2.0 (2013-XX-XX)
 ------------------
 
+* Added Application::subscribe()
 * Reverted "convert attributes on the request that actually exist"
 * [BC BREAK] Routes are now always added in the order of their registration (even for mounted routes)
 * Added run() on Route to be able to define the controller code

--- a/src/Silex/Provider/HttpCacheServiceProvider.php
+++ b/src/Silex/Provider/HttpCacheServiceProvider.php
@@ -54,6 +54,6 @@ class HttpCacheServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
-        $app['dispatcher']->addSubscriber($app['http_cache.esi_listener']);
+        $app->subscribe($app['http_cache.esi_listener']);
     }
 }

--- a/src/Silex/Provider/HttpFragmentServiceProvider.php
+++ b/src/Silex/Provider/HttpFragmentServiceProvider.php
@@ -84,6 +84,6 @@ class HttpFragmentServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
-        $app['dispatcher']->addSubscriber($app['fragment.listener']);
+        $app->subscribe($app['fragment.listener']);
     }
 }

--- a/src/Silex/Provider/RememberMeServiceProvider.php
+++ b/src/Silex/Provider/RememberMeServiceProvider.php
@@ -99,6 +99,6 @@ class RememberMeServiceProvider implements ServiceProviderInterface
             throw new \LogicException('You must register the SecurityServiceProvider to use the RememberMeServiceProvider');
         }
 
-        $app['dispatcher']->addSubscriber($app['security.remember_me.response_listener']);
+        $app->subscribe($app['security.remember_me.response_listener']);
     }
 }

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -537,7 +537,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
-        $app['dispatcher']->addSubscriber($app['security.firewall']);
+        $app->subscribe($app['security.firewall']);
 
         foreach ($this->fakeRoutes as $route) {
             list($method, $pattern, $name) = $route;

--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -114,11 +114,11 @@ class SessionServiceProvider implements ServiceProviderInterface
 
     public function boot(Application $app)
     {
-        $app['dispatcher']->addListener(KernelEvents::REQUEST, array($this, 'onEarlyKernelRequest'), 128);
+        $app->on(KernelEvents::REQUEST, array($this, 'onEarlyKernelRequest'), 128);
 
         if ($app['session.test']) {
-            $app['dispatcher']->addListener(KernelEvents::REQUEST, array($this, 'onKernelRequest'), 192);
-            $app['dispatcher']->addListener(KernelEvents::RESPONSE, array($this, 'onKernelResponse'), -128);
+            $app->on(KernelEvents::REQUEST, array($this, 'onKernelRequest'), 192);
+            $app->on(KernelEvents::RESPONSE, array($this, 'onKernelResponse'), -128);
         }
     }
 }


### PR DESCRIPTION
This PR purpose is two-fold:
- it makes registering an event subscriber as easy as registering an event listener (`on()` vs `subscribe()`).
- it abstracts the `dispatcher` service in service provider `boot()` method, which is the first step towards decoupling the service providers from Silex (see #352).
