### PR TITLE
Fix error never removed from session in SecurotyProvider

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -350,10 +350,10 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
 
             $session = $request->getSession();
             if ($session && $session->has($error)) {
-                $error = $session->get($error)->getMessage();
+                $message = $session->get($error)->getMessage();
                 $session->remove($error);
 
-                return $error;
+                return $message;
             }
         });
 


### PR DESCRIPTION
When $message is different than the $error variable, the wrong session key is deleted.