### PR TITLE
Verify that the spool is enabled and an actual spool before flushing it

### DIFF
--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -102,7 +102,7 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface, EventListe
         $onTerminate = function (PostResponseEvent $event) use ($app) {
             // To speed things up (by avoiding Swift Mailer initialization), flush
             // messages only if our mailer has been created (potentially used)
-            if ($app['mailer.initialized']) {
+            if ($app['mailer.initialized'] && $app['swiftmailer.use_spool'] && $app['swiftmailer.spooltransport'] instanceof \Swift_Transport_SpoolTransport) {
                 $app['swiftmailer.spooltransport']->getSpool()->flushQueue($app['swiftmailer.transport']);
             }
         };


### PR DESCRIPTION
At least the use_spool check is necessary, the other third check IMO is a nice safeguard because for example I had redefined the swiftmailer.spooltransport to be swiftmailer.transport as a workaround (I don't think use_spool existed back then).