### PR TITLE
Add conflict for symfony/dependency-injection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,9 @@
         "symfony/dom-crawler": ">=2.3,<2.5-dev",
         "symfony/form": ">=2.3,<2.5-dev"
     },
+    "conflict": {
+        "symfony/dependency-injection": ">=3.0"
+    },
     "autoload": {
         "psr-0": { "Silex": "src/" }
     },


### PR DESCRIPTION
Not sure if it's the good way, let's tell me.

Since SF 3.0 out, I got strange issues on Travis: https://travis-ci.org/Soullivaneuh/IsoCodesValidator/jobs/94142522

I think add a conflict key here will solve it.

Is it's accepted, this should be back-ported on `1.2`.