### PR TITLE
[2.0] refactored session code to reuse Symfony listeners

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.0 (2013-XX-XX)
 ------------------
 
-* n/a
+* Updated session listeners to extends HttpKernel ones
 
 1.2.0 (2013-XX-XX)
 ------------------

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -273,6 +273,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
     {
         if ($this->booted) {
             $this['dispatcher']->addListener($eventName, $callback, $priority);
+
             return;
         }
 

--- a/src/Silex/EventListener/SessionListener.php
+++ b/src/Silex/EventListener/SessionListener.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\EventListener;
+
+use Silex\Application;
+use Symfony\Component\HttpKernel\EventListener\SessionListener as BaseSessionListener;
+
+/**
+ * Sets the session in the request.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class SessionListener extends BaseSessionListener
+{
+    private $app;
+
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    public function getSession()
+    {
+        if (!isset($this->app['session'])) {
+            return null;
+        }
+
+        return $this->app['session'];
+    }
+}

--- a/src/Silex/EventListener/TestSessionListener.php
+++ b/src/Silex/EventListener/TestSessionListener.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\EventListener;
+
+use Silex\Application;
+use Symfony\Component\HttpKernel\EventListener\TestSessionListener as BaseTestSessionListener;
+
+/**
+ * Simulates sessions for testing purpose.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class TestSessionListener extends BaseTestSessionListener
+{
+    private $app;
+
+    public function __construct(Application $app)
+    {
+        $this->app = $app;
+    }
+
+    public function getSession()
+    {
+        if (!isset($this->app['session'])) {
+            return null;
+        }
+
+        return $this->app['session'];
+    }
+}

--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -13,15 +13,12 @@ namespace Silex\Provider;
 
 use Silex\Application;
 use Silex\ServiceProviderInterface;
+use Silex\EventListener\SessionListener;
+use Silex\EventListener\TestSessionListener;
 use Symfony\Component\HttpFoundation\Session\Storage\Handler\NativeFileSessionHandler;
 use Symfony\Component\HttpFoundation\Session\Storage\NativeSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Storage\MockFileSessionStorage;
 use Symfony\Component\HttpFoundation\Session\Session;
-use Symfony\Component\HttpFoundation\Cookie;
-use Symfony\Component\HttpKernel\HttpKernelInterface;
-use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
-use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
 /**
  * Symfony HttpFoundation component Provider for sessions.
@@ -61,8 +58,16 @@ class SessionServiceProvider implements ServiceProviderInterface
             );
         });
 
+        $app['session.listener'] = $app->share(function ($app) {
+            return new SessionListener($app);
+        });
+
         $app['session.storage.test'] = $app->share(function () {
             return new MockFileSessionStorage();
+        });
+
+        $app['session.listener.test'] = $app->share(function ($app) {
+            return new TestSessionListener($app);
         });
 
         $app['session.storage.options'] = array();
@@ -70,55 +75,12 @@ class SessionServiceProvider implements ServiceProviderInterface
         $app['session.storage.save_path'] = null;
     }
 
-    public function onEarlyKernelRequest(GetResponseEvent $event)
-    {
-        $event->getRequest()->setSession($this->app['session']);
-    }
-
-    public function onKernelRequest(GetResponseEvent $event)
-    {
-        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
-            return;
-        }
-
-        // bootstrap the session
-        if (!isset($this->app['session'])) {
-            return;
-        }
-
-        $session = $this->app['session'];
-        $cookies = $event->getRequest()->cookies;
-
-        if ($cookies->has($session->getName())) {
-            $session->setId($cookies->get($session->getName()));
-        } else {
-            $session->migrate(false);
-        }
-    }
-
-    public function onKernelResponse(FilterResponseEvent $event)
-    {
-        if (HttpKernelInterface::MASTER_REQUEST !== $event->getRequestType()) {
-            return;
-        }
-
-        $session = $event->getRequest()->getSession();
-        if ($session && $session->isStarted()) {
-            $session->save();
-
-            $params = session_get_cookie_params();
-
-            $event->getResponse()->headers->setCookie(new Cookie($session->getName(), $session->getId(), 0 === $params['lifetime'] ? 0 : time() + $params['lifetime'], $params['path'], $params['domain'], $params['secure'], $params['httponly']));
-        }
-    }
-
     public function boot(Application $app)
     {
-        $app['dispatcher']->addListener(KernelEvents::REQUEST, array($this, 'onEarlyKernelRequest'), 128);
+        $app['dispatcher']->addSubscriber($app['session.listener']);
 
         if ($app['session.test']) {
-            $app['dispatcher']->addListener(KernelEvents::REQUEST, array($this, 'onKernelRequest'), 192);
-            $app['dispatcher']->addListener(KernelEvents::RESPONSE, array($this, 'onKernelResponse'), -128);
+            $app['dispatcher']->addSubscriber($app['session.listener.test']);
         }
     }
 }

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
@@ -200,7 +200,9 @@ class SecurityServiceProviderTest extends WebTestCase
                 'default' => array(
                     'pattern' => '^.*$',
                     'anonymous' => true,
-                    'form' => true,
+                    'form' => array(
+                        'require_previous_session' => false,
+                    ),
                     'logout' => true,
                     'users' => array(
                         // password is foo


### PR DESCRIPTION
Now that HttpKernel contains Symfony listeners for session, let's use them.
