### PR TITLE
Allow custom logout handlers when using custom authentication

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -488,6 +488,12 @@ class SecurityServiceProvider implements ServiceProviderInterface
                 );
             });
         });
+        
+        $app['security.authentication.logout_clear_data_handler._proto'] = $app->protect(function ($name, $options) use ($app) {
+            return $app->share(function () use ($name, $options, $app) {
+                return new SessionLogoutHandler();
+            });
+        });
 
         $app['security.authentication_listener.logout._proto'] = $app->protect(function ($name, $options) use ($app, $that) {
             return $app->share(function () use ($app, $name, $options, $that) {
@@ -500,6 +506,10 @@ class SecurityServiceProvider implements ServiceProviderInterface
                 if (!isset($app['security.authentication.logout_handler.'.$name])) {
                     $app['security.authentication.logout_handler.'.$name] = $app['security.authentication.logout_handler._proto']($name, $options);
                 }
+                
+                if (!isset($app['security.authentication.logout_clear_data_handler.'.$name])) {
+                    $app['security.authentication.logout_clear_data_handler.'.$name] = $app['security.authentication.logout_clear_data_handler._proto']($name, $options);
+                }
 
                 $listener = new LogoutListener(
                     $app['security.token_storage'],
@@ -509,7 +519,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
                     isset($options['with_csrf']) && $options['with_csrf'] && isset($app['form.csrf_provider']) ? $app['form.csrf_provider'] : null
                 );
 
-                $listener->addHandler(new SessionLogoutHandler());
+                $listener->addHandler($app['security.authentication.logout_clear_data_handler.'.$name]);
 
                 return $listener;
             });

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -488,7 +488,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
                 );
             });
         });
-        
+
         $app['security.authentication.logout_clear_data_handler._proto'] = $app->protect(function ($name, $options) use ($app) {
             return $app->share(function () use ($name, $options, $app) {
                 return new SessionLogoutHandler();
@@ -506,7 +506,7 @@ class SecurityServiceProvider implements ServiceProviderInterface
                 if (!isset($app['security.authentication.logout_handler.'.$name])) {
                     $app['security.authentication.logout_handler.'.$name] = $app['security.authentication.logout_handler._proto']($name, $options);
                 }
-                
+
                 if (!isset($app['security.authentication.logout_clear_data_handler.'.$name])) {
                     $app['security.authentication.logout_clear_data_handler.'.$name] = $app['security.authentication.logout_clear_data_handler._proto']($name, $options);
                 }


### PR DESCRIPTION
When using a custom authentication factory:
As of now, one can only select a Logout Success Handler(which is erroneously called logout handler, but I left the old name for compatibility's sake) which is called after the Logout handler was called and the logout was successful.
But custom authentication may need a custom Logout handler.(one may not want to use sessions at all, but custom cookies/etc.)
I've called it logout_clear_data_handler, since it clears data. And by default it should be SessionLogoutHandler();(the prototype for it).