### PR TITLE
cascade route configuration for embedded route collection

### DIFF
--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -171,9 +171,7 @@ class ControllerCollection
         call_user_func_array(array($this->defaultRoute, $method), $arguments);
 
         foreach ($this->controllers as $controller) {
-            if ($controller instanceof Controller) {
-                call_user_func_array(array($controller, $method), $arguments);
-            }
+            call_user_func_array(array($controller, $method), $arguments);
         }
 
         return $this;

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -176,6 +176,24 @@ class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
         $controller = new ControllerCollection($route);
         $controller->bar();
     }
+
+    public function testNestedCollectionRouteCallbacks()
+    {
+        $cl1 = new ControllerCollection(new MyRoute1());
+        $cl2 = new ControllerCollection(new MyRoute1());
+
+        $c1 = $cl2->match('/c1', function () {});
+        $cl1->mount('/foo', $cl2);
+        $c2 = $cl2->match('/c2', function () {});
+        $cl1->before('before');
+        $c3 = $cl2->match('/c3', function () {});
+
+        $cl1->flush();
+
+        $this->assertEquals(array('before'), $c1->getRoute()->getOption('_before_middlewares'));
+        $this->assertEquals(array('before'), $c2->getRoute()->getOption('_before_middlewares'));
+        $this->assertEquals(array('before'), $c3->getRoute()->getOption('_before_middlewares'));
+    }
 }
 
 class MyRoute1 extends Route


### PR DESCRIPTION
In 4e6031e2, I added a safeguard by mistake which makes configuration on nested collection not possible. This fixes this issue but only for the upcoming 2.0 branch as it might break BC.

fixes #1017, #1100, and #1081
