### PR TITLE
Inject app in function or object that handler error.

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -490,7 +490,7 @@ takes an ``Exception`` argument and returns a response::
 
     use Symfony\Component\HttpFoundation\Response;
 
-    $app->error(function (\Exception $e, $request, $code) {
+    $app->error(function (\Exception $e, $request, $app, $code) {
         return new Response('We are sorry, but something went terribly wrong.');
     });
 
@@ -499,7 +499,7 @@ handle them differently::
 
     use Symfony\Component\HttpFoundation\Response;
 
-    $app->error(function (\Exception $e, $request, $code) {
+    $app->error(function (\Exception $e, $request, $app, $code) {
         switch ($code) {
             case 404:
                 $message = 'The requested page could not be found.';
@@ -523,7 +523,7 @@ handle them differently::
 You can restrict an error handler to only handle some Exception classes by
 setting a more specific type hint for the Closure argument::
 
-    $app->error(function (\LogicException $e, $request, $code) {
+    $app->error(function (\LogicException $e, $request, $app, $code) {
         // this handler will only handle \LogicException exceptions
         // and exceptions that extends \LogicException
     });
@@ -547,7 +547,7 @@ once a response is returned, the following handlers are ignored.
 
         use Symfony\Component\HttpFoundation\Response;
 
-        $app->error(function (\Exception $e, $request, $code) use ($app) {
+        $app->error(function (\Exception $e, $request, $app, $code) {
             if ($app['debug']) {
                 return;
             }

--- a/src/Silex/ExceptionListenerWrapper.php
+++ b/src/Silex/ExceptionListenerWrapper.php
@@ -50,7 +50,7 @@ class ExceptionListenerWrapper
 
         $code = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
 
-        $response = call_user_func($this->callback, $exception, $event->getRequest(), $code);
+        $response = call_user_func($this->callback, $exception, $event->getRequest(), $this->app, $code);
 
         $this->ensureResponse($response, $event);
     }

--- a/tests/Silex/Tests/ExceptionHandlerTest.php
+++ b/tests/Silex/Tests/ExceptionHandlerTest.php
@@ -136,7 +136,7 @@ class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
 
         $app->get('/405', function () { return 'foo'; });
 
-        $app->error(function ($e, $code) {
+        $app->error(function ($e) {
             return new Response('foo exception handler');
         });
 

--- a/tests/Silex/Tests/RouterTest.php
+++ b/tests/Silex/Tests/RouterTest.php
@@ -156,7 +156,7 @@ class RouterTest extends \PHPUnit_Framework_TestCase
             return new Response($request->getRequestUri());
         });
 
-        $app->error(function ($e, Request $request, $code) use ($app) {
+        $app->error(function ($e, Request $request, $app, $code) {
             return new Response($request->getRequestUri());
         });
 


### PR DESCRIPTION
Inject $app in function or object that handler error.
When we use a object like: 
```php 
$app->error(new ErrorHandler);
``` 
or a array like: 
```php 
$app->error(array('ErrorHandler', 'myMethod'));
``` 
we cant use $app inside the class. Now we can do it:
```php 
class ErrorHandler 
{
    public function __invoke(\Exception $exception, $request, $app, $code)
    {
        if ($app['debug']) {
            return;
        }

        $app['monolog']->addError(sprintf('An error occurred: %s', $exception->getMessage()));
    }
}
``` 
or
```php 
class ErrorHandler 
{
    public function myMethod(\Exception $exception, $request, $app, $code)
    {
        if ($app['debug']) {
            return;
        }

        $app['monolog']->addError(sprintf('An error occurred: %s', $exception->getMessage()));
    }
}
``` 