### PR TITLE
unit test fail fixed

### DIFF
--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -110,7 +110,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         ))));
 
         $this->assertFalse($form->isValid());
-        $this->assertContains('ERROR: German translation', $form->getErrorsAsString());
+        $this->assertContains('ERROR: The CSRF token is invalid.', $form->getErrorsAsString());
     }
 }
 


### PR DESCRIPTION
I clone recent changes and run `phpunit` but unit test returned "fail". This fix with unit tests 100% success.
