### PR TITLE
Allow changing of ResolvedFormTypeFactory

### DIFF
--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -19,6 +19,7 @@ use Symfony\Component\Form\Extension\Csrf\CsrfProvider\SessionCsrfProvider;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension as FormValidatorExtension;
 use Symfony\Component\Form\Forms;
+use Symfony\Component\Form\ResolvedFormTypeFactory;
 
 /**
  * Symfony Form component Provider.
@@ -77,8 +78,13 @@ class FormServiceProvider implements ServiceProviderInterface
                 ->addExtensions($app['form.extensions'])
                 ->addTypeExtensions($app['form.type.extensions'])
                 ->addTypeGuessers($app['form.type.guessers'])
+                ->setResolvedTypeFactory($app['form.resolved_type_factory'])
                 ->getFormFactory()
             ;
+        });
+        
+        $app['form.resolved_type_factory'] = $app->share(function ($app) {
+            return new ResolvedFormTypeFactory();
         });
 
         $app['form.csrf_provider'] = $app->share(function ($app) {


### PR DESCRIPTION
Added a new service for the ResolvedTypeFactory. The service name is based on the symfony service name.

This is needed to get the debug form panel working in silex. (PR for this follows soon in web-profiler-provider)
