### PR TITLE
Removing the default array to allow for $app config to be used

### DIFF
--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -50,12 +50,12 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface
             );
 
             $options = $app['swiftmailer.options'] = array_replace(array(
-                'host'       => 'localhost',
-                'port'       => 25,
-                'username'   => '',
-                'password'   => '',
+                'host' => 'localhost',
+                'port' => 25,
+                'username' => '',
+                'password' => '',
                 'encryption' => null,
-                'auth_mode'  => null,
+                'auth_mode' => null,
             ), $app['swiftmailer.options']);
 
             $transport->setHost($options['host']);

--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -23,7 +23,6 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface
 {
     public function register(Application $app)
     {
-        $app['swiftmailer.options'] = array();
         $app['swiftmailer.use_spool'] = true;
 
         $app['mailer.initialized'] = false;


### PR DESCRIPTION
This would allow $app to have the config options passed to swiftmailer's provider.