### PR TITLE
__call() cascade on instanceof ControllerCollection.

### DIFF
--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -161,7 +161,7 @@ class ControllerCollection
         call_user_func_array(array($this->defaultRoute, $method), $arguments);
 
         foreach ($this->controllers as $controller) {
-            if ($controller instanceof Controller) {
+            if ($controller instanceof Controller || $controller instanceof ControllerCollection) {
                 call_user_func_array(array($controller, $method), $arguments);
             }
         }


### PR DESCRIPTION
I am not sure if this is expected behaviour or not, but this will not cascade `__call()` to children `ControllerCollection`s.

This PR fixes this.

See http://stackoverflow.com/questions/28098158/silex-controllercollection-not-cascading-call-to-fellow-controllercollection