### PR TITLE
Allowed shared ContextListener for firewalls

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -171,8 +171,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                 $users = isset($firewall['users']) ? $firewall['users'] : array();
                 $security = isset($firewall['security']) ? (bool) $firewall['security'] : true;
                 $stateless = isset($firewall['stateless']) ? (bool) $firewall['stateless'] : false;
-                $stateless = isset($firewall['stateless']) ? (bool) $firewall['stateless'] : false;
-                $firewall['context'] = isset($firewall['context']) ? $firewall['context'] : $name;
+                $context = isset($firewall['context']) ? $firewall['context'] : $name;
                 unset($firewall['pattern'], $firewall['users'], $firewall['security'], $firewall['stateless'], $firewall['context']);
 
                 $protected = false === $security ? false : count($firewall);


### PR DESCRIPTION
In response to #963.

Checks for a `context` key in the firewall configuration, if it's not there use `name`.
