### PR TITLE
Remove mandatory dependency on request_stack and some monolog improvements

### DIFF
--- a/src/Silex/Provider/TranslationServiceProvider.php
+++ b/src/Silex/Provider/TranslationServiceProvider.php
@@ -54,9 +54,11 @@ class TranslationServiceProvider implements ServiceProviderInterface, EventListe
             return $translator;
         };
 
-        $app['translator.listener'] = function ($app) {
-            return new TranslatorListener($app['translator'], $app['request_stack']);
-        };
+        if (isset($app['request_stack'])) {
+            $app['translator.listener'] = function ($app) {
+                return new TranslatorListener($app['translator'], $app['request_stack']);
+            };
+        }
 
         $app['translator.message_selector'] = function () {
             return new MessageSelector();
@@ -73,6 +75,8 @@ class TranslationServiceProvider implements ServiceProviderInterface, EventListe
 
     public function subscribe(Container $app, EventDispatcherInterface $dispatcher)
     {
-        $dispatcher->addSubscriber($app['translator.listener']);
+        if (isset($app['translator.listener'])) {
+            $dispatcher->addSubscriber($app['translator.listener']);
+        }
     }
 }

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -44,7 +44,9 @@ class TwigServiceProvider implements ServiceProviderInterface
             if (isset($app['security.token_storage'])) {
                 $var->setTokenStorage($app['security.token_storage']);
             }
-            $var->setRequestStack($app['request_stack']);
+            if (isset($app['request_stack'])) {
+                $var->setRequestStack($app['request_stack']);
+            }
             $var->setDebug($app['debug']);
 
             return $var;
@@ -67,8 +69,10 @@ class TwigServiceProvider implements ServiceProviderInterface
             }
 
             if (class_exists('Symfony\Bridge\Twig\Extension\RoutingExtension')) {
-                $twig->addExtension(new HttpFoundationExtension($app['request_stack']));
-                $twig->addExtension(new RoutingExtension($app['url_generator']));
+                if (isset($app['request_stack'])) {
+                    $twig->addExtension(new HttpFoundationExtension($app['request_stack']));
+                    $twig->addExtension(new RoutingExtension($app['url_generator']));
+                }
 
                 if (isset($app['translator'])) {
                     $twig->addExtension(new TranslationExtension($app['translator']));


### PR DESCRIPTION
This lets everything work with Silex which lacks a request_stack, and I also made a couple changes to the monolog bootstrapping so it's easier to just override the monolog.handler OR monolog.handlers, before you kinda had to redefine both to customize anything.

I also moved the monolog.handler.debug out of the GroupHandler which makes more sense I think because if it is in the group then it falls under the not_found_activation_strategy and therefore even in debug mode you won't get any logs unless you get an error-level record.