### PR TITLE
Add OPTIONS request routing directly to Application

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -225,6 +225,19 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
     }
 
     /**
+     * Maps an OPTIONS request to a callable.
+     *
+     * @param string $pattern Matched route pattern
+     * @param mixed  $to      Callback that returns the response when matched
+     *
+     * @return Controller
+     */
+    public function options($pattern, $to = null)
+    {
+        return $this['controllers']->options($pattern, $to);
+    }
+
+    /**
      * Maps a PATCH request to a callable.
      *
      * @param string $pattern Matched route pattern

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -84,7 +84,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
             return new ExceptionHandler($app['debug']);
         };
 
-
         $this['callback_resolver'] = function () use ($app) {
             return new CallbackResolver($app);
         };

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -139,6 +139,19 @@ class ControllerCollection
     {
         return $this->match($pattern, $to)->method('DELETE');
     }
+    
+    /**
+     * Maps an OPTIONS request to a callable.
+     *
+     * @param string $pattern Matched route pattern
+     * @param mixed  $to      Callback that returns the response when matched
+     *
+     * @return Controller
+     */
+    public function options($pattern, $to = null)
+    {
+        return $this->match($pattern, $to)->method('OPTIONS');
+    }
 
     /**
      * Maps a PATCH request to a callable.

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -139,7 +139,7 @@ class ControllerCollection
     {
         return $this->match($pattern, $to)->method('DELETE');
     }
-    
+
     /**
      * Maps an OPTIONS request to a callable.
      *


### PR DESCRIPTION
I think it's important to add this HTTP Method directly to the application because it's often called automatically by browsers during AJAX requests. Meaning it's required that anyone sending AJAX requests to Silex will have to implement some kind of OPTIONS handling. I realize that you can use the match and method calls to do this same thing but those make routing OPTIONS requests less obvious. 