### PR TITLE
Remove gendered pronouns

### DIFF
--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -159,9 +159,9 @@ Using a form to authenticate users is very similar to the above configuration.
 Instead of using the ``http`` setting, use the ``form`` one and define these
 two parameters:
 
-* **login_path**: The login path where the user is redirected when he is
-  accessing a secured area without being authenticated so that he can enter
-  his credentials;
+* **login_path**: The login path where the user is redirected when they are
+  accessing a secured area without being authenticated so that they can enter
+  their credentials;
 
 * **check_path**: The check URL used by Symfony to validate the credentials of
   the user.
@@ -371,7 +371,7 @@ parameter to any URL when logged in as a user who has the
 
 You can check that you are impersonating a user by checking the special
 ``ROLE_PREVIOUS_ADMIN``. This is useful for instance to allow the user to
-switch back to his primary account:
+switch back to their primary account:
 
 .. code-block:: jinja
 

--- a/doc/providers/session.rst
+++ b/doc/providers/session.rst
@@ -60,7 +60,7 @@ Usage
 -----
 
 The Session provider provides a ``session`` service. Here is an example that
-authenticates a user and creates a session for him::
+authenticates a user and creates a session for them::
 
     use Symfony\Component\HttpFoundation\Response;
 


### PR DESCRIPTION
When referencing hypothetical users, it's more inclusive to use
gender-neutral prnouns. Instances of he/she/his/her/him have been
replaced with they/them/their and verb tenses changed to match.
