### PR TITLE
Add an ability to users to add their own custom form types

### DIFF
--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -47,6 +47,10 @@ class FormServiceProvider implements ServiceProviderInterface
 
         $app['form.secret'] = md5(__DIR__);
 
+        $app['form.type.custom_types'] = function ($app) {
+            return array();
+        };
+
         $app['form.type.extensions'] = $app->share(function ($app) {
             return array();
         });
@@ -84,6 +88,7 @@ class FormServiceProvider implements ServiceProviderInterface
         $app['form.factory'] = $app->share(function ($app) {
             return Forms::createFormFactoryBuilder()
                 ->addExtensions($app['form.extensions'])
+                ->addTypes($app['form.type.custom_types'])
                 ->addTypeExtensions($app['form.type.extensions'])
                 ->addTypeGuessers($app['form.type.guessers'])
                 ->setResolvedTypeFactory($app['form.resolved_type_factory'])

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -14,6 +14,7 @@ namespace Silex\Tests\Provider;
 use Silex\Application;
 use Silex\Provider\FormServiceProvider;
 use Silex\Provider\TranslationServiceProvider;
+use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\Form\FormTypeGuesserChain;
@@ -27,6 +28,25 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         $app = new Application();
         $app->register(new FormServiceProvider());
         $this->assertInstanceOf('Symfony\Component\Form\FormFactory', $app['form.factory']);
+    }
+
+    public function testFormServiceProviderWillLoadCustomFormTypes()
+    {
+        $app = new Application();
+
+        $app->register(new FormServiceProvider());
+
+        $app->extend('form.type.custom_types', function($customTypes) {
+            $customTypes[] = new DummyFormType();
+
+            return $customTypes;
+        });
+
+        $form = $app['form.factory']->createBuilder('form', array())
+            ->add('dummy', 'dummy')
+            ->getForm();
+
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $form);
     }
 
     public function testFormServiceProviderWillLoadTypeExtensions()
@@ -91,6 +111,14 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($form->isValid());
         $this->assertContains('ERROR: German translation', $form->getErrorsAsString());
+    }
+}
+
+class DummyFormType extends AbstractType
+{
+    public function getName()
+    {
+        return 'dummy';
     }
 }
 


### PR DESCRIPTION
Example:

``` php
$app->extend('form.type.custom_types', function($customTypes) {
    $customTypes[] = new DummyFormType();
    return $customTypes;
});
...
$form = $app['form.factory']->createBuilder()
    ->add('dummy-field', 'dummy')
    ->getForm();
```
