### PR TITLE
Proposal: Generator-style middleware

### DIFF
--- a/src/Silex/Application/MiddlewareTrait.php
+++ b/src/Silex/Application/MiddlewareTrait.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Application;
+
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Middleware trait.
+ *
+ * @author Chris Heng <hengkuanyen@gmail.com>
+ */
+trait MiddlewareTrait
+{
+    /**
+     * Utilize generator style middleware.
+     *
+     * @param callable|array $callback
+     * @param integer|array  $priorities
+     */
+    public function utilize($callback, $priorities = 0)
+    {
+        static $counter;
+
+        if (is_array($callback) && !is_callable($callback)) {
+            foreach ($callback as $priority => $callable) {
+                $this->utilize($callable, $priority);
+            }
+
+            return $this;
+        }
+
+        $resolver = $this['callback_resolver'];
+
+        $listener = function ($event) use ($callback, $resolver, &$counter) {
+            static $generators = array();
+
+            if (isset($generators[$counter])) {
+                $generator = $generators[$counter];
+
+                return $generator->send($event);
+            }
+
+            $ret = call_user_func($resolver->resolveCallback($callback), $event);
+
+            if ($ret instanceof \Continuation || $ret instanceof \Generator) {
+                $generator = $generators[$counter] = $ret;
+
+                if ($generator instanceof \Continuation) {
+                    $generator->next();
+                }
+
+                return $generator->current();
+            }
+        };
+
+        if (!is_array($priorities)) {
+            $priority = (int) $priorities;
+            $priorities = array(
+                KernelEvents::REQUEST => $priority,
+                KernelEvents::RESPONSE => -$priority
+            );
+        }
+
+        $before = function () use (&$counter) {
+            $counter++;
+        };
+
+        $after = function () use (&$counter) {
+            $counter--;
+        };
+
+        if ($this->booted) {
+            foreach ($priorities as $eventName => $priority) {
+                $this['dispatcher']->addListener($eventName, $listener, $priority);
+            }
+            if (null === $counter) {
+                $this['dispatcher']->addListener(KernelEvents::REQUEST, $before, 9999);
+                $this['dispatcher']->addListener(KernelEvents::FINISH_REQUEST, $after, -9999);
+                $counter = 0;
+            }
+        } else {
+            $this['dispatcher'] = $this->share(
+                $this->extend(
+                    'dispatcher',
+                    function ($dispatcher, $app) use ($priorities, $listener, &$counter, $before, $after) {
+                        foreach ($priorities as $eventName => $priority) {
+                            $dispatcher->addListener($eventName, $listener, $priority);
+                        }
+                        if (null === $counter) {
+                            $dispatcher->addListener(KernelEvents::REQUEST, $before, 9999);
+                            $dispatcher->addListener(KernelEvents::FINISH_REQUEST, $after, -9999);
+                            $counter = 0;
+                        }
+
+                        return $dispatcher;
+                    }
+                )
+            );
+        }
+
+        return $this;
+    }
+}


### PR DESCRIPTION
Seeing as PHP 5.5 adds support for [generators](http://www.php.net/manual/en/language.generators.overview.php), I experimented with generator-style middleware in Silex. The basic idea is something like:

``` php
$app->use(function () use ($app) {
    $start = microtime(true);
    $response = yield;
    $response->headers->set('X-Response-Time', sprintf('%fms', microtime(true) - $start));
});
```

With this particular implementation I tap into the `EventDispatcher` so it makes use of events (`use` is a reserved keyword so I went with `utilize`):

``` php
$app->utilize(function ($event) use ($app) {
    $start = microtime(true);
    $event = yield;
    if ($event->isMasterRequest()) {
        $response = $event->getResponse();
        $response->headers->set('X-Response-Time', sprintf('%fms', microtime(true) - $start));
    }
});
```

`utilize()` will register the listener function with the `REQUEST` and `RESPONSE` events by default, but you can specify any event/priority combination as the second parameter:

``` php
$app->utilize(function ($event) use ($app) {
    // GetResponseEvent
    $request = $event->getRequest();

    // GetResponseForControllerResultEvent
    $event = yield;
    $result = $event->getControllerResult();

    // FilterResponseEvent
    $event = yield;
    $response = $event->getResponse();
}, array(
    KernelEvents::REQUEST => 16,
    KernelEvents::VIEW => -16,
    KernelEvents::RESPONSE => 0
));
```

I implemented it as a trait, since (obviously) it only works with PHP 5.5 and HHVM.

Example usage:

``` php
require_once './vendor/autoload.php';

class MyApplication extends Silex\Application
{
    use Silex\Application\MiddlewareTrait;
}

$app = new MyApplication();

// You can define middleware as a regular closure
$app->utilize(function () {
    //...
});

// Or you can define it as a separate class
class ResponseTimeMiddleware
{
    public function __invoke()
    {
        $start = microtime(true);

        $event = yield;
        $response = $event->getResponse();

        $end = microtime(true);

        $response->headers->set('X-Response-Time', sprintf('%fms', $end - $start));
    }

    // for demonstration purposes
    public function run()
    {
        $this->__invoke();
    }
}

$app->utilize(new ResponseTimeMiddleware());

// You can also make use of the callback resolver to lazy load classes
$app['response_time_middleware'] = $app->share(function ($app) {
    return new ResponseTimeMiddleware();
});

$app->utilize('response_time_middleware:run');

// Register multiple middlewares
$app->utilize([
    new ResponseTimeMiddleware(),
    new ContentNegotiationMiddleware(),
    new LayoutMiddleware(),
    ...
]);
```

What do you think?
