### PR TITLE
[2.0] moved locale management to a locale service provider

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.0 (2013-XX-XX)
 ------------------
 
-* n/a
+* [BC BREAK] Locale management has been moved to LocaleServiceProvider which must be registered
+  if you want Silex to manage your locale (must also be registered for the translation service provider)
 
 1.2.0 (2013-XX-XX)
 ------------------

--- a/doc/providers/locale.rst
+++ b/doc/providers/locale.rst
@@ -1,0 +1,24 @@
+LocaleServiceProvider
+=====================
+
+The *LocaleServiceProvider* manages the locale of an application.
+
+Parameters
+----------
+
+* **locale**: The locale of the user. When set before any request handling, it
+  defines the default locale (``en`` by default). When a request is being
+  handled, it is automatically set according to the ``_locale`` request
+  attribute of the current route.
+
+Services
+--------
+
+* n/a
+
+Registering
+-----------
+
+.. code-block:: php
+
+    $app->register(new Silex\Provider\LocaleServiceProvider());

--- a/doc/providers/translation.rst
+++ b/doc/providers/translation.rst
@@ -37,6 +37,7 @@ Registering
 
 .. code-block:: php
 
+    $app->register(new Silex\Provider\LocaleServiceProvider());
     $app->register(new Silex\Provider\TranslationServiceProvider(), array(
         'locale_fallbacks' => array('en'),
     ));

--- a/doc/services.rst
+++ b/doc/services.rst
@@ -253,11 +253,6 @@ Core parameters
 
   This parameter can be used by the ``UrlGeneratorProvider``.
 
-* **locale** (optional): The locale of the user. When set before any request
-  handling, it defines the default locale (``en`` by default). When a request
-  is being handled, it is automatically set according to the ``_locale``
-  request attribute of the current route.
-
 * **debug** (optional): Returns whether or not the application is running in
   debug mode.
 

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -30,7 +30,6 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
 use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\RequestContext;
-use Silex\EventListener\LocaleListener;
 use Silex\EventListener\MiddlewareListener;
 use Silex\EventListener\ConverterListener;
 use Silex\EventListener\StringToResponseListener;
@@ -94,7 +93,6 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
                 return $app['url_matcher'];
             });
             $dispatcher->addSubscriber(new RouterListener($urlMatcher, $app['request_context'], $app['logger'], $app['request_stack']));
-            $dispatcher->addSubscriber(new LocaleListener($app, $urlMatcher, $app['request_stack']));
             if (isset($app['exception_handler'])) {
                 $dispatcher->addSubscriber($app['exception_handler']);
             }
@@ -149,7 +147,6 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
         $this['request.https_port'] = 443;
         $this['debug'] = false;
         $this['charset'] = 'UTF-8';
-        $this['locale'] = 'en';
 
         foreach ($values as $key => $value) {
             $this[$key] = $value;

--- a/src/Silex/Provider/LocaleServiceProvider.php
+++ b/src/Silex/Provider/LocaleServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Provider;
+
+use Silex\Application;
+use Silex\LazyUrlMatcher;
+use Silex\ServiceProviderInterface;
+use Silex\EventListener\LocaleListener;
+
+/**
+ * Locale Provider.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class LocaleServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        $app['locale.listener'] = $app->share(function ($app) {
+            $urlMatcher = null;
+            if (isset($app['url_matcher'])) {
+                $urlMatcher = new LazyUrlMatcher(function () use ($app) {
+                    return $app['url_matcher'];
+                });
+            }
+
+            return new LocaleListener($app, $urlMatcher, $app['request_stack']);
+        });
+
+        $app['locale'] = 'en';
+    }
+
+    public function boot(Application $app)
+    {
+        $app['dispatcher']->addSubscriber($app['locale.listener']);
+    }
+}

--- a/src/Silex/Provider/TranslationServiceProvider.php
+++ b/src/Silex/Provider/TranslationServiceProvider.php
@@ -28,6 +28,10 @@ class TranslationServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['translator'] = $app->share(function ($app) {
+            if (!isset($app['locale'])) {
+                throw new \LogicException('You must register the LocaleServiceProvider to use the TranslationServiceProvider');
+            }
+
             $translator = new Translator($app, $app['translator.message_selector']);
 
             // Handle deprecated 'locale_fallback'

--- a/tests/Silex/Tests/LocaleTest.php
+++ b/tests/Silex/Tests/LocaleTest.php
@@ -12,6 +12,7 @@
 namespace Silex\Tests;
 
 use Silex\Application;
+use Silex\Provider\LocaleServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -25,17 +26,20 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
     public function testLocale()
     {
         $app = new Application();
+        $app->register(new LocaleServiceProvider());
         $app->get('/', function (Request $request) { return $request->getLocale(); });
         $response = $app->handle(Request::create('/'));
         $this->assertEquals('en', $response->getContent());
 
         $app = new Application();
+        $app->register(new LocaleServiceProvider());
         $app['locale'] = 'fr';
         $app->get('/', function (Request $request) { return $request->getLocale(); });
         $response = $app->handle(Request::create('/'));
         $this->assertEquals('fr', $response->getContent());
 
         $app = new Application();
+        $app->register(new LocaleServiceProvider());
         $app->get('/{_locale}', function (Request $request) { return $request->getLocale(); });
         $response = $app->handle(Request::create('/es'));
         $this->assertEquals('es', $response->getContent());
@@ -44,6 +48,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
     public function testLocaleInSubRequests()
     {
         $app = new Application();
+        $app->register(new LocaleServiceProvider());
         $app->get('/embed/{_locale}', function (Request $request) { return $request->getLocale(); });
         $app->get('/{_locale}', function (Request $request) use ($app) {
             return $request->getLocale().$app->handle(Request::create('/embed/es'), HttpKernelInterface::SUB_REQUEST)->getContent().$request->getLocale();
@@ -52,6 +57,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('fresfr', $response->getContent());
 
         $app = new Application();
+        $app->register(new LocaleServiceProvider());
         $app->get('/embed', function (Request $request) { return $request->getLocale(); });
         $app->get('/{_locale}', function (Request $request) use ($app) {
             return $request->getLocale().$app->handle(Request::create('/embed'), HttpKernelInterface::SUB_REQUEST)->getContent().$request->getLocale();
@@ -64,6 +70,7 @@ class LocaleTest extends \PHPUnit_Framework_TestCase
     public function testLocaleWithBefore()
     {
         $app = new Application();
+        $app->register(new LocaleServiceProvider());
         $app->before(function (Request $request) use ($app) { $request->setLocale('fr'); });
         $app->get('/embed', function (Request $request) { return $request->getLocale(); });
         $app->get('/', function (Request $request) use ($app) {

--- a/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
@@ -13,6 +13,7 @@ namespace Silex\Tests\Provider;
 
 use Silex\Application;
 use Silex\Provider\TranslationServiceProvider;
+use Silex\Provider\LocaleServiceProvider;
 
 /**
  * TranslationProvider test cases.
@@ -28,6 +29,7 @@ class TranslationServiceProviderTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
+        $app->register(new LocaleServiceProvider());
         $app->register(new TranslationServiceProvider());
         $app['translator.domains'] = array(
             'messages' => array(


### PR DESCRIPTION
I've also made the URL matcher optional is none is available.
