### PR TITLE
Add a cached translator

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -10,6 +10,7 @@ Changelog
 * Deprecated TwigCoreExtension (register the new HttpFragmentServiceProvider instead)
 * Added HttpFragmentServiceProvider
 * Allowed a callback to be a method call on a service (before, after, finish, error, on Application; convert, before, after on Controller)
+* Add a cached translator
 
 1.1.3 (2013-XX-XX)
 ------------------

--- a/doc/providers/translation.rst
+++ b/doc/providers/translation.rst
@@ -35,6 +35,9 @@ Services
 Registering
 -----------
 
+Default
+~~~~~~~
+
 .. code-block:: php
 
     $app->register(new Silex\Provider\TranslationServiceProvider(), array(
@@ -51,6 +54,35 @@ Registering
 
         "require": {
             "symfony/translation": "~2.3"
+        }
+
+Cached translator
+~~~~~~~~~~~~~~~~~
+
+Loading translations from non-PHP files can be expensive. Silex provides a
+cached translator that will speed up this process.
+
+.. code-block:: php
+
+    $app->register(new Silex\Provider\TranslationServiceProvider(), array(
+        'locale_fallbacks' => array('en'),
+        'translator.cache-options' => array(
+            'cache_dir' => '/path/to/translations/tmp-dir',
+        )
+    ));
+
+.. note::
+
+    The cached translator is automatically loaded if you provide a
+    ``cache_dir`` option and if Symfony Config Component is available.
+
+    As it requires the Symfony Config Component, add this dependency to your
+    ``composer.json`` file:
+
+    .. code-block:: json
+
+        "require": {
+            "symfony/config": "~2.3"
         }
 
 Usage

--- a/src/Silex/CachedTranslator.php
+++ b/src/Silex/CachedTranslator.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex;
+
+use Symfony\Component\Config\ConfigCache;
+use Symfony\Component\Translation\MessageSelector;
+
+/**
+ * Translator that gets the current locale from the Silex application
+ * and cache the translations on filesystem.
+ */
+class CachedTranslator extends Translator
+{
+    protected $app;
+    protected $options = array(
+        'cache_dir' => null,
+        'debug'     => false,
+    );
+
+    public function __construct(Application $app, MessageSelector $selector, array $options = array())
+    {
+        $this->app = $app;
+
+        if ($diff = array_diff(array_keys($options), array_keys($this->options))) {
+            throw new \InvalidArgumentException(sprintf('The Translator does not support the following options: \'%s\'.', implode('\', \'', $diff)));
+        }
+
+        $this->options = array_merge($this->options, $options);
+
+        parent::__construct($app, $selector);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function loadCatalogue($locale)
+    {
+        if (isset($this->catalogues[$locale])) {
+            return;
+        }
+
+        if (null === $this->options['cache_dir']) {
+            return parent::loadCatalogue($locale);
+        }
+
+        $cache = new ConfigCache($this->options['cache_dir'].'/catalogue.'.$locale.'.php', $this->options['debug']);
+        if (!$cache->isFresh()) {
+            parent::loadCatalogue($locale);
+
+            $fallbackContent = '';
+            $current = '';
+            foreach ($this->computeFallbackLocales($locale) as $fallback) {
+                $fallbackSuffix = ucfirst(str_replace('-', '_', $fallback));
+
+                $fallbackContent .= sprintf(<<<EOF
+\$catalogue%s = new MessageCatalogue('%s', %s);
+\$catalogue%s->addFallbackCatalogue(\$catalogue%s);
+
+
+EOF
+                    ,
+                    $fallbackSuffix,
+                    $fallback,
+                    var_export($this->catalogues[$fallback]->all(), true),
+                    ucfirst(str_replace('-', '_', $current)),
+                    $fallbackSuffix
+                );
+                $current = $fallback;
+            }
+
+            $content = sprintf(<<<EOF
+<?php
+
+use Symfony\Component\Translation\MessageCatalogue;
+
+\$catalogue = new MessageCatalogue('%s', %s);
+
+%s
+return \$catalogue;
+
+EOF
+                ,
+                $locale,
+                var_export($this->catalogues[$locale]->all(), true),
+                $fallbackContent
+            );
+
+            $cache->write($content, $this->catalogues[$locale]->getResources());
+
+            return;
+        }
+
+        $this->catalogues[$locale] = include $cache;
+    }
+}


### PR DESCRIPTION
TranslationServiceProvider provides the use of symfony/translation component.
This component is nice but it's quite slow as loaders parse the translations sources on every requests.

I've added a `Silex\CachedTranslator` based on Symfony Framework bundle [one](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Translation/Translator.php).
