### PR TITLE
Re-added request service using request_stack one and returning current request

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -118,6 +118,10 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
             return new RequestStack();
         };
 
+        $this['request'] = function () use ($app) {
+            return $app['request_stack']->getCurrentRequest();
+        };
+
         $this['request.http_port'] = 80;
         $this['request.https_port'] = 443;
         $this['debug'] = false;


### PR DESCRIPTION
The WebProfilerBundle use the `app.request` key to be able to retreive the base url:
https://github.com/symfony/WebProfilerBundle/blob/0906ddfa721a1ad5aac4f97db51a77f4d2506ae6/Resources/views/Profiler/search.html.twig#L18

In Symfony the `app` twig global variable is an instance of `GlobalVariable` which contain a method `getRequest()`. This method internaly use the `request_stack` service.

But in Silex, the `app` twig global variable is the `Silex\Application` instance.
So we need to declare a service called `request` which internally use the `request_stack` service.

I don't know if another Silex service provider use the (old) `request` service.
I think It could be a great shortcut and it's one less migration to do for Silex 2.0.
