### PR TITLE
create logdir if not exists

### DIFF
--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -55,6 +55,14 @@ class MonologServiceProvider implements ServiceProviderInterface
 
         $app['monolog.handler'] = function () use ($app) {
             $level = MonologServiceProvider::translateLevel($app['monolog.level']);
+            if (is_string($app['monolog.logfile']) && false === strpos($app['monolog.logfile'], '://')) {
+                $logdir = dirname($app['monolog.logfile']);
+                if (!is_dir($logdir)) {
+                    if (!@mkdir($logdir, 0755, true)) {
+                        throw new \Exception(sprintf('There is no logdir at: %s and its not createable!', $logdir));
+                    }
+                }
+            }
 
             return new StreamHandler($app['monolog.logfile'], $level, $app['monolog.bubble'], $app['monolog.permission']);
         };


### PR DESCRIPTION
Would be cool , if the provider guaranteed, that the log folder exists, where the logfile will be storred in.