### PR TITLE
Changed Doctrine page to use utf8mb4 as sample

### DIFF
--- a/doc/providers/doctrine.rst
+++ b/doc/providers/doctrine.rst
@@ -103,7 +103,7 @@ and values are options::
                 'dbname'    => 'my_database',
                 'user'      => 'my_username',
                 'password'  => 'my_password',
-                'charset'   => 'utf8',
+                'charset'   => 'utf8mb4',
             ),
             'mysql_write' => array(
                 'driver'    => 'pdo_mysql',
@@ -111,7 +111,7 @@ and values are options::
                 'dbname'    => 'my_database',
                 'user'      => 'my_username',
                 'password'  => 'my_password',
-                'charset'   => 'utf8',
+                'charset'   => 'utf8mb4',
             ),
         ),
     ));


### PR DESCRIPTION
MySQL's `utf8` character set is a little broken, and does not cover 4-byte UTF-8 characters. In most cases it will quietly truncate the string whenever it sees one, saving incomplete text data.  

In  5.5.3 they introduced `utf8mb4` to fix this inconsistency, and given that it's been 5 years, it's probably safe to encourage people to use it. If their MySQL installation is older, it should be easy for them to find the distinctive string and change it back to `utf8`, and for a new project.

Additional details can be found in the equivalent [pull-request for Symfony-2](https://github.com/symfony/symfony-docs/pull/5100).