### PR TITLE
auto inject controller argument

### DIFF
--- a/src/Silex/ControllerResolver.php
+++ b/src/Silex/ControllerResolver.php
@@ -44,6 +44,10 @@ class ControllerResolver extends BaseControllerResolver
                 $request->attributes->set($param->getName(), $this->app);
 
                 break;
+            } elseif ($param->getClass() && isset($this->app[$param->getClass()->getName()])) {
+                $request->attributes->set($param->getName(), $this->app[$param->getClass()->getName()]);
+
+                break;
             }
         }
 

--- a/tests/Silex/Tests/ControllerResolverTest.php
+++ b/tests/Silex/Tests/ControllerResolverTest.php
@@ -52,9 +52,5 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 
 /**
  * Dummy class
- * Class Foo
- * @package Silex\Tests
  */
-class Foo {
-
-}
+class Foo {}

--- a/tests/Silex/Tests/ControllerResolverTest.php
+++ b/tests/Silex/Tests/ControllerResolverTest.php
@@ -32,4 +32,29 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
         $args = $resolver->getArguments(Request::create('/'), $controller);
         $this->assertSame($app, $args[0]);
     }
+
+    public function testAutoInjectArguments()
+    {
+        $app = new Application();
+        $resolver = new ControllerResolver($app);
+
+        $app[Foo::class] = function () {
+            return new Foo();
+        };
+
+        $controller = function (Foo $foo) {};
+
+        $args = $resolver->getArguments(Request::create('/'), $controller);
+
+        $this->assertSame($app[Foo::class], $args[0]);
+    }
+}
+
+/**
+ * Dummy class
+ * Class Foo
+ * @package Silex\Tests
+ */
+class Foo {
+
 }

--- a/tests/Silex/Tests/ControllerResolverTest.php
+++ b/tests/Silex/Tests/ControllerResolverTest.php
@@ -51,6 +51,6 @@ class ControllerResolverTest extends \PHPUnit_Framework_TestCase
 }
 
 /**
- * Dummy class
+ * Dummy class.
  */
 class Foo {}


### PR DESCRIPTION
Automatically inject controller argument where parameter typehinted and object exist in container.

~~~php
public function indexAction(Request $request, Foo $foo) 
{

}
~~~

In order autoinject Foo, it must have defined in container

~~~php
// service ID must full classname of object
$app[Foo:class] = function () {
    return new Foo();
}
~~~