### PR TITLE
Allow to change variable name with converter

### DIFF
--- a/src/Silex/EventListener/ConverterListener.php
+++ b/src/Silex/EventListener/ConverterListener.php
@@ -49,10 +49,12 @@ class ConverterListener implements EventSubscriberInterface
         $request = $event->getRequest();
         $route = $this->routes->get($request->attributes->get('_route'));
         if ($route && $converters = $route->getOption('_converters')) {
-            foreach ($converters as $name => $callback) {
+            foreach ($converters as $name => list($callback, $newName)) {
                 $callback = $this->callbackResolver->resolveCallback($callback);
 
-                $request->attributes->set($name, call_user_func($callback, $request->attributes->get($name), $request));
+                $attribute = $request->attributes->get($name);
+                $request->attributes->remove($name);
+                $request->attributes->set($newName, call_user_func($callback, $attribute, $request));
             }
         }
     }

--- a/src/Silex/Route.php
+++ b/src/Silex/Route.php
@@ -90,13 +90,14 @@ class Route extends BaseRoute
      *
      * @param string $variable The variable name
      * @param mixed  $callback A PHP callback that converts the original value
+     * @param string $variable The new variable name (defaults to the variable name)
      *
      * @return Route $this The current Route instance
      */
-    public function convert($variable, $callback)
+    public function convert($variable, $callback, $newVariableName = null)
     {
         $converters = $this->getOption('_converters');
-        $converters[$variable] = $callback;
+        $converters[$variable] = [$callback, $newVariableName ?: $variable];
         $this->setOption('_converters', $converters);
 
         return $this;

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -154,11 +154,11 @@ class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
     public function testConvert()
     {
         $controllers = new ControllerCollection(new Route());
-        $controllers->convert('id', '1');
+        $controllers->convert('id', '1', 'object');
         $controller = $controllers->match('/{id}/{name}/{extra}', function () {})->convert('name', 'Fabien')->convert('extra', 'Symfony');
         $controllers->convert('extra', 'Twig');
 
-        $this->assertEquals(array('id' => '1', 'name' => 'Fabien', 'extra' => 'Twig'), $controller->getRoute()->getOption('_converters'));
+        $this->assertEquals(array('id' => ['1', 'object'], 'name' => ['Fabien', 'name'], 'extra' => ['Twig', 'extra']), $controller->getRoute()->getOption('_converters'));
     }
 
     public function testRequireHttp()

--- a/tests/Silex/Tests/ControllerTest.php
+++ b/tests/Silex/Tests/ControllerTest.php
@@ -65,7 +65,16 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
         $ret = $controller->convert('bar', $func = function ($bar) { return $bar; });
 
         $this->assertSame($ret, $controller);
-        $this->assertEquals(array('bar' => $func), $controller->getRoute()->getOption('_converters'));
+        $this->assertEquals(array('bar' => [$func, 'bar']), $controller->getRoute()->getOption('_converters'));
+    }
+
+    public function testConvertRename()
+    {
+        $controller = new Controller(new Route('/foo/{bar}'));
+        $ret = $controller->convert('bar', $func = function ($bar) { return $bar; }, 'taz');
+
+        $this->assertSame($ret, $controller);
+        $this->assertEquals(array('bar' => [$func, 'taz']), $controller->getRoute()->getOption('_converters'));
     }
 
     public function testRun()


### PR DESCRIPTION
sometimes the name of a route parameter does not fit exactly for the name of the converted object, this allows to optionally set a new name for a converted variable

usage:

```php
$app->get('/user/:username', function(UserInterface $user) {
    // ...
})->convert('username', 'provider.user: loadUserByUsername', 'user');
```