### PR TITLE
Correct exception message when mounting

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -500,8 +500,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
                 throw new \LogicException(sprintf('The method "%s::connect" must return a "ControllerCollection" instance. Got: "%s', get_class($controllers), is_object($connectedControllers) ? get_class($connectedControllers) : gettype($connectedControllers)));
             }
 
-			$controllers = $connectedControllers;
-
+            $controllers = $connectedControllers;
         } elseif (!$controllers instanceof ControllerCollection) {
             throw new \LogicException('The "mount" method takes either a "ControllerCollection" or a "ControllerProviderInterface" instance.');
         }

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -495,9 +495,12 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
     {
         if ($controllers instanceof ControllerProviderInterface) {
             $controllers = $controllers->connect($this);
-        }
+        
+            if (!$controllers instanceof ControllerCollection) {
+                throw new \LogicException('The ControllerProviderInterface must return a ControllerCollection instance for the "connect" method.');
+            }
 
-        if (!$controllers instanceof ControllerCollection) {
+        } elseif (!$controllers instanceof ControllerCollection) {
             throw new \LogicException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
         }
 

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -495,11 +495,10 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
     {
         if ($controllers instanceof ControllerProviderInterface) {
             $controllers = $controllers->connect($this);
-        
+
             if (!$controllers instanceof ControllerCollection) {
                 throw new \LogicException('The ControllerProviderInterface must return a ControllerCollection instance for the "connect" method.');
             }
-
         } elseif (!$controllers instanceof ControllerCollection) {
             throw new \LogicException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
         }

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -497,7 +497,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
             $connectedControllers = $controllers->connect($this);
 
             if (!$connectedControllers instanceof ControllerCollection) {
-                throw new \LogicException(sprintf('The method "%s::connect" must return a "ControllerCollection" instance. Got: "%s', get_class($controllers), is_object($connectedControllers) ? get_class($connectedControllers) : gettype($connectedControllers)));
+                throw new \LogicException(sprintf('The method "%s::connect" must return a "ControllerCollection" instance. Got: "%s"', get_class($controllers), is_object($connectedControllers) ? get_class($connectedControllers) : gettype($connectedControllers)));
             }
 
             $controllers = $connectedControllers;

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -494,13 +494,16 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
     public function mount($prefix, $controllers)
     {
         if ($controllers instanceof ControllerProviderInterface) {
-            $controllers = $controllers->connect($this);
+            $connectedControllers = $controllers->connect($this);
 
-            if (!$controllers instanceof ControllerCollection) {
-                throw new \LogicException('The ControllerProviderInterface must return a ControllerCollection instance for the "connect" method.');
+            if (!$connectedControllers instanceof ControllerCollection) {
+                throw new \LogicException(sprintf('The method "%s::connect" must return a "ControllerCollection" instance. Got: "%s', get_class($controllers), is_object($connectedControllers) ? get_class($connectedControllers) : gettype($connectedControllers)));
             }
+
+			$controllers = $connectedControllers;
+
         } elseif (!$controllers instanceof ControllerCollection) {
-            throw new \LogicException('The "mount" method takes either a ControllerCollection or a ControllerProviderInterface instance.');
+            throw new \LogicException('The "mount" method takes either a "ControllerCollection" or a "ControllerProviderInterface" instance.');
         }
 
         $this['controllers']->mount($prefix, $controllers);

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -13,6 +13,7 @@ namespace Silex\Tests;
 
 use Silex\Application;
 use Silex\ControllerCollection;
+use Silex\ControllerProviderInterface;
 use Silex\Route;
 use Silex\Provider\MonologServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -505,6 +506,26 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('first', 'second', 'third'), array_keys(iterator_to_array($app['routes'])));
     }
 
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage The "mount" method takes either a "ControllerCollection" or a "ControllerProviderInterface" instance.
+     */
+    public function testMountNullException()
+    {
+        $app = new Application();
+        $app->mount('/exception', null);
+    }
+
+    /**
+     * @expectedException        \LogicException
+     * @expectedExceptionMessage The method "Silex\Tests\IncorrectControllerCollection::connect" must return a "ControllerCollection" instance. Got: "NULL"
+     */
+    public function testMountWrongConnectReturnValueException()
+    {
+        $app = new Application();
+        $app->mount('/exception', new IncorrectControllerCollection());
+    }
+
     public function testSendFile()
     {
         $app = new Application();
@@ -549,5 +570,13 @@ class FooController
     public function barAction(Application $app, $name)
     {
         return 'Hello '.$app->escape($name);
+    }
+}
+
+class IncorrectControllerCollection implements ControllerProviderInterface
+{
+    public function connect(Application $app)
+    {
+        return null;
     }
 }

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -577,6 +577,6 @@ class IncorrectControllerCollection implements ControllerProviderInterface
 {
     public function connect(Application $app)
     {
-        return null;
+        return;
     }
 }


### PR DESCRIPTION
Use a better exception message when calling `mount` with a `ControllerProviderInterface` that doesn't return an `ControllerCollection` on the `connect` call.