### PR TITLE
Change that if the app locale is empty use the one from the locale listener

### DIFF
--- a/src/Silex/EventListener/LocaleListener.php
+++ b/src/Silex/EventListener/LocaleListener.php
@@ -36,7 +36,9 @@ class LocaleListener extends BaseLocaleListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         parent::onKernelRequest($event);
-
-        $this->app['locale'] = $event->getRequest()->getLocale();
+        if($this->app['locale'] === null)
+        {
+          $this->app['locale'] = $event->getRequest()->getLocale();
+        }
     }
 }

--- a/src/Silex/EventListener/LocaleListener.php
+++ b/src/Silex/EventListener/LocaleListener.php
@@ -36,8 +36,7 @@ class LocaleListener extends BaseLocaleListener
     public function onKernelRequest(GetResponseEvent $event)
     {
         parent::onKernelRequest($event);
-        if($this->app['locale'] === null)
-        {
+        if($this->app['locale'] === null){
           $this->app['locale'] = $event->getRequest()->getLocale();
         }
     }


### PR DESCRIPTION
Setting the locale with $app['translator']->setLocale($lang); was always override by the listener on the onKernelRequest method:

$this->app['locale'] = $event->getRequest()->getLocale();

the $event->getRequest()->getLocale() was NULL so the default was given setting that to 'en' 

Changing that check first is a locale is set fix that problem.