### PR TITLE
Flush spool queue for console terminate as well

### DIFF
--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -14,6 +14,7 @@ namespace Silex\Provider;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
+use Symfony\Component\Console\ConsoleEvents;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\PostResponseEvent;

--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -99,9 +99,9 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface, EventListe
                 $app['swiftmailer.spooltransport']->getSpool()->flushQueue($app['swiftmailer.transport']);
             }
         };
-        
+
         $dispatcher->addListener(KernelEvents::TERMINATE, $onTerminate);
-        
+
         if (class_exists('Symfony\Component\Console\ConsoleEvents')) {
             $dispatcher->addListener(ConsoleEvents::TERMINATE, $onTerminate);
         }

--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -92,12 +92,18 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface, EventListe
 
     public function subscribe(Container $app, EventDispatcherInterface $dispatcher)
     {
-        $dispatcher->addListener(KernelEvents::TERMINATE, function (PostResponseEvent $event) use ($app) {
+        $onTerminate = function (PostResponseEvent $event) use ($app) {
             // To speed things up (by avoiding Swift Mailer initialization), flush
             // messages only if our mailer has been created (potentially used)
             if ($app['mailer.initialized']) {
                 $app['swiftmailer.spooltransport']->getSpool()->flushQueue($app['swiftmailer.transport']);
             }
-        });
+        };
+        
+        $dispatcher->addListener(KernelEvents::TERMINATE, $onTerminate);
+        
+        if (class_exists('Symfony\Component\Console\ConsoleEvents')) {
+            $dispatcher->addListener(ConsoleEvents::TERMINATE, $onTerminate);
+        }
     }
 }


### PR DESCRIPTION
This allows to flush Swift messages automatically inside a Silex console application.

It basically does the same as the ``EmailSenderListener`` in Symfony's SwiftMailerBundle. (see https://github.com/symfony/SwiftmailerBundle/commit/4b90392463296acc9ccf8f10649d7ac4937ae0f3).

```php
use Symfony\Component\Console\Application;

$app = require __DIR__.'/app.php';

$console = new Application('My Silex Application', 'n/a');
$console->setDispatcher($app['dispatcher']);

// .. register commands that send emails

$console->run();
```