### PR TITLE
Use the constant to refer to session auth strategy

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -311,7 +311,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
         };
 
         $app['security.session_strategy'] = function ($app) {
-            return new SessionAuthenticationStrategy('migrate');
+            return new SessionAuthenticationStrategy(SessionAuthenticationStrategy::MIGRATE);
         };
 
         $app['security.http_utils'] = function ($app) {


### PR DESCRIPTION
It is always better to refer to a constant with its name rather than its value.