### PR TITLE
Allowing the use of both objects and arrays for the register()

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -162,11 +162,11 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      * Registers a service provider.
      *
      * @param ServiceProviderInterface $provider A ServiceProviderInterface instance
-     * @param array                    $values   An array of values that customizes the provider
+     * @param array|Traversible        $values   An array or a Traversible of values that customizes the provider
      *
      * @return Application
      */
-    public function register(ServiceProviderInterface $provider, array $values = array())
+    public function register(ServiceProviderInterface $provider, $values = array())
     {
         $this->providers[] = $provider;
 

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -162,7 +162,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      * Registers a service provider.
      *
      * @param ServiceProviderInterface $provider A ServiceProviderInterface instance
-     * @param array|Traversible        $values   An array or a Traversible of values that customizes the provider
+     * @param array|Traversable        $values   An array or a Traversable of values that customizes the provider
      *
      * @return Application
      */


### PR DESCRIPTION
Sometimes we may like to use objects for lazy loading and whatsoever and since PHP has the Traversable interface, that should be perfectly fine.