### PR TITLE
Fixed DoctrineServiceProvider when no logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "symfony/dom-crawler": ">=2.4,<2.6-dev",
         "symfony/finder": ">=2.4,<2.6-dev",
         "symfony/monolog-bridge": ">=2.4,<2.6-dev",
+        "symfony/doctrine-bridge": ">=2.4,<2.6-dev",
         "symfony/options-resolver": ">=2.4,<2.6-dev",
         "symfony/process": ">=2.4,<2.6-dev",
         "symfony/serializer": ">=2.4,<2.6-dev",

--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -86,7 +86,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             $app['dbs.options.initializer']();
 
             $configs = new Container();
-            $addLogger = null !== $app['logger'] && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger');
+            $addLogger = isset($app['logger']) && null !== $app['logger'] && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger');
             foreach ($app['dbs.options'] as $name => $options) {
                 $configs[$name] = new Configuration();
                 if ($addLogger) {

--- a/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use Pimple\Container;
 use Silex\Application;
 use Silex\Provider\DoctrineServiceProvider;
 
@@ -85,13 +86,25 @@ class DoctrineServiceProviderTest extends \PHPUnit_Framework_TestCase
             $this->markTestSkipped('pdo_sqlite is not available');
         }
 
-        if (!class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger')) {
-            $this->markTestSkipped('Symfony\Bridge\Doctrine\Logger\DbalLogger is not available');
-        }
-
         $app = new Application();
         $this->assertTrue(isset($app['logger']));
         $this->assertNull($app['logger']);
+        $app->register(new DoctrineServiceProvider(), array(
+            'dbs.options' => array(
+                'sqlite1' => array('driver' => 'pdo_sqlite', 'memory' => true),
+            ),
+        ));
+        $this->assertEquals(22, $app['db']->fetchColumn('SELECT 22'));
+        $this->assertNull($app['db']->getConfiguration()->getSQLLogger());
+    }
+
+    public function testLoggerNotLoaded()
+    {
+        if (!in_array('sqlite', \PDO::getAvailableDrivers())) {
+            $this->markTestSkipped('pdo_sqlite is not available');
+        }
+
+        $app = new Container();
         $app->register(new DoctrineServiceProvider(), array(
             'dbs.options' => array(
                 'sqlite1' => array('driver' => 'pdo_sqlite', 'memory' => true),


### PR DESCRIPTION
When the provider is used with `Pimple` alone, it throws an exception if the `logger` is not defined.

It was previously working, but it seems to be introduced in https://github.com/silexphp/Silex/commit/784a24665de285cb8c31db2c12c4785eb5605773.
