### PR TITLE
Improve exception messages for mount()

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -467,7 +467,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
      *
      * @return Application
      *
-     * @throws \UnexpectedValueException
+     * @throws \LogicException
      */
     public function mount($prefix, $controllers)
     {
@@ -475,12 +475,12 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
             $controllers = $controllers->connect($this);
 
             if (!$controllers instanceof ControllerCollection) {
-                throw new \UnexpectedValueException('The "connect" method of the ControllerProviderInterface must return a ControllerCollection.');
+                throw new \LogicException('The "connect" method of the ControllerProviderInterface must return a ControllerCollection.');
             }
         }
 
         if (!$controllers instanceof ControllerCollection) {
-            throw new \UnexpectedValueException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
+            throw new \LogicException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
         }
 
         $this['controllers']->mount($prefix, $controllers);


### PR DESCRIPTION
Improve the exception message if the `connect` method of a `ControllerProviderInterface` returns an invalid type.

Previously a misleading message about the arguments to `mount()` was emitted if your `connect` method did not return a `ControllerCollection`.
