### PR TITLE
Try to resolve the #983 issus

### DIFF
--- a/src/Silex/Provider/Translation/Translator.php
+++ b/src/Silex/Provider/Translation/Translator.php
@@ -28,7 +28,9 @@ class Translator extends BaseTranslator
     {
         $this->app = $app;
 
-        parent::__construct(null, $selector);
+        $locale = $app['locale'] ?: null;
+
+        parent::__construct($locale, $selector);
     }
 
     public function getLocale()

--- a/src/Silex/Provider/TranslationServiceProvider.php
+++ b/src/Silex/Provider/TranslationServiceProvider.php
@@ -29,7 +29,7 @@ class TranslationServiceProvider implements ServiceProviderInterface
     {
         $app['translator'] = function ($app) {
             if (!isset($app['locale'])) {
-                throw new \LogicException('You must register the LocaleServiceProvider to use the TranslationServiceProvider');
+                throw new \LogicException('You must define \'locale\' parameter or register the LocaleServiceProvider to use the TranslationServiceProvider');
             }
 
             $translator = new Translator($app, $app['translator.message_selector']);

--- a/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
@@ -118,6 +118,26 @@ class TranslationServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('The german translation', $result);
     }
 
+    public function testInitialLocaleNotChange()
+    {
+        $app = $this->getPreparedApp();
+
+        $app['locale'] = 'fr';
+
+        $app['translator'];
+
+        $this->assertEquals('fr', $app['locale']);
+    }
+
+    public function testGettingLocaleViaTranslator()
+    {
+        $app = $this->getPreparedApp();
+
+        $app['locale'] = 'fr';
+
+        $this->assertEquals('fr', $app['translator']->getLocale());
+    }
+
     public function testChangingLocale()
     {
         $app = $this->getPreparedApp();


### PR DESCRIPTION
Try to resolve the #983 issue (particularly, the fact that Translator override $app['locale']).

But, for me, this solution is not acceptable yet because the "Silex Translator" can modify the $app['locale'] parameter. Why this side effect ?
