### PR TITLE
Allow overriding formatter used by default monolog.handler service.

### DIFF
--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Provider;
 
+use Monolog\Formatter\LineFormatter;
 use Monolog\Logger;
 use Monolog\Handler\StreamHandler;
 use Silex\Application;
@@ -56,10 +57,16 @@ class MonologServiceProvider implements ServiceProviderInterface
             return $log;
         });
 
+        $app['monolog.formatter'] = function () {
+            return new LineFormatter();
+        };
+
         $app['monolog.handler'] = function () use ($app) {
             $level = MonologServiceProvider::translateLevel($app['monolog.level']);
+            $handler = new StreamHandler($app['monolog.logfile'], $level);
+            $handler->setFormatter($app['monolog.formatter']);
 
-            return new StreamHandler($app['monolog.logfile'], $level);
+            return $handler;
         };
 
         $app['monolog.level'] = function () {

--- a/tests/Silex/Tests/Provider/MonologServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/MonologServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
 use Silex\Application;
@@ -57,6 +58,17 @@ class MonologServiceProviderTest extends \PHPUnit_Framework_TestCase
         $app->handle($request);
 
         $this->assertTrue($app['monolog.handler']->hasDebug('logging a message'));
+    }
+
+    public function testOverrideFormatter()
+    {
+        $app = new Application();
+
+        $app->register(new MonologServiceProvider());
+        $app['monolog.formatter'] = new JsonFormatter();
+        $app['monolog.logfile'] = null;
+
+        $this->assertInstanceOf('Monolog\Formatter\JsonFormatter', $app['logger']->popHandler()->getFormatter());
     }
 
     public function testErrorLogging()


### PR DESCRIPTION
This PR adds a new service, `monolog.formatter`, which is read by the default `monolog.handler` in order to allow easy override of the default formatter to use. 
