### PR TITLE
Patch debug and caching translator (Symfony 2.6+ with caching enabled).

### DIFF
--- a/src/Silex/Provider/TranslationServiceProvider.php
+++ b/src/Silex/Provider/TranslationServiceProvider.php
@@ -28,7 +28,7 @@ class TranslationServiceProvider implements ServiceProviderInterface
     public function register(Application $app)
     {
         $app['translator'] = $app->share(function ($app) {
-            $translator = new Translator($app, $app['translator.message_selector']);
+            $translator = new Translator($app, $app['translator.message_selector'], $app['translator.cache_dir'], $app['debug']);
 
             // Handle deprecated 'locale_fallback'
             if (isset($app['locale_fallback'])) {
@@ -55,6 +55,7 @@ class TranslationServiceProvider implements ServiceProviderInterface
 
         $app['translator.domains'] = array();
         $app['locale_fallbacks'] = array('en');
+        $app['translator.cache_dir'] = null;
     }
 
     public function boot(Application $app)

--- a/src/Silex/Translator.php
+++ b/src/Silex/Translator.php
@@ -23,11 +23,11 @@ class Translator extends BaseTranslator
 {
     protected $app;
 
-    public function __construct(Application $app, MessageSelector $selector)
+    public function __construct(Application $app, MessageSelector $selector, $cacheDir = null, $debug = false)
     {
         $this->app = $app;
 
-        parent::__construct(null, $selector);
+        parent::__construct(null, $selector, $cacheDir, $debug);
     }
 
     public function getLocale()


### PR DESCRIPTION
Patch debug and caching translator (Symfony 2.6+ with caching enabled).

API 2.6 : http://api.symfony.com/2.6/Symfony/Component/Translation/Translator.html