### PR TITLE
Update twig.rst SymfonyBridgesServiceProvider

### DIFF
--- a/doc/providers/twig.rst
+++ b/doc/providers/twig.rst
@@ -118,7 +118,7 @@ from a template:
 
     {{ render(app.request.baseUrl ~ '/sidebar') }}
 
-    {# or if you are also using UrlGeneratorServiceProvider with the SymfonyBridgesServiceProvider #}
+    {# or if you are also using the UrlGeneratorServiceProvider #}
     {{ render(url('sidebar')) }}
 
 .. note::


### PR DESCRIPTION
Changelog:
2012-05-26: Removed SymfonyBridgesServiceProvider. It is now implicit by checking the existence of the bridge.
