### PR TITLE
Boot ServiceProvider before adding events.

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -164,13 +164,14 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
             $this->booted = true;
 
             foreach ($this->providers as $provider) {
+                if ($provider instanceof BootableProviderInterface) {
+                    $provider->boot($this);
+                }
+
                 if ($provider instanceof EventListenerProviderInterface) {
                     $provider->subscribe($this, $this['dispatcher']);
                 }
 
-                if ($provider instanceof BootableProviderInterface) {
-                    $provider->boot($this);
-                }
             }
         }
     }


### PR DESCRIPTION
It makes more sense that the first thing to happen is booting the
service provider, because it might contain some further customization.
