### PR TITLE
[2.0] removed the flush call in the url generator service

### DIFF
--- a/doc/providers/url_generator.rst
+++ b/doc/providers/url_generator.rst
@@ -64,6 +64,14 @@ Moreover, if you have ``twig-bridge`` in your ``composer.json``, you will have a
     {{ path('hello', {name: 'Fabien'}) }}
     {{ url('hello', {name: 'Fabien'}) }} {# generates the absolute url http://example.org/hello/Fabien #}
 
+.. warning::
+
+    If you try to use the ``url_generator`` service outside the handling of a
+    request, you must explicitly flush routes first::
+
+        $app->flush();
+        $url = $app['url_generator']->generate('homepage');
+
 Traits
 ------
 

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -30,8 +30,6 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
     public function register(\Pimple $app)
     {
         $app['url_generator'] = $app->share(function ($app) {
-            $app->flush();
-
             return new UrlGenerator($app['routes'], $app['request_context']);
         });
 


### PR DESCRIPTION
As explained in #858, the flush call in the URL generator service hurts reusability and is only useful when you need to get the URL generator before the handling of the request. As this use case is an edge case, and because it can be easily documented and explained, I propose to remove the call in 2.0.
