### PR TITLE
The form csrf extension should use the translator if available

### DIFF
--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -55,9 +55,17 @@ class FormServiceProvider implements ServiceProviderInterface
             return array();
         });
 
+        $app['form.extension.csrf'] = $app->share(function ($app) {
+            if (isset($app['translator'])) {
+                return new CsrfExtension($app['form.csrf_provider'], $app['translator']);
+            }
+
+            return new CsrfExtension($app['form.csrf_provider']);
+        });
+
         $app['form.extensions'] = $app->share(function ($app) {
             $extensions = array(
-                new CsrfExtension($app['form.csrf_provider']),
+                $app['form.extension.csrf'],
                 new HttpFoundationExtension(),
             );
 


### PR DESCRIPTION
Fixes #896
