### PR TITLE
[1.2] Fix doc about running unit tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,12 +39,12 @@ Read the `documentation`_ for more information.
 Tests
 -----
 
-To run the test suite, you need `Composer`_:
+To run the test suite, you need `Composer`_ and `PHPUnit`_:
 
 .. code-block:: bash
 
-    $ php composer.phar install --dev
-    $ vendor/bin/phpunit
+    $ composer install
+    $ phpunit
 
 Community
 ---------
@@ -58,5 +58,6 @@ Silex is licensed under the MIT license.
 
 .. _Symfony2 components: http://symfony.com
 .. _Composer:            http://getcomposer.org
+.. _PHPUnit:             https://phpunit.de
 .. _silex.zip:           http://silex.sensiolabs.org/download
 .. _documentation:       http://silex.sensiolabs.org/documentation


### PR DESCRIPTION
Alternative to #1075.

I've kept the syntax using phpunit.phar as it must be the most portable way to run PHPUnit (like it is for Composer).