### PR TITLE
Fix: Require phpunit/phpunit as dev dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ before_script:
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.3' ]; then sed -i 's/~2.3/2.3.*@dev/g' composer.json; composer update --dev --prefer-source; fi"
     - composer install --dev --prefer-source
 
-script: phpunit
+script:
+    - vendor/bin/phpunit
 
 php:
   - 5.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.5' ]; then sed -i 's/~2.3/2.5.*@dev/g' composer.json; composer update --dev --prefer-source; fi"
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.4' ]; then sed -i 's/~2.3/2.4.*@dev/g' composer.json; composer update --dev --prefer-source; fi"
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.3' ]; then sed -i 's/~2.3/2.3.*@dev/g' composer.json; composer update --dev --prefer-source; fi"
-    - composer install --dev --prefer-source
+    - composer install --dev
 
 script:
     - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+sudo: false
+
 before_script:
     # symfony/*
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.7' ]; then sed -i 's/~2.3/2.7.*@dev/g' composer.json; composer update --dev --prefer-source; fi"

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: php
 
 sudo: false
 
+cache:
+    directories:
+      - $HOME/.composer/cache
+
 before_script:
     # symfony/*
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.7' ]; then sed -i 's/~2.3/2.7.*@dev/g' composer.json; composer update --dev --prefer-source; fi"

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,8 @@
         "twig/twig": ">=1.8.0,<2.0-dev",
         "doctrine/dbal": "~2.2",
         "swiftmailer/swiftmailer": "5.*",
-        "monolog/monolog": "~1.4,>=1.4.1"
+        "monolog/monolog": "~1.4,>=1.4.1",
+        "phpunit/phpunit": "~4.4"
     },
     "suggest": {
         "symfony/browser-kit": "~2.3",


### PR DESCRIPTION
The section running tests in about https://github.com/silexphp/Silex/blob/1.2/README.rst#tests is currently lying, and there are two options

* require users to install phpunit globally, remove the instructions on how to install dev depencencies, and change the line for running the tests to `$ phpunit` **or**
* require `phpunit/phpunit` as a dev depenceny