### PR TITLE
Have `Controller::generateRouteName()` always put the method first.

### DIFF
--- a/src/Silex/Controller.php
+++ b/src/Silex/Controller.php
@@ -107,11 +107,14 @@ class Controller
 
     public function generateRouteName($prefix)
     {
-        $methods = implode('_', $this->route->getMethods());
+        $methods = implode('_', $this->route->getMethods()).'_';
 
-        $routeName = $prefix.$methods.$this->route->getPath();
+        $routeName = $methods.$prefix.$this->route->getPath();
         $routeName = str_replace(array('/', ':', '|', '-'), '_', $routeName);
         $routeName = preg_replace('/[^a-z0-9A-Z_.]+/', '', $routeName);
+
+        // Collapse consecutive underscores down into a single underscore.
+        $routeName = preg_replace('/_+/', '_', $routeName);
 
         return $routeName;
     }

--- a/tests/Silex/Tests/ControllerTest.php
+++ b/tests/Silex/Tests/ControllerTest.php
@@ -80,10 +80,10 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     /**
      * @dataProvider provideRouteAndExpectedRouteName
      */
-    public function testDefaultRouteNameGeneration(Route $route, $expectedRouteName)
+    public function testDefaultRouteNameGeneration(Route $route, $prefix, $expectedRouteName)
     {
         $controller = new Controller($route);
-        $controller->bind($controller->generateRouteName(''));
+        $controller->bind($controller->generateRouteName($prefix));
 
         $this->assertEquals($expectedRouteName, $controller->getRouteName());
     }
@@ -91,10 +91,11 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function provideRouteAndExpectedRouteName()
     {
         return array(
-            array(new Route('/Invalid%Symbols#Stripped', array(), array(), array(), '', array(), array('POST')), 'POST_InvalidSymbolsStripped'),
-            array(new Route('/post/{id}', array(), array(), array(), '', array(), array('GET')), 'GET_post_id'),
-            array(new Route('/colon:pipe|dashes-escaped'), '_colon_pipe_dashes_escaped'),
-            array(new Route('/underscores_and.periods'), '_underscores_and.periods'),
+            array(new Route('/Invalid%Symbols#Stripped', array(), array(), array(), '', array(), array('POST')), '', 'POST_InvalidSymbolsStripped'),
+            array(new Route('/post/{id}', array(), array(), array(), '', array(), array('GET')), '', 'GET_post_id'),
+            array(new Route('/colon:pipe|dashes-escaped'), '', '_colon_pipe_dashes_escaped'),
+            array(new Route('/underscores_and.periods'), '', '_underscores_and.periods'),
+            array(new Route('/post/{id}', array(), array(), array(), '', array(), array('GET')), 'prefix', 'GET_prefix_post_id'),
         );
     }
 


### PR DESCRIPTION
(As requested, this is #1154 rebased against 1.3.)

At present, mounted controllers can get weird route names. For instance, let's say you have this controller definition:

    $otherController = $app['controllers_factory'];
    $otherController->get('/{name}', function (Request $request, $name) use ($app) {
      return new Response("Goodbye $name!\n", 200, ['Content-Type' => 'text/plain']);
      });
    $app->mount('/goodbye', $otherController);

The generated route name in this case will be `_goodbyeGET_name`, which technically contains everything, but is ugly.

With this PR, the route name will change to `GET_goodbye_name`, which is considerably easier to parse when debugging.