### PR TITLE
Fix Monolog error where newer versions does not allow an empty stream

### DIFF
--- a/tests/Silex/Tests/Provider/MonologServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/MonologServiceProviderTest.php
@@ -66,7 +66,7 @@ class MonologServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app->register(new MonologServiceProvider());
         $app['monolog.formatter'] = new JsonFormatter();
-        $app['monolog.logfile'] = null;
+        $app['monolog.logfile'] = "php://memory";
 
         $this->assertInstanceOf('Monolog\Formatter\JsonFormatter', $app['logger']->popHandler()->getFormatter());
     }


### PR DESCRIPTION
Fixes an error with Monolog, only problem is that i think i have already done this PR once before, but it have gone missing.
