### PR TITLE
Easier user access

### DIFF
--- a/src/Silex/Application/SecurityTrait.php
+++ b/src/Silex/Application/SecurityTrait.php
@@ -23,7 +23,7 @@ use Symfony\Component\Security\Core\User\UserInterface;
 trait SecurityTrait
 {
     /**
-     * Gets a user from the Security Context.
+     * Gets a user from the Security context.
      *
      * @return mixed
      *
@@ -31,15 +31,7 @@ trait SecurityTrait
      */
     public function user()
     {
-        if (null === $token = $this['security.token_storage']->getToken()) {
-            return;
-        }
-
-        if (!is_object($user = $token->getUser())) {
-            return;
-        }
-
-        return $user;
+        return $this['user'];
     }
 
     /**

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -101,6 +101,18 @@ class SecurityServiceProvider implements ServiceProviderInterface
             });
         }
 
+        $app['user'] = function ($app) {
+            if (null === $token = $app['security.token_storage']->getToken()) {
+                return;
+            }
+
+            if (!is_object($user = $token->getUser())) {
+                return;
+            }
+
+            return $user;
+        };
+
         $app['security.authentication_manager'] = $app->share(function ($app) {
             $manager = new AuthenticationProviderManager($app['security.authentication_providers']);
             $manager->setEventDispatcher($app['dispatcher']);


### PR DESCRIPTION
In Silex 1.3, it's "harder" to get the user from the security layer as the `security` service has been deprecated. The code is already available in the security trait, but if you are not using it, you need to use a somewhat "complex" expression in templates to access it (see #1152)

This PR moves the code from the trait to the security service to make it available to everyone.

One question though: can we deprecate the trait `user()` function? It is not useful anymore after this PR.
