### PR TITLE
TranslationServiceProvider replaced translator.messages by translator.domains.

### DIFF
--- a/doc/providers/form.rst
+++ b/doc/providers/form.rst
@@ -142,7 +142,7 @@ form by adding constraints on the fields::
 
     $app->register(new Silex\Provider\ValidatorServiceProvider());
     $app->register(new Silex\Provider\TranslationServiceProvider(), array(
-        'translator.messages' => array(),
+        'translator.domains' => array(),
     ));
 
     $form = $app['form.factory']->createBuilder('form')


### PR DESCRIPTION
- changed in commit 7C496D
