### PR TITLE
Allow custom JSON encoding options

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -445,6 +445,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         $response = new JsonResponse(null, $status, $headers);
         $response->setEncodingOptions($response->getEncodingOptions() | $encodingOptions);
         $response->setData($data);
+        
         return $response;
     }
 


### PR DESCRIPTION
Allow the caller to provide additional options to `json_encode`.
