### PR TITLE
Allow setting of Session FlashBag and AttributeBag.

### DIFF
--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -47,7 +47,19 @@ class SessionServiceProvider implements ServiceProviderInterface
                 }
             }
 
-            return new Session($app['session.storage']);
+            if (!isset($app['session.attribute_bag'])) {
+                $app['session.attribute_bag'] = null;
+            }
+
+            if (!isset($app['session.flashbag'])) {
+                $app['session.flashbag'] = null;
+            }
+
+            return new Session(
+                $app['session.storage'], 
+                $app['session.attribute_bag'], 
+                $app['session.flashbag']
+            );
         });
 
         $app['session.storage.handler'] = $app->share(function ($app) {


### PR DESCRIPTION
This change allows you to set the FlashBag and AttributeBag for the Symfony Session when registering the SessionServiceProvier:

    $app->register(new Silex\Provider\SessionServiceProvider(), array(
        'session.storage.options' => array(
          'name' => 'mycookie'
        ),
        'session.flashbag' => new Symfony\Component\HttpFoundation\Session\Flash\AutoExpireFlashBag
      )
    );

Allows options equivalent to Symfony's `session.flashbag.class` and `session.attribute_bag.class` options.
