### PR TITLE
Move Services into ServiceProvider

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -15,7 +15,6 @@ use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\TerminableInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -24,12 +23,10 @@ use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpFoundation\Request;
-use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpFoundation\JsonResponse;
-use Symfony\Component\Routing\RouteCollection;
 use Silex\Api\BootableProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
 use Silex\Api\ControllerProviderInterface;
@@ -61,47 +58,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
     public function __construct(array $values = array())
     {
         parent::__construct();
-
-        $this['routes_factory'] = $this->factory(function () {
-            return new RouteCollection();
-        });
-
-        $this['routes'] = function ($app) {
-            return $app['routes_factory'];
-        };
-
-        $this['controllers'] = function ($app) {
-            return $app['controllers_factory'];
-        };
-
-        $this['controllers_factory'] = $this->factory(function ($app) {
-            return new ControllerCollection($app['route_factory'], $app['routes_factory']);
-        });
-
-        $this['route_class'] = 'Silex\\Route';
-        $this['route_factory'] = $this->factory(function ($app) {
-            return new $app['route_class']();
-        });
-
-        $this['exception_handler'] = function ($app) {
-            return new ExceptionHandler($app['debug']);
-        };
-
-        $this['callback_resolver'] = function ($app) {
-            return new CallbackResolver($app);
-        };
-
-        $this['resolver'] = function ($app) {
-            return new ControllerResolver($app, $app['logger']);
-        };
-
-        $this['kernel'] = function ($app) {
-            return new HttpKernel($app['dispatcher'], $app['resolver'], $app['request_stack']);
-        };
-
-        $this['request_stack'] = function () {
-            return new RequestStack();
-        };
 
         $this['request.http_port'] = 80;
         $this['request.https_port'] = 443;

--- a/src/Silex/Provider/KernelServiceProvider.php
+++ b/src/Silex/Provider/KernelServiceProvider.php
@@ -6,7 +6,6 @@ use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
 use Silex\CallbackResolver;
-use Silex\ControllerCollection;
 use Silex\ControllerResolver;
 use Silex\EventListener\ConverterListener;
 use Silex\EventListener\MiddlewareListener;
@@ -25,14 +24,6 @@ class KernelServiceProvider implements ServiceProviderInterface, EventListenerPr
      */
     public function register(Container $app)
     {
-        $app['controllers'] = function ($app) {
-            return $app['controllers_factory'];
-        };
-
-        $app['controllers_factory'] = $app->factory(function ($app) {
-            return new ControllerCollection($app['route_factory'], $app['routes_factory']);
-        });
-
         $app['exception_handler'] = function ($app) {
             return new ExceptionHandler($app['debug']);
         };

--- a/src/Silex/Provider/KernelServiceProvider.php
+++ b/src/Silex/Provider/KernelServiceProvider.php
@@ -2,26 +2,61 @@
 
 namespace Silex\Provider;
 
-use Pimple\ServiceProviderInterface;
 use Pimple\Container;
+use Pimple\ServiceProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
+use Silex\CallbackResolver;
+use Silex\ControllerCollection;
+use Silex\ControllerResolver;
 use Silex\EventListener\ConverterListener;
 use Silex\EventListener\MiddlewareListener;
 use Silex\EventListener\StringToResponseListener;
+use Silex\ExceptionHandler;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
+use Symfony\Component\HttpKernel\HttpKernel;
 
 class KernelServiceProvider implements ServiceProviderInterface, EventListenerProviderInterface
 {
     /**
      * {@inheritdoc}
      */
-    public function register(Container $pimple)
+    public function register(Container $app)
     {
-        $pimple['dispatcher'] = function () {
+        $app['controllers'] = function ($app) {
+            return $app['controllers_factory'];
+        };
+
+        $app['controllers_factory'] = $app->factory(function ($app) {
+            return new ControllerCollection($app['route_factory'], $app['routes_factory']);
+        });
+
+        $app['exception_handler'] = function ($app) {
+            return new ExceptionHandler($app['debug']);
+        };
+
+        $app['resolver'] = function ($app) {
+            return new ControllerResolver($app, $app['logger']);
+        };
+
+        $app['kernel'] = function ($app) {
+            return new HttpKernel($app['dispatcher'], $app['resolver'], $app['request_stack']);
+        };
+
+        $app['request_stack'] = function () {
+            return new RequestStack();
+        };
+
+        $app['dispatcher'] = function () {
             return new EventDispatcher();
         };
+
+        $app['callback_resolver'] = function ($app) {
+            return new CallbackResolver($app);
+        };
+
     }
 
     /**

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -6,7 +6,7 @@
  * (c) Fabien Potencier <fabien@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
+ * file that was distributed with app source code.
  */
 
 namespace Silex\Provider;
@@ -16,6 +16,7 @@ use Pimple\ServiceProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
 use Silex\Provider\Routing\RedirectableUrlMatcher;
 use Silex\Provider\Routing\LazyRequestMatcher;
+use Symfony\Component\Routing\RouteCollection;
 use Symfony\Component\Routing\Generator\UrlGenerator;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\HttpKernel\EventListener\RouterListener;
@@ -30,6 +31,18 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
 {
     public function register(Container $app)
     {
+        $app['route_class'] = 'Silex\\Route';
+        $app['route_factory'] = $app->factory(function ($app) {
+            return new $app['route_class']();
+        });
+
+        $app['routes_factory'] = $app->factory(function () {
+            return new RouteCollection();
+        });
+
+        $app['routes'] = function ($app) {
+            return $app['routes_factory'];
+        };
         $app['url_generator'] = function ($app) {
             return new UrlGenerator($app['routes'], $app['request_context']);
         };

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -33,6 +33,7 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
     public function register(Container $app)
     {
         $app['route_class'] = 'Silex\\Route';
+
         $app['route_factory'] = $app->factory(function ($app) {
             return new $app['route_class']();
         });
@@ -68,7 +69,6 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
         $app['controllers_factory'] = $app->factory(function ($app) {
             return new ControllerCollection($app['route_factory'], $app['routes_factory']);
         });
-
 
         $app['routing.listener'] = function ($app) {
             $urlMatcher = new LazyRequestMatcher(function () use ($app) {

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -6,13 +6,14 @@
  * (c) Fabien Potencier <fabien@symfony.com>
  *
  * For the full copyright and license information, please view the LICENSE
- * file that was distributed with app source code.
+ * file that was distributed with this source code.
  */
 
 namespace Silex\Provider;
 
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use Silex\ControllerCollection;
 use Silex\Api\EventListenerProviderInterface;
 use Silex\Provider\Routing\RedirectableUrlMatcher;
 use Silex\Provider\Routing\LazyRequestMatcher;
@@ -59,6 +60,15 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
 
             return $context;
         };
+
+        $app['controllers'] = function ($app) {
+            return $app['controllers_factory'];
+        };
+
+        $app['controllers_factory'] = $app->factory(function ($app) {
+            return new ControllerCollection($app['route_factory'], $app['routes_factory']);
+        });
+
 
         $app['routing.listener'] = function ($app) {
             $urlMatcher = new LazyRequestMatcher(function () use ($app) {


### PR DESCRIPTION
Some time ago we added KernelServiceProvider and RoutingServiceProvider. I have taken the rest of the services defined directly in the Silex\Application class and moved them into those two service providers.

This makes Application more of a delegation class.