### PR TITLE
Add option to specify another route param for converters

### DIFF
--- a/src/Silex/EventListener/ConverterListener.php
+++ b/src/Silex/EventListener/ConverterListener.php
@@ -49,10 +49,11 @@ class ConverterListener implements EventSubscriberInterface
         $request = $event->getRequest();
         $route = $this->routes->get($request->attributes->get('_route'));
         if ($route && $converters = $route->getOption('_converters')) {
-            foreach ($converters as $name => $callback) {
+            foreach ($converters as $name => list($callback, $originalName)) {
                 $callback = $this->callbackResolver->resolveCallback($callback);
+                $originalValue = $request->attributes->get($originalName);
 
-                $request->attributes->set($name, call_user_func($callback, $request->attributes->get($name), $request));
+                $request->attributes->set($name, call_user_func($callback, $originalValue, $request));
             }
         }
     }

--- a/src/Silex/Route.php
+++ b/src/Silex/Route.php
@@ -93,10 +93,10 @@ class Route extends BaseRoute
      *
      * @return Route $this The current Route instance
      */
-    public function convert($variable, $callback)
+    public function convert($variable, $callback, $name = null)
     {
         $converters = $this->getOption('_converters');
-        $converters[$variable] = $callback;
+        $converters[$variable] = [$callback, $name ?: $variable];
         $this->setOption('_converters', $converters);
 
         return $this;

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -154,11 +154,11 @@ class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
     public function testConvert()
     {
         $controllers = new ControllerCollection(new Route());
-        $controllers->convert('id', '1');
+        $controllers->convert('id', '1', 'object');
         $controller = $controllers->match('/{id}/{name}/{extra}', function () {})->convert('name', 'Fabien')->convert('extra', 'Symfony');
         $controllers->convert('extra', 'Twig');
 
-        $this->assertEquals(array('id' => '1', 'name' => 'Fabien', 'extra' => 'Twig'), $controller->getRoute()->getOption('_converters'));
+        $this->assertEquals(array('id' => ['1', 'object'], 'name' => ['Fabien', 'name'], 'extra' => ['Twig', 'extra']), $controller->getRoute()->getOption('_converters'));
     }
 
     public function testRequireHttp()

--- a/tests/Silex/Tests/ControllerTest.php
+++ b/tests/Silex/Tests/ControllerTest.php
@@ -62,10 +62,10 @@ class ControllerTest extends \PHPUnit_Framework_TestCase
     public function testConvert()
     {
         $controller = new Controller(new Route('/foo/{bar}'));
-        $ret = $controller->convert('bar', $func = function ($bar) { return $bar; });
+        $ret = $controller->convert('taz', $func = function ($bar) { return $bar; }, 'bar');
 
         $this->assertSame($ret, $controller);
-        $this->assertEquals(array('bar' => $func), $controller->getRoute()->getOption('_converters'));
+        $this->assertEquals(array('taz' => [$func, 'bar']), $controller->getRoute()->getOption('_converters'));
     }
 
     public function testRun()


### PR DESCRIPTION
As said in #1211 this simplify renaming a route parameter to another controller variable name, this is reduce boilerplate a lot, especially when using existing providers as converters:

``` php
$app->get('/user/:username', function(UserInterface $user) {
    // ...
})->convert('user', 'provider.user:loadUserByUsername', 'username');
```

instead of:

``` php
use Symfony\Component\HttpFoundation\Request;
$app->get('/user/:username', function(UserInterface $user) {
    // ...
})->convert('user', function($_, Request $request) use ($app) {
    return $app["provider.user"]->loadUserByUsername($request->get('username'));
});
```
