### PR TITLE
Fix TwigServiceProvider if no Symfony\Bridge\Twig available

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -39,18 +39,20 @@ class TwigServiceProvider implements ServiceProviderInterface
         $app['twig.path'] = array();
         $app['twig.templates'] = array();
 
-        $app['twig.app_variable'] = function ($app) {
-            $var = new AppVariable();
-            if (isset($app['security.token_storage'])) {
-                $var->setTokenStorage($app['security.token_storage']);
-            }
-            if (isset($app['request_stack'])) {
-                $var->setRequestStack($app['request_stack']);
-            }
-            $var->setDebug($app['debug']);
+        if (class_exists('Symfony\Bridge\Twig\AppVariable')) {
+            $app['twig.app_variable'] = function ($app) {
+                $var = new AppVariable();
+                if (isset($app['security.token_storage'])) {
+                    $var->setTokenStorage($app['security.token_storage']);
+                }
+                if (isset($app['request_stack'])) {
+                    $var->setRequestStack($app['request_stack']);
+                }
+                $var->setDebug($app['debug']);
 
-            return $var;
-        };
+                return $var;
+            };
+        }
 
         $app['twig'] = function ($app) {
             $app['twig.options'] = array_replace(
@@ -62,7 +64,7 @@ class TwigServiceProvider implements ServiceProviderInterface
             );
 
             $twig = $app['twig.environment_factory']($app);
-            $twig->addGlobal('app', $app['twig.app_variable']);
+            $twig->addGlobal('app', isset($app['twig.app_variable']) ? $app['twig.app_variable'] : $app);
 
             if ($app['debug']) {
                 $twig->addExtension(new \Twig_Extension_Debug());


### PR DESCRIPTION
As already described in https://github.com/silexphp/Silex/pull/1231#issuecomment-136828673 the change introduced an error if the `symfony/twig-bridge` is not loaded: `Fatal error: Class 'Symfony\Bridge\Twig\AppVariable' not found in \vendor\silex\silex\src\Silex\Provider\TwigServiceProvider.php on line 43`

My first try for a solution was to only add the `AppVariable` if the twig-bridge is available and just fall back to adding `$app` otherwise. But I'm not sure if this is the desired behaviour, so I'm curious what you think about this.

The documentation has to be adapted once it's clear how the behaviour should be.