### PR TITLE
Update SecurityServiceProvider.php

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -56,6 +56,7 @@ use Symfony\Component\Security\Http\HttpUtils;
  * Symfony Security component Provider.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author Yannick Gagnon <yannick.gagnon@gmail.com>
  */
 class SecurityServiceProvider implements ServiceProviderInterface
 {
@@ -541,8 +542,11 @@ class SecurityServiceProvider implements ServiceProviderInterface
 
         foreach ($this->fakeRoutes as $route) {
             list($method, $pattern, $name) = $route;
-
-            $app->$method($pattern)->run(null)->bind($name);
+            
+            // Only add fake routes if they're not defined already
+            if( $app['routes']->get($name) === null) {
+            	$app->$method($pattern, null)->bind($name);
+            }
         }
     }
 


### PR DESCRIPTION
I think we should support route names for all configurations, currently we only have the option for login_path, this way, we'd support route name for all options: login_path, check_path, logout_path and target_url. Current use case is about keeping track o locale through the URL. With the current update, it only requires that one defines the routes and bind them.

Thanks.
