### PR TITLE
Allow extends of SessionServiceProvider with access to Silex\Application...

### DIFF
--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -30,7 +30,7 @@ use Symfony\Component\HttpKernel\Event\GetResponseEvent;
  */
 class SessionServiceProvider implements ServiceProviderInterface
 {
-    private $app;
+    protected $app;
 
     public function register(Application $app)
     {


### PR DESCRIPTION
I wanted to extend SessionServiceProvider. Attribute $app is private, so you can't extend the class and access this attribute. I had to copy/paste all the code of the class to a new one implementing ServiceProviderInterface, although I only needed to extends 1 method.
