### PR TITLE
Have `Controller::generateRouteName()` always put the method first.

### DIFF
--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -109,8 +109,6 @@ class Controller
     {
         $requirements = $this->route->getRequirements();
 
-        // The trailing underscore is required to separate the method from the
-        // prefix, if one is set.
         $method = isset($requirements['_method']) ? $requirements['_method'].'_' : '';
 
         $routeName = $method.$prefix.$this->route->getPath();
@@ -118,7 +116,7 @@ class Controller
         $routeName = preg_replace('/[^a-z0-9A-Z_.]+/', '', $routeName);
 
         // Collapse consecutive underscores down into a single underscore.
-        $routeName = preg_replace('/_{2,}/', '_', $routeName);
+        $routeName = preg_replace('/_+/', '_', $routeName);
 
         return $routeName;
     }

--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -107,11 +107,17 @@ class Controller
     public function generateRouteName($prefix)
     {
         $requirements = $this->route->getRequirements();
-        $method = isset($requirements['_method']) ? $requirements['_method'] : '';
 
-        $routeName = $prefix.$method.$this->route->getPath();
+        // The trailing underscore is required to separate the method from the
+        // prefix, if one is set.
+        $method = isset($requirements['_method']) ? $requirements['_method'].'_' : '';
+
+        $routeName = $method.$prefix.$this->route->getPath();
         $routeName = str_replace(array('/', ':', '|', '-'), '_', $routeName);
         $routeName = preg_replace('/[^a-z0-9A-Z_.]+/', '', $routeName);
+
+        // Collapse consecutive underscores down into a single underscore.
+        $routeName = preg_replace('/_{2,}/', '_', $routeName);
 
         return $routeName;
     }

--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -27,6 +27,7 @@ use Silex\Exception\ControllerFrozenException;
  * @method Controller requireHttps()
  * @method Controller before(mixed $callback)
  * @method Controller after(mixed $callback)
+ *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
 class Controller

--- a/tests/Silex/Tests/ControllerTest.php
+++ b/tests/Silex/Tests/ControllerTest.php
@@ -80,10 +80,10 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideRouteAndExpectedRouteName
      */
-    public function testDefaultRouteNameGeneration(Route $route, $expectedRouteName)
+    public function testDefaultRouteNameGeneration(Route $route, $prefix, $expectedRouteName)
     {
         $controller = new Controller($route);
-        $controller->bind($controller->generateRouteName(''));
+        $controller->bind($controller->generateRouteName($prefix));
 
         $this->assertEquals($expectedRouteName, $controller->getRouteName());
     }
@@ -91,10 +91,11 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function provideRouteAndExpectedRouteName()
     {
         return array(
-            array(new Route('/Invalid%Symbols#Stripped', array(), array('_method' => 'POST')), 'POST_InvalidSymbolsStripped'),
-            array(new Route('/post/{id}', array(), array('_method' => 'GET')), 'GET_post_id'),
-            array(new Route('/colon:pipe|dashes-escaped'), '_colon_pipe_dashes_escaped'),
-            array(new Route('/underscores_and.periods'), '_underscores_and.periods'),
+            array(new Route('/Invalid%Symbols#Stripped', array(), array('_method' => 'POST')), '', 'POST_InvalidSymbolsStripped'),
+            array(new Route('/post/{id}', array(), array('_method' => 'GET')), '', 'GET_post_id'),
+            array(new Route('/colon:pipe|dashes-escaped'), '', '_colon_pipe_dashes_escaped'),
+            array(new Route('/underscores_and.periods'), '', '_underscores_and.periods'),
+            array(new Route('/post/{id}', array(), array('_method' => 'GET')), 'prefix', 'GET_prefix_post_id'),
         );
     }
 


### PR DESCRIPTION
At present, mounted controllers can get weird route names. For instance, let's say you have this controller definition:

    $otherController = $app['controllers_factory'];
    $otherController->get('/{name}', function (Request $request, $name) use ($app) {
      return new Response("Goodbye $name!\n", 200, ['Content-Type' => 'text/plain']);
      });
    $app->mount('/goodbye', $otherController);

The generated route name in this case will be `_goodbyeGET_name`, which technically contains everything, but is ugly.

With this PR, the route name will change to `GET_goodbye_name`, which is considerably easier to parse when debugging.