### PR TITLE
Fixes #1068 by checking if translation file exists before adding it as a resource

### DIFF
--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -78,7 +78,10 @@ class FormServiceProvider implements ServiceProviderInterface
 
                 if (isset($app['translator'])) {
                     $r = new \ReflectionClass('Symfony\Component\Form\Form');
-                    $app['translator']->addResource('xliff', dirname($r->getFilename()).'/Resources/translations/validators.'.$app['locale'].'.xlf', $app['locale'], 'validators');
+                    $file = dirname($r->getFilename()).'/Resources/translations/validators.'.$app['locale'].'.xlf';
+                    if (file_exists($file)) {
+                        $app['translator']->addResource('xliff', $file, $app['locale'], 'validators');
+                    }
                 }
             }
 

--- a/src/Silex/Provider/ValidatorServiceProvider.php
+++ b/src/Silex/Provider/ValidatorServiceProvider.php
@@ -31,7 +31,10 @@ class ValidatorServiceProvider implements ServiceProviderInterface
         $app['validator'] = $app->share(function ($app) {
             if (isset($app['translator'])) {
                 $r = new \ReflectionClass('Symfony\Component\Validator\Validator');
-                $app['translator']->addResource('xliff', dirname($r->getFilename()).'/Resources/translations/validators.'.$app['locale'].'.xlf', $app['locale'], 'validators');
+                $file = dirname($r->getFilename()).'/Resources/translations/validators.'.$app['locale'].'.xlf';
+                if (file_exists($file)) {
+                    $app['translator']->addResource('xliff', $file, $app['locale'], 'validators');
+                }
             }
 
             return new Validator(

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -131,7 +131,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         $translator = $app['translator'];
 
         try {
-            $translator->getMessages();
+            $translator->trans('test');
         } catch (NotFoundResourceException $e) {
             $this->fail('Form factory should not add a translation resource that does not exist');
         }

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -14,12 +14,14 @@ namespace Silex\Tests\Provider;
 use Silex\Application;
 use Silex\Provider\FormServiceProvider;
 use Silex\Provider\TranslationServiceProvider;
+use Silex\Provider\ValidatorServiceProvider;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\AbstractTypeExtension;
 use Symfony\Component\Form\Extension\Csrf\CsrfProvider\CsrfProviderInterface;
 use Symfony\Component\Form\FormTypeGuesserChain;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
 
 class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
 {
@@ -111,6 +113,28 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertFalse($form->isValid());
         $this->assertContains('ERROR: German translation', $form->getErrorsAsString());
+    }
+
+    public function testFormServiceProviderWillNotAddNonexistentTranslationFiles()
+    {
+        $app = new Application(array(
+            'locale' => 'nonexistent',
+        ));
+
+        $app->register(new FormServiceProvider());
+        $app->register(new ValidatorServiceProvider());
+        $app->register(new TranslationServiceProvider(), array(
+            'locale_fallbacks' => array(),
+        ));
+
+        $app['form.factory'];
+        $translator = $app['translator'];
+
+        try {
+            $translator->getMessages();
+        } catch (NotFoundResourceException $e) {
+            $this->fail('Form factory should not add a translation resource that does not exist');
+        }
     }
 }
 

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -120,7 +120,7 @@ class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
         $translator = $app['translator'];
 
         try {
-            $translator->getMessages();
+            $translator->trans('test');
         } catch (NotFoundResourceException $e) {
             $this->fail('Validator should not add a translation resource that does not exist');
         }

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -12,8 +12,10 @@
 namespace Silex\Tests\Provider;
 
 use Silex\Application;
+use Silex\Provider\TranslationServiceProvider;
 use Silex\Provider\ValidatorServiceProvider;
 use Silex\Provider\FormServiceProvider;
+use Symfony\Component\Translation\Exception\NotFoundResourceException;
 use Symfony\Component\Validator\Constraints as Assert;
 use Silex\Tests\Provider\ValidatorServiceProviderTest\Constraint\Custom;
 use Silex\Tests\Provider\ValidatorServiceProviderTest\Constraint\CustomValidator;
@@ -101,6 +103,27 @@ class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals($isValid, $form->isValid());
         $this->assertEquals($nbGlobalError, count($form->getErrors()));
         $this->assertEquals($nbEmailError, count($form->offsetGet('email')->getErrors()));
+    }
+
+    public function testValidatorWillNotAddNonexistentTranslationFiles()
+    {
+        $app = new Application(array(
+            'locale' => 'nonexistent',
+        ));
+
+        $app->register(new ValidatorServiceProvider());
+        $app->register(new TranslationServiceProvider(), array(
+            'locale_fallbacks' => array(),
+        ));
+
+        $app['validator'];
+        $translator = $app['translator'];
+
+        try {
+            $translator->getMessages();
+        } catch (NotFoundResourceException $e) {
+            $this->fail('Validator should not add a translation resource that does not exist');
+        }
     }
 
     public function testValidatorConstraintProvider()


### PR DESCRIPTION
Some locales (such as turkish) don't have translation files, which causes errors.