### PR TITLE
Introduce KernelServiceProvider in order to remove "hacks"

### DIFF
--- a/src/Silex/Provider/KernelServiceProvider.php
+++ b/src/Silex/Provider/KernelServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Silex\Provider;
+
+use Pimple\ServiceProviderInterface;
+use Pimple\Container;
+use Silex\Api\EventListenerProviderInterface;
+use Silex\EventListener\ConverterListener;
+use Silex\EventListener\MiddlewareListener;
+use Silex\EventListener\StringToResponseListener;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpKernel\EventListener\ResponseListener;
+
+class KernelServiceProvider implements ServiceProviderInterface, EventListenerProviderInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function register(Container $pimple)
+    {
+        $pimple['dispatcher'] = function () {
+            return new EventDispatcher();
+        };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function subscribe(Container $app, EventDispatcherInterface $dispatcher)
+    {
+        if (isset($app['exception_handler'])) {
+            $dispatcher->addSubscriber($app['exception_handler']);
+        }
+
+        $dispatcher->addSubscriber(new ResponseListener($app['charset']));
+        $dispatcher->addSubscriber(new MiddlewareListener($app));
+        $dispatcher->addSubscriber(new ConverterListener($app['routes'], $app['callback_resolver']));
+        $dispatcher->addSubscriber(new StringToResponseListener());
+    }
+}


### PR DESCRIPTION
This introduces a new KernelServiceProvider that is auto registered
by Silex\Application.

The main reason for including this is to remove the ugly
"dispatcher_class" hack we used to have. But since we introduced a
seperate interface for listeners to use for subscribing we can just have
a nice normal service.