### PR TITLE
Remove slash from FallbackResource

### DIFF
--- a/doc/web_servers.rst
+++ b/doc/web_servers.rst
@@ -29,7 +29,7 @@ Alternatively, if you use Apache 2.2.16 or higher, you can use the
 
 .. code-block:: apache
 
-    FallbackResource /index.php
+    FallbackResource index.php
 
 .. note::
 


### PR DESCRIPTION
Apache config is not my thing, so this might not be correct. However, what I can tell is that it does not work with the slash for me, and that it does without the slash.