### PR TITLE
SecurityServiceProvider.php

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -542,7 +542,9 @@ class SecurityServiceProvider implements ServiceProviderInterface
         foreach ($this->fakeRoutes as $route) {
             list($method, $pattern, $name) = $route;
 
-            $app->$method($pattern)->run(null)->bind($name);
+            if ( $app['routes']->get($name) === null) {
+                $app->$method($pattern, null)->bind($name);
+             }
         }
     }
 


### PR DESCRIPTION
I think we should support route names for all configurations, currently we only have the option for login_path, this way, we'd support route name for all options: login_path, check_path, logout_path and target_url. Current use case is about keeping track o locale through the URL. With the current update, it only requires that one defines the routes and bind them.

Thanks.