### PR TITLE
Use ArgumentResolver instead of ControllerResolver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
             "email": "igor@wiedler.ch"
         }
     ],
+    "repositories" : [
+        { "type" : "vcs", "url" : "http://github.com/WouterJ/symfony" }
+    ],
     "require": {
         "php": ">=5.5.9",
         "pimple/pimple": "~3.0",
@@ -45,7 +48,9 @@
         "twig/twig": ">=1.8.0,<2.0-dev",
         "doctrine/dbal": "~2.2",
         "swiftmailer/swiftmailer": "5.*",
-        "monolog/monolog": "~1.4,>=1.4.1"
+        "monolog/monolog": "~1.4,>=1.4.1",
+        "symfony/symfony" : "dev-pr_11457 as 2.8.0"
+
     },
     "suggest": {
         "symfony/browser-kit": "~2.7",

--- a/src/Silex/ArgumentResolver/ApplicationArgumentResolver.php
+++ b/src/Silex/ArgumentResolver/ApplicationArgumentResolver.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Silex\ArgumentResolver;
+
+use Pimple\Container;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolver\ArgumentResolverInterface;
+
+class ApplicationArgumentResolver implements ArgumentResolverInterface
+{
+    private $pimple;
+
+    /**
+     * @param Container $pimple
+     */
+    public function __construct(Container $pimple)
+    {
+        $this->pimple = $pimple;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, \ReflectionParameter $parameter)
+    {
+        $class = $parameter->getClass();
+
+        return $class && $class->isInstance($this->pimple);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, \ReflectionParameter $parameter)
+    {
+        return $this->pimple;
+    }
+}

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -17,6 +17,7 @@ use Silex\Application;
 use Silex\Api\BootableProviderInterface;
 use Silex\Api\ControllerProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
+use Symfony\Bundle\SecurityBundle\ArgumentResolver\UserArgumentResolver;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpFoundation\Request;
@@ -569,6 +570,14 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
             };
 
             $app['validator.validator_service_ids'] = array_merge($app['validator.validator_service_ids'], array('security.validator.user_password' => 'security.validator.user_password_validator'));
+        }
+
+        if (class_exists('Symfony\Bundle\SecurityBundle\ArgumentResolver\UserArgumentResolver')) {
+            $app->extend('argument_resolvers', function ($resolvers, $app) {
+                $resolvers[] = new UserArgumentResolver($app['security.token_storage']);
+
+                return $resolvers;
+            });
         }
     }
 

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -177,6 +177,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     public function testControllersAsMethods()
     {
         $app = new Application();
+        $app['debug'] = true;
 
         $app->get('/{name}', 'Silex\Tests\FooController::barAction');
 


### PR DESCRIPTION
This lets us use the standard ControllerResolver and provides
more flexibility by letting users register additional ArgumentResolvers
which could be shared by FrameworkExtra bundle etc.

This obviously needs symfony/symfony#14971 to be merged first.

Additional stuff to add.

- [x] Use the psr-7 bridge for auto converting requests.
- [x] user argument resolver