### PR TITLE
Remove duplicate call to add collection

### DIFF
--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -210,7 +210,7 @@ class ControllerCollection
                 $routes->add($name, $controller->getRoute());
                 $controller->freeze();
             } else {
-                $routes->addCollection($controller->doFlush($prefix.$controller->prefix, $routes));
+                $controller->doFlush($prefix.$controller->prefix, $routes);
             }
         }
 


### PR DESCRIPTION
`doFlush` returns the same `RouteCollection` instance now, so there's no need to add the sub-collection routes to itself.