### PR TITLE
Bump log level for HTTP exceptions

### DIFF
--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -76,7 +76,7 @@ class MonologServiceProvider implements ServiceProviderInterface
             function (\Exception $e) use ($app) {
                 $message = sprintf('%s: %s (uncaught exception) at %s line %s', get_class($e), $e->getMessage(), $e->getFile(), $e->getLine());
                 if ($e instanceof HttpExceptionInterface && $e->getStatusCode() < 500) {
-                    $app['monolog']->addError($message, array('exception' => $e));
+                    $app['monolog']->addNotice($message, array('exception' => $e));
                 } else {
                     $app['monolog']->addCritical($message, array('exception' => $e));
                 }


### PR DESCRIPTION
403 and 404 http exceptions is a part of typical site workflow. They can be produced by search engines or mistyping in address bar. It is not an application error.
