### PR TITLE
Support automatic cookie removal on logout

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -49,6 +49,7 @@ use Symfony\Component\Security\Http\EntryPoint\RetryAuthenticationEntryPoint;
 use Symfony\Component\Security\Http\Session\SessionAuthenticationStrategy;
 use Symfony\Component\Security\Http\Logout\SessionLogoutHandler;
 use Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler;
+use Symfony\Component\Security\Http\Logout\CookieClearingLogoutHandler;
 use Symfony\Component\Security\Http\AccessMap;
 use Symfony\Component\Security\Http\HttpUtils;
 

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -469,6 +469,32 @@ class SecurityServiceProvider implements ServiceProviderInterface
 
                 $listener->addHandler(new SessionLogoutHandler());
 
+                $removeCookies = isset($options['remove_cookies']) ? $options['remove_cookies'] : null;
+                if (null !== $removeCookies) {
+                	$cookies = array();
+                	
+                	foreach ($removeCookies as $key => $value) {
+                		if (is_array($value)) {
+                			// Check for existence of method parameters otherwise
+                			// use default values given by ResponseHeaderBag:clearCookie()
+                			if (!isset($value['path'])) {
+                				$value['path'] = '/';
+                			}
+                			if (!isset($value['domain'])) {
+                				$value['domain'] = null;
+                			}
+                			
+                			$cookies[$key] = $value;
+                		} else {
+                			// Possibility to skip cookie values and use default
+                			// values given by ResponseHeaderBag:clearCookie()
+                			$cookies[$value] = array('path' => '/', 'domain' => null);
+                		}
+                	}
+                	
+                	$listener->addHandler(new CookieClearingLogoutHandler($cookies));
+                }
+
                 return $listener;
             });
         });

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -473,7 +473,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
                 $removeCookies = isset($options['remove_cookies']) ? $options['remove_cookies'] : null;
                 if (null !== $removeCookies) {
                     $cookies = array();
-                    
+
                     foreach ($removeCookies as $key => $value) {
                         if (is_array($value)) {
                             // Check for existence of method parameters otherwise
@@ -484,7 +484,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
                             if (!isset($value['domain'])) {
                                 $value['domain'] = null;
                             }
-                            
+
                             $cookies[$key] = $value;
                         } else {
                             // Possibility to skip cookie values and use default
@@ -492,7 +492,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
                             $cookies[$value] = array('path' => '/', 'domain' => null);
                         }
                     }
-                    
+
                     $listener->addHandler(new CookieClearingLogoutHandler($cookies));
                 }
 

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -471,28 +471,28 @@ class SecurityServiceProvider implements ServiceProviderInterface
 
                 $removeCookies = isset($options['remove_cookies']) ? $options['remove_cookies'] : null;
                 if (null !== $removeCookies) {
-                	$cookies = array();
-                	
-                	foreach ($removeCookies as $key => $value) {
-                		if (is_array($value)) {
-                			// Check for existence of method parameters otherwise
-                			// use default values given by ResponseHeaderBag:clearCookie()
-                			if (!isset($value['path'])) {
-                				$value['path'] = '/';
-                			}
-                			if (!isset($value['domain'])) {
-                				$value['domain'] = null;
-                			}
-                			
-                			$cookies[$key] = $value;
-                		} else {
-                			// Possibility to skip cookie values and use default
-                			// values given by ResponseHeaderBag:clearCookie()
-                			$cookies[$value] = array('path' => '/', 'domain' => null);
-                		}
-                	}
-                	
-                	$listener->addHandler(new CookieClearingLogoutHandler($cookies));
+                    $cookies = array();
+                    
+                    foreach ($removeCookies as $key => $value) {
+                        if (is_array($value)) {
+                            // Check for existence of method parameters otherwise
+                            // use default values given by ResponseHeaderBag:clearCookie()
+                            if (!isset($value['path'])) {
+                                $value['path'] = '/';
+                            }
+                            if (!isset($value['domain'])) {
+                                $value['domain'] = null;
+                            }
+                            
+                            $cookies[$key] = $value;
+                        } else {
+                            // Possibility to skip cookie values and use default
+                            // values given by ResponseHeaderBag:clearCookie()
+                            $cookies[$value] = array('path' => '/', 'domain' => null);
+                        }
+                    }
+                    
+                    $listener->addHandler(new CookieClearingLogoutHandler($cookies));
                 }
 
                 return $listener;


### PR DESCRIPTION
Support of cookie destroying on logout by adding "remove_cookies: { 'cookieName1', 'cookieName2':  { 'path': '/', 'domain': null } }" in your configuration e.g.

```
$app['security.firewalls'] = array(
[...]
        'logout' => array(
            'logout_path' => '/user/logout',
            'remove_cookies' => array('cookieName1', 'cookieName2' => array('path' => '/', 'domain' => null))
        ),
[...]
);
```

Based on discussion https://groups.google.com/d/topic/silex-php/828UcSi7bks/discussion
