### PR TITLE
Adding a default port for the connection to the database

### DIFF
--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -33,7 +33,7 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             'host'     => 'localhost',
             'user'     => 'root',
             'password' => null,
-            'port'     => null,
+            'port'     => 3306,
         );
 
         $app['dbs.options.initializer'] = $app->protect(function () use ($app) {


### PR DESCRIPTION
On HHVM an exception is thrown like what it is not a number.
