### PR TITLE
removed flush() argument

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -399,12 +399,10 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
 
     /**
      * Flushes the controller collection.
-     *
-     * @param string $prefix The route prefix
      */
-    public function flush($prefix = '')
+    public function flush()
     {
-        $this['routes']->addCollection($this['controllers']->flush($prefix));
+        $this['routes']->addCollection($this['controllers']->flush());
     }
 
     /**

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -182,11 +182,9 @@ class ControllerCollection
     /**
      * Persists and freezes staged controllers.
      *
-     * @param string $prefix
-     *
      * @return RouteCollection A RouteCollection instance
      */
-    public function flush($prefix = '')
+    public function flush()
     {
         if (null === $this->routesFactory) {
             $routes = new RouteCollection();
@@ -194,7 +192,7 @@ class ControllerCollection
             $routes = $this->routesFactory;
         }
 
-        return $this->doFlush($prefix, $routes);
+        return $this->doFlush('', $routes);
     }
 
     private function doFlush($prefix, RouteCollection $routes)


### PR DESCRIPTION
I propose to remove the `flush()` prefix argument as I don't see any use case. I think it was there because the method is recursive, but that's leaking an implementation detail. Passing a prefix was not documented.
