### PR TITLE
[2.0] Request service removal

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -138,12 +138,6 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
             return new RedirectableUrlMatcher($app['routes'], $app['request_context']);
         });
 
-        $this['request_error'] = $this->protect(function () {
-            throw new \RuntimeException('Accessed request service outside of request scope. Try moving that call to a before handler or controller.');
-        });
-
-        $this['request'] = $this['request_error'];
-
         $this['request.http_port'] = 80;
         $this['request.https_port'] = 443;
         $this['debug'] = false;
@@ -514,17 +508,9 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
             $this->boot();
         }
 
-        $current = HttpKernelInterface::SUB_REQUEST === $type ? $this['request'] : $this['request_error'];
-
-        $this['request'] = $request;
-
         $this->flush();
 
-        $response = $this['kernel']->handle($request, $type, $catch);
-
-        $this['request'] = $current;
-
-        return $response;
+        return $this['kernel']->handle($request, $type, $catch);
     }
 
     /**

--- a/src/Silex/ExceptionListenerWrapper.php
+++ b/src/Silex/ExceptionListenerWrapper.php
@@ -49,7 +49,7 @@ class ExceptionListenerWrapper
 
         $code = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
 
-        $response = call_user_func($this->callback, $exception, $code);
+        $response = call_user_func($this->callback, $exception, $event->getRequest(), $code);
 
         $this->ensureResponse($response, $event);
     }

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -432,30 +432,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $app->handle(Request::create('/'), HttpKernelInterface::MASTER_REQUEST, false);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testAccessingRequestOutsideOfScopeShouldThrowRuntimeException()
-    {
-        $app = new Application();
-
-        $request = $app['request'];
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testAccessingRequestOutsideOfScopeShouldThrowRuntimeExceptionAfterHandling()
-    {
-        $app = new Application();
-        $app->get('/', function () {
-            return 'hello';
-        });
-        $app->handle(Request::create('/'), HttpKernelInterface::MASTER_REQUEST, false);
-
-        $request = $app['request'];
-    }
-
     public function testSubRequest()
     {
         $app = new Application();
@@ -467,27 +443,6 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertEquals('foo', $app->handle(Request::create('/'))->getContent());
-    }
-
-    public function testSubRequestDoesNotReplaceMainRequestAfterHandling()
-    {
-        $mainRequest = Request::create('/');
-        $subRequest = Request::create('/sub');
-
-        $app = new Application();
-        $app->get('/sub', function (Request $request) {
-            return new Response('foo');
-        });
-        $app->get('/', function (Request $request) use ($subRequest, $app) {
-            $response = $app->handle($subRequest, HttpKernelInterface::SUB_REQUEST);
-
-            // request in app must be the main request here
-            $response->setContent($response->getContent().' '.$app['request']->getPathInfo());
-
-            return $response;
-        });
-
-        $this->assertEquals('foo /', $app->handle($mainRequest)->getContent());
     }
 
     public function testRegisterShouldReturnSelf()

--- a/tests/Silex/Tests/MiddlewareTest.php
+++ b/tests/Silex/Tests/MiddlewareTest.php
@@ -191,8 +191,8 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->before(function () use ($app) {
-            $app['project'] = $app['request']->get('project');
+        $app->before(function (Request $request) use ($app) {
+            $app['project'] = $request->get('project');
         });
 
         $app->match('/foo/{project}', function () use ($app) {

--- a/tests/Silex/Tests/RouterTest.php
+++ b/tests/Silex/Tests/RouterTest.php
@@ -147,12 +147,12 @@ class RouterTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
 
-        $app->get('/foo', function () use ($app) {
-            return new Response($app['request']->getRequestUri());
+        $app->get('/foo', function (Request $request) use ($app) {
+            return new Response($request->getRequestUri());
         });
 
-        $app->error(function ($e) use ($app) {
-            return new Response($app['request']->getRequestUri());
+        $app->error(function ($e, Request $request, $code) use ($app) {
+            return new Response($request->getRequestUri());
         });
 
         foreach (array('/foo', '/bar') as $path) {

--- a/tests/Silex/Tests/WebTestCaseTest.php
+++ b/tests/Silex/Tests/WebTestCaseTest.php
@@ -13,6 +13,7 @@ namespace Silex\Tests;
 
 use Silex\Application;
 use Silex\WebTestCase;
+use Symfony\Component\HttpFoundation\Request;
 
 /**
  * Functional test cases.
@@ -33,9 +34,9 @@ class WebTestCaseTest extends WebTestCase
             return '<h1>title</h1>';
         });
 
-        $app->match('/server', function () use ($app) {
-            $user = $app['request']->server->get('PHP_AUTH_USER');
-            $pass = $app['request']->server->get('PHP_AUTH_PW');
+        $app->match('/server', function (Request $request) use ($app) {
+            $user = $request->server->get('PHP_AUTH_USER');
+            $pass = $request->server->get('PHP_AUTH_PW');
 
             return "<h1>$user:$pass</h1>";
         });


### PR DESCRIPTION
This one is probably going to be controversial but I'd really think that removing the `request` service is a big step in the right direction.

Giving access to the Request object as a service is wrong for many reasons I won't reiterate here and of course it can cause problems if someone store a reference of it in another service. Instead, the `request_stack` should be injected and the Request object retrieved from it.

If you look at the patch, it's surprisingly easy enough to get rid of it probably because Silex/Symfony are already well aware of that problem (the main changes come from updating the tests).
