### PR TITLE
Remove PHPUnit as a development dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ before_script:
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.3' ]; then sed -i 's/>=2.3,<2.6-dev/2.3.*@dev/g' composer.json; composer update --dev --prefer-source; fi"
     - composer install --dev --prefer-source
 
-script: vendor/bin/phpunit
+script: phpunit
 
 php:
   - 5.3

--- a/composer.json
+++ b/composer.json
@@ -43,8 +43,7 @@
         "twig/twig": ">=1.8.0,<2.0-dev",
         "doctrine/dbal": "~2.2",
         "swiftmailer/swiftmailer": "5.*",
-        "monolog/monolog": "~1.4,>=1.4.1",
-        "phpunit/phpunit": "~4.0"
+        "monolog/monolog": "~1.4,>=1.4.1"
     },
     "suggest": {
         "symfony/browser-kit": ">=2.4,<2.6-dev",


### PR DESCRIPTION
This will make it more inline with how Symfony uses PHPUnit and already
considers this a tool installed when developing.

for reference as PR that rejects having phpunit as dependency in symfony
https://github.com/symfony/symfony/issues/12136
