### PR TITLE
Example of use of regular expressions when defining routes

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -152,7 +152,7 @@ early. It actually throws an exception, which you will see how to handle later
 on.
 
 You can also use regular expressions to control how variable parts of a route
-definition are matched:
+definition are matched::
 
     $app->get('/blog/{id}', function (Silex\Application $app, $id) use ($blogPosts) {
         // process blog post

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -151,6 +151,17 @@ When the post does not exist, you are using ``abort()`` to stop the request
 early. It actually throws an exception, which you will see how to handle later
 on.
 
+You can also use regular expressions to control how variable parts of a route
+definition are matched:
+
+    $app->get('/blog/{id}', function (Silex\Application $app, $id) use ($blogPosts) {
+        // process blog post
+    })
+    ->assert('id', '[0-9]+');
+
+The above route will only match requests where ``{id}`` consists of one or more
+digits.
+
 Example POST Route
 ~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
Current documentation mentions that regular expressions can be used in routes but does not provide an example.

It took me a while and some Googling before I found out how to do this, so I think an example on the page which describes routing would be useful.