### PR TITLE
Support optional session invalidation on logout

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -467,7 +467,10 @@ class SecurityServiceProvider implements ServiceProviderInterface
                     isset($options['with_csrf']) && $options['with_csrf'] && isset($app['form.csrf_provider']) ? $app['form.csrf_provider'] : null
                 );
 
-                $listener->addHandler(new SessionLogoutHandler());
+                $tmp = isset($options['invalidate_session']) ? $options['invalidate_session'] : true;
+                if (true === $tmp) {
+                    $listener->addHandler(new SessionLogoutHandler());
+                }
 
                 return $listener;
             });

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -467,8 +467,8 @@ class SecurityServiceProvider implements ServiceProviderInterface
                     isset($options['with_csrf']) && $options['with_csrf'] && isset($app['form.csrf_provider']) ? $app['form.csrf_provider'] : null
                 );
 
-                $tmp = isset($options['invalidate_session']) ? $options['invalidate_session'] : true;
-                if (true === $tmp) {
+                $invalidateSession = isset($options['invalidate_session']) ? $options['invalidate_session'] : true;
+                if (true === $invalidateSession) {
                     $listener->addHandler(new SessionLogoutHandler());
                 }
 


### PR DESCRIPTION
Avoid session destroying on logout by adding "invalidate_session: false" in your configuration e.g.

$app['security.firewalls'] = array(
[...]
        'logout' => array(
            'logout_path' => '/user/logout',
            'target_url' => '/logout',
            'invalidate_session' => false
        ),
[...]
);