### PR TITLE
Fixes #1017 by cascading __call to mounted ControllerCollection

### DIFF
--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -42,6 +42,7 @@ class ControllerCollection
     protected $defaultRoute;
     protected $defaultController;
     protected $prefix;
+    protected $calls = array();
 
     /**
      * Constructor.
@@ -63,6 +64,11 @@ class ControllerCollection
     public function mount($prefix, ControllerCollection $controllers)
     {
         $controllers->prefix = $prefix;
+
+        foreach ($this->calls as $call) {
+            list($method, $arguments) = $call;
+            call_user_func_array(array($controllers, $method), $arguments);
+        }
 
         $this->controllers[] = $controllers;
     }
@@ -161,10 +167,10 @@ class ControllerCollection
         call_user_func_array(array($this->defaultRoute, $method), $arguments);
 
         foreach ($this->controllers as $controller) {
-            if ($controller instanceof Controller) {
-                call_user_func_array(array($controller, $method), $arguments);
-            }
+            call_user_func_array(array($controller, $method), $arguments);
         }
+
+        $this->calls[] = array($method, $arguments);
 
         return $this;
     }

--- a/src/Silex/EventListener/MiddlewareListener.php
+++ b/src/Silex/EventListener/MiddlewareListener.php
@@ -50,7 +50,7 @@ class MiddlewareListener implements EventSubscriberInterface
             return;
         }
 
-        foreach ((array) $route->getOption('_before_middlewares') as $callback) {
+        foreach (clone ($route->getOption('_before_middlewares') ?: new \SplPriorityQueue()) as $callback) {
             $ret = call_user_func($this->app['callback_resolver']->resolveCallback($callback), $request, $this->app);
             if ($ret instanceof Response) {
                 $event->setResponse($ret);
@@ -75,7 +75,7 @@ class MiddlewareListener implements EventSubscriberInterface
             return;
         }
 
-        foreach ((array) $route->getOption('_after_middlewares') as $callback) {
+        foreach (clone ($route->getOption('_after_middlewares') ?: new \SplPriorityQueue()) as $callback) {
             $response = call_user_func($this->app['callback_resolver']->resolveCallback($callback), $request, $event->getResponse(), $this->app);
             if ($response instanceof Response) {
                 $event->setResponse($response);

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -152,8 +152,8 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-    * @dataProvider escapeProvider
-    */
+     * @dataProvider escapeProvider
+     */
     public function testEscape($expected, $text)
     {
         $app = new Application();
@@ -349,6 +349,25 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $app->handle(Request::create('/foo'));
 
         $this->assertSame(array('route_triggered', 'middleware_triggered', 'after_triggered'), $middlewareTarget);
+    }
+
+    public function testRoutesMiddlewaresMultipleRequests()
+    {
+        $actualCalls = array('get' => 0, 'before' => 0);
+        $expectedCalls = array('get' => 5, 'before' => 5);
+
+        $app = new Application();
+
+        $app->get('/', function () use ($app, &$actualCalls) {
+            $actualCalls['get']++;
+        })->before(function () use ($app, &$actualCalls) {
+            $actualCalls['before']++;
+        });
+
+        for ($i = 0; $i < 5; $i++) {
+            $app->handle(Request::create('/'));
+        }
+        $this->assertEquals($expectedCalls, $actualCalls);
     }
 
     public function testFinishFilter()


### PR DESCRIPTION
all method calls that are handled by ControllerCollection::__call
will be recorded and replayed for a mounted ControllerCollection.

forward method calls to already mounted ControllerCollections
in the list of controllers.

include support for route-level middlewares using a priority
queue for the callbacks. insertion order is preserved by converting
the priority to an array and negative count as the subordinate
priority