### PR TITLE
remove not needed logger tests

### DIFF
--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -86,10 +86,10 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             $app['dbs.options.initializer']();
 
             $configs = new Container();
+            $addLogger = (null !== $app['logger'] && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger'));
             foreach ($app['dbs.options'] as $name => $options) {
                 $configs[$name] = new Configuration();
-
-                if (isset($app['logger']) && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger')) {
+                if ($addLogger) {
                     $configs[$name]->setSQLLogger(new DbalLogger($app['logger'], isset($app['stopwatch']) ? $app['stopwatch'] : null));
                 }
             }

--- a/src/Silex/Provider/RememberMeServiceProvider.php
+++ b/src/Silex/Provider/RememberMeServiceProvider.php
@@ -75,7 +75,7 @@ class RememberMeServiceProvider implements ServiceProviderInterface, EventListen
                     'remember_me_parameter' => '_remember_me',
                 ), $options);
 
-                return new TokenBasedRememberMeServices(array($app['security.user_provider.'.$providerKey]), $options['key'], $providerKey, $options, isset($app['logger']) ? $app['logger'] : null);
+                return new TokenBasedRememberMeServices(array($app['security.user_provider.'.$providerKey]), $options['key'], $providerKey, $options, $app['logger']);
             };
         });
 
@@ -85,7 +85,7 @@ class RememberMeServiceProvider implements ServiceProviderInterface, EventListen
                     $app['security'],
                     $app['security.remember_me.service.'.$providerKey],
                     $app['security.authentication_manager'],
-                    isset($app['logger']) ? $app['logger'] : null
+                    $app['logger']
                 );
 
                 return $listener;

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -52,7 +52,7 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
                 return $app['url_matcher'];
             });
 
-            return new RouterListener($urlMatcher, $app['request_context'], isset($app['logger']) ? $app['logger'] : null, $app['request_stack']);
+            return new RouterListener($urlMatcher, $app['request_context'], $app['logger'], $app['request_stack']);
         };
     }
 

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -125,7 +125,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     isset($app['request.http_port']) ? $app['request.http_port'] : 80,
                     isset($app['request.https_port']) ? $app['request.https_port'] : 443
                 ),
-                isset($app['logger']) ? $app['logger'] : null
+                $app['logger']
             );
         };
 
@@ -283,7 +283,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                 $app['security.access_manager'],
                 $app['security.access_map'],
                 $app['security.authentication_manager'],
-                isset($app['logger']) ? $app['logger'] : null
+                $app['logger']
             );
         };
 
@@ -335,7 +335,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security'],
                     $userProviders,
                     $providerKey,
-                    isset($app['logger']) ? $app['logger'] : null,
+                    $app['logger'],
                     $app['dispatcher']
                 );
             };
@@ -362,7 +362,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app[$entryPoint],
                     null, // errorPage
                     null, // AccessDeniedHandlerInterface
-                    isset($app['logger']) ? $app['logger'] : null
+                    $app['logger']
                 );
             };
         });
@@ -385,7 +385,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app,
                     $app['security.http_utils'],
                     $options,
-                    isset($app['logger']) ? $app['logger'] : null
+                    $app['logger']
                 );
             };
         });
@@ -417,7 +417,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security.authentication.success_handler.'.$name],
                     $app['security.authentication.failure_handler.'.$name],
                     $options,
-                    isset($app['logger']) ? $app['logger'] : null,
+                    $app['logger'],
                     $app['dispatcher'],
                     isset($options['with_csrf']) && $options['with_csrf'] && isset($app['form.csrf_provider']) ? $app['form.csrf_provider'] : null
                 );
@@ -431,7 +431,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security.authentication_manager'],
                     $providerKey,
                     $app['security.entry_point.'.$providerKey.'.http'],
-                    isset($app['logger']) ? $app['logger'] : null
+                    $app['logger']
                 );
             };
         });
@@ -441,7 +441,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                 return new AnonymousAuthenticationListener(
                     $app['security'],
                     $providerKey,
-                    isset($app['logger']) ? $app['logger'] : null
+                    $app['logger']
                 );
             };
         });
@@ -489,7 +489,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security.user_checker'],
                     $name,
                     $app['security.access_manager'],
-                    isset($app['logger']) ? $app['logger'] : null,
+                    $app['logger'],
                     isset($options['parameter']) ? $options['parameter'] : '_switch_user',
                     isset($options['role']) ? $options['role'] : 'ROLE_ALLOWED_TO_SWITCH',
                     $app['dispatcher']

--- a/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
@@ -78,4 +78,26 @@ class DoctrineServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(array_key_exists('path', $params));
         $this->assertEquals(sys_get_temp_dir().'/silex', $params['path']);
     }
+
+    public function testLoggerLoading()
+    {
+        if (!in_array('sqlite', \PDO::getAvailableDrivers())) {
+            $this->markTestSkipped('pdo_sqlite is not available');
+        }
+
+        if (!class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger')){
+            $this->markTestSkipped('Symfony\Bridge\Doctrine\Logger\DbalLogger is not available');
+        }
+
+        $app = new Application();
+        $this->assertTrue(isset($app['logger']));
+        $this->assertTrue($app['logger'] == null);
+        $app->register(new DoctrineServiceProvider(), array(
+                'dbs.options' => array(
+                        'sqlite1' => array('driver' => 'pdo_sqlite', 'memory' => true)
+                )
+        ));
+        $this->assertEquals(22, $app['db']->fetchColumn('SELECT 22'));
+        $this->assertTrue($app['db']->getConfiguration()->getSQLLogger() == null);
+    }
 }


### PR DESCRIPTION
The `isset` checks on `$app['logger']` make no sense since `Application` always sets the logger (to `null`). Checks for `!empty` would be more safe/complete (altough `!empty && instance_of('LoggerInterface')` would be more ideal in some cases).
Updating the unit tests is more complicated because some code under test depends on classes outside of Silex.
Hacking the `class_exists` function or use `mocking` of classes that do not exists (@see https://github.com/sebastianbergmann/phpunit-mock-objects/issues/12) would effect the whole test suit (as @stof pointed out).
