### PR TITLE
Change closures to use $app as the first parameter.

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -62,12 +62,11 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
     {
         parent::__construct();
 
-        $app = $this;
-
         $this['routes_factory'] = $this->factory(function () {
             return new RouteCollection();
         });
-        $this['routes'] = function () use ($app) {
+
+        $this['routes'] = function ($app) {
             return $app['routes_factory'];
         };
 

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -71,36 +71,36 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
             return $app['routes_factory'];
         };
 
-        $this['controllers'] = function () use ($app) {
+        $this['controllers'] = function ($app) {
             return $app['controllers_factory'];
         };
 
-        $this['controllers_factory'] = $this->factory(function () use ($app) {
+        $this['controllers_factory'] = $this->factory(function ($app) {
             return new ControllerCollection($app['route_factory'], $app['routes_factory']);
         });
 
         $this['route_class'] = 'Silex\\Route';
-        $this['route_factory'] = $this->factory(function () use ($app) {
+        $this['route_factory'] = $this->factory(function ($app) {
             return new $app['route_class']();
         });
 
-        $this['exception_handler'] = function () use ($app) {
+        $this['exception_handler'] = function ($app) {
             return new ExceptionHandler($app['debug']);
         };
 
-        $this['callback_resolver'] = function () use ($app) {
+        $this['callback_resolver'] = function ($app) {
             return new CallbackResolver($app);
         };
 
-        $this['resolver'] = function () use ($app) {
+        $this['resolver'] = function ($app) {
             return new ControllerResolver($app, $app['logger']);
         };
 
-        $this['kernel'] = function () use ($app) {
+        $this['kernel'] = function ($app) {
             return new HttpKernel($app['dispatcher'], $app['resolver'], $app['request_stack']);
         };
 
-        $this['request_stack'] = function () use ($app) {
+        $this['request_stack'] = function () {
             return new RequestStack();
         };
 

--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -35,7 +35,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             'password' => null,
         );
 
-        $app['dbs.options.initializer'] = $app->protect(function ($app) {
+        $app['dbs.options.initializer'] = $app->protect(function () use ($app) {
             static $initialized = false;
 
             if ($initialized) {
@@ -60,7 +60,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
         });
 
         $app['dbs'] = function ($app) {
-            $app['dbs.options.initializer']($app);
+            $app['dbs.options.initializer']();
 
             $dbs = new Container();
             foreach ($app['dbs.options'] as $name => $options) {
@@ -82,7 +82,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
         };
 
         $app['dbs.config'] = function ($app) {
-            $app['dbs.options.initializer']($app);
+            $app['dbs.options.initializer']();
 
             $configs = new Container();
             $addLogger = isset($app['logger']) && null !== $app['logger'] && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger');
@@ -97,7 +97,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
         };
 
         $app['dbs.event_manager'] = function ($app) {
-            $app['dbs.options.initializer']($app);
+            $app['dbs.options.initializer']();
 
             $managers = new Container();
             foreach ($app['dbs.options'] as $name => $options) {

--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -35,7 +35,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             'password' => null,
         );
 
-        $app['dbs.options.initializer'] = $app->protect(function () use ($app) {
+        $app['dbs.options.initializer'] = $app->protect(function ($app) {
             static $initialized = false;
 
             if ($initialized) {
@@ -60,7 +60,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
         });
 
         $app['dbs'] = function ($app) {
-            $app['dbs.options.initializer']();
+            $app['dbs.options.initializer']($app);
 
             $dbs = new Container();
             foreach ($app['dbs.options'] as $name => $options) {
@@ -82,7 +82,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
         };
 
         $app['dbs.config'] = function ($app) {
-            $app['dbs.options.initializer']();
+            $app['dbs.options.initializer']($app);
 
             $configs = new Container();
             $addLogger = isset($app['logger']) && null !== $app['logger'] && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger');
@@ -97,7 +97,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
         };
 
         $app['dbs.event_manager'] = function ($app) {
-            $app['dbs.options.initializer']();
+            $app['dbs.options.initializer']($app);
 
             $managers = new Container();
             foreach ($app['dbs.options'] as $name => $options) {

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -34,11 +34,11 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
             return new UrlGenerator($app['routes'], $app['request_context']);
         };
 
-        $app['request_matcher'] = function () use ($app) {
+        $app['request_matcher'] = function ($app) {
             return new RedirectableUrlMatcher($app['routes'], $app['request_context']);
         };
 
-        $app['request_context'] = function () use ($app) {
+        $app['request_context'] = function ($app) {
             $context = new RequestContext();
 
             $context->setHttpPort(isset($app['request.http_port']) ? $app['request.http_port'] : 80);
@@ -47,7 +47,7 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
             return $context;
         };
 
-        $app['routing.listener'] = function () use ($app) {
+        $app['routing.listener'] = function ($app) {
             $urlMatcher = new LazyRequestMatcher(function () use ($app) {
                 return $app['request_matcher'];
             });

--- a/src/Silex/Provider/SerializerServiceProvider.php
+++ b/src/Silex/Provider/SerializerServiceProvider.php
@@ -35,7 +35,7 @@ class SerializerServiceProvider implements ServiceProviderInterface
      */
     public function register(Container $app)
     {
-        $app['serializer'] = function () use ($app) {
+        $app['serializer'] = function ($app) {
             return new Serializer($app['serializer.normalizers'], $app['serializer.encoders']);
         };
 


### PR DESCRIPTION
Almost always the first parameter is $app therefor it makes little sense
to use `use` part of the closure and having PHP do context switching all
over the place.

This also makes it explicit in the service providers exactly what $app
instance is used.