### PR TITLE
Added factory for RouteCollection, makes subclassing of RouteCollection possible.

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -64,8 +64,11 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
         $app = $this;
 
-        $this['routes'] = function () {
+        $this['routes_factory'] = $this->factory(function () {
             return new RouteCollection();
+        });
+        $this['routes'] = function () use ($app) {
+            return $app['routes_factory'];
         };
 
         $this['controllers'] = function () use ($app) {
@@ -73,7 +76,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         };
 
         $this['controllers_factory'] = $this->factory(function () use ($app) {
-            return new ControllerCollection($app['route_factory']);
+            return new ControllerCollection($app['route_factory'], $app['routes_factory']);
         });
 
         $this['route_class'] = 'Silex\\Route';

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -42,10 +42,12 @@ class ControllerCollection
     protected $defaultRoute;
     protected $defaultController;
     protected $prefix;
+    protected $routesFactory;
 
-    public function __construct(Route $defaultRoute)
+    public function __construct(Route $defaultRoute, $routesFactory = null)
     {
         $this->defaultRoute = $defaultRoute;
+        $this->routesFactory = $routesFactory;
         $this->defaultController = function (Request $request) {
             throw new \LogicException(sprintf('The "%s" route must have code to run when it matches.', $request->attributes->get('_route')));
         };
@@ -186,7 +188,11 @@ class ControllerCollection
      */
     public function flush($prefix = '')
     {
-        $routes = new RouteCollection();
+        if (null === $this->routesFactory) {
+            $routes = new RouteCollection();
+        } else {
+            $routes = $this->routesFactory;
+        }
 
         foreach ($this->controllers as $controller) {
             if ($controller instanceof Controller) {

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -23,6 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * Application test cases.
@@ -635,6 +636,21 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('Hello view listener', $response->getContent());
     }
+
+    public function testDefaultRoutesFactory()
+    {
+        $app = new Application();
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $app['routes']);
+    }
+
+    public function testOverriddenRoutesFactory()
+    {
+        $app = new Application();
+        $app['routes_factory'] = $app->factory(function () {
+            return new RouteCollectionSubClass();
+        });
+        $this->assertInstanceOf('Silex\Tests\RouteCollectionSubClass', $app['routes']);
+    }
 }
 
 class FooController
@@ -651,4 +667,8 @@ class IncorrectControllerCollection implements ControllerProviderInterface
     {
         return;
     }
+}
+
+class RouteCollectionSubClass extends RouteCollection
+{
 }

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -11,10 +11,12 @@
 
 namespace Silex\Tests;
 
+use Silex\Application;
 use Silex\Controller;
 use Silex\ControllerCollection;
 use Silex\Exception\ControllerFrozenException;
 use Silex\Route;
+use Symfony\Component\Routing\RouteCollection;
 
 /**
  * ControllerCollection test cases.
@@ -194,6 +196,25 @@ class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(array('before'), $c2->getRoute()->getOption('_before_middlewares'));
         $this->assertEquals(array('before'), $c3->getRoute()->getOption('_before_middlewares'));
     }
+
+    public function testRoutesFactoryOmitted()
+    {
+        $controllers = new ControllerCollection(new Route());
+        $routes = $controllers->flush();
+        $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $routes);
+    }
+
+    public function testRoutesFactoryInConstructor()
+    {
+        $app = new Application();
+        $app['routes_factory'] = $app->factory(function () {
+            return new RouteCollectionSubClass2();
+        });
+
+        $controllers = new ControllerCollection(new Route(), $app['routes_factory']);
+        $routes = $controllers->flush();
+        $this->assertInstanceOf('Silex\Tests\RouteCollectionSubClass2', $routes);
+    }
 }
 
 class MyRoute1 extends Route
@@ -204,4 +225,8 @@ class MyRoute1 extends Route
     {
         $this->foo = $value;
     }
+}
+
+class RouteCollectionSubClass2 extends RouteCollection
+{
 }


### PR DESCRIPTION
Note: replaces #1174, which was targeting a wrong branch (and where I messed a bit with the commits ;)).

--

The aim of this PR is to allow developpers to subclass `Symfony\Component\Routing\RouteCollection` to change some of its behavior.

In most of my Silex apps, I figured I don't want the Symfony's `RouteCollection` regular behavior where if you define two routes with the same name (bad copy-paste for instance), the first route added simply gets overriden by the second. Instead, I would like to be able to throw an Exception if that happens. So I've written [a tiny subclass of RouteCollection](https://github.com/lschricke/symfony-strict-route-collection), but to be able to use it (through [a service provider like this](https://github.com/lschricke/silex-strict-route-collection-service-provider) for instance (needs to be updated for Silex 2)), I need to be able to replace `RouteCollection` by my subclass. This PR makes it possible.

Thanks! :)