### PR TITLE
Allow global after middlewares to return responses like route specific ones

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -339,7 +339,12 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
                 return;
             }
 
-            call_user_func($app['callback_resolver']->resolveCallback($callback), $event->getRequest(), $event->getResponse(), $app);
+            $response = call_user_func($app['callback_resolver']->resolveCallback($callback), $event->getRequest(), $event->getResponse(), $app);
+            if ($response instanceof Response) {
+                $event->setResponse($response);
+            } elseif (null !== $response) {
+                throw new \RuntimeException('An after middleware returned an invalid response value. Must return null or an instance of Response.');
+            }
         }, $priority);
     }
 

--- a/tests/Silex/Tests/MiddlewareTest.php
+++ b/tests/Silex/Tests/MiddlewareTest.php
@@ -234,6 +234,20 @@ class MiddlewareTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('foo---', $app->handle($request)->getContent());
     }
 
+    public function testAfterFilterCanReturnResponse()
+    {
+        $app = new Application();
+
+        $app->after(function (Request $request, Response $response) {
+            return new Response('bar');
+        });
+
+        $app->match('/', function () { return new Response('foo'); });
+
+        $request = Request::create('/');
+        $this->assertEquals('bar', $app->handle($request)->getContent());
+    }
+
     public function testRouteAndApplicationMiddlewareParameterInjection()
     {
         $app = new Application();


### PR DESCRIPTION
Handling responses returned from after middlewares is already implemented in the middleware event listener, but was missing from the application's after method. https://github.com/naderman/Silex/blob/1.2/src/Silex/EventListener/MiddlewareListener.php#L79