### PR TITLE
first changes to try get legacy provider up and running within silex 2.0

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -99,7 +99,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
      * Registers a legacy service provider.
      *
      * @param LegacyServiceProviderInterface $provider A LegacyServiceProviderInterface instance
-     * @param array $values An array of values that customizes the provider
+     * @param array                          $values An array of values that customizes the provider
      *
      * @return Application
      */

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -99,7 +99,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
      * Registers a legacy service provider.
      *
      * @param LegacyServiceProviderInterface $provider A LegacyServiceProviderInterface instance
-     * @param array                          $values An array of values that customizes the provider
+     * @param array                          $values   An array of values that customizes the provider
      *
      * @return Application
      */

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -575,12 +575,30 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
      *
      * @return SharedService
      */
-    public static function share($callable)
+    public function share($callable)
     {
         if (!is_object($callable) || !method_exists($callable, '__invoke')) {
             throw new \InvalidArgumentException('Service definition is not a Closure or invokable object.');
         }
 
         return new SharedService($callable);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function protect($callable)
+    {
+        if (!$this->legacyProvider) {
+            return parent::protect($callable);
+        }
+
+        if (!is_object($callable) || !method_exists($callable, '__invoke')) {
+            throw new \InvalidArgumentException('Callable is not a Closure or invokable object.');
+        }
+
+        return function ($c) use ($callable) {
+            return $callable;
+        };
     }
 }

--- a/src/Silex/Legacy/SharedService.php
+++ b/src/Silex/Legacy/SharedService.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Legacy;
+
+class SharedService
+{
+    /**
+     * @var callable
+     */
+    private $callable;
+
+    /**
+     * @param $callable
+     */
+    public function __construct($callable)
+    {
+        $this->callable = $callable;
+    }
+
+    /**
+     * @return callable
+     */
+    public function getCallable()
+    {
+        return $this->callable;
+    }
+}

--- a/src/Silex/Legacy/SharedService.php
+++ b/src/Silex/Legacy/SharedService.php
@@ -11,6 +11,9 @@
 
 namespace Silex\Legacy;
 
+/**
+ * @internal
+ */
 class SharedService
 {
     /**

--- a/src/Silex/ServiceProviderInterface.php
+++ b/src/Silex/ServiceProviderInterface.php
@@ -16,7 +16,7 @@ namespace Silex;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  * 
- * @deprecated
+ * @deprecated this is the old silex ~1.0 service provider interface, and should not be used anymore
  */
 interface ServiceProviderInterface
 {

--- a/src/Silex/ServiceProviderInterface.php
+++ b/src/Silex/ServiceProviderInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex;
+
+/**
+ * Interface that all Silex service providers must implement.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @deprecated
+ */
+interface ServiceProviderInterface
+{
+    /**
+     * Registers services on the given app.
+     *
+     * This method should only be used to configure services and parameters.
+     * It should not get services.
+     */
+    public function register(Application $app);
+
+    /**
+     * Bootstraps the application.
+     *
+     * This method is called after all services are registered
+     * and should be used for "dynamic" configuration (whenever
+     * a service must be requested).
+     */
+    public function boot(Application $app);
+}

--- a/src/Silex/ServiceProviderInterface.php
+++ b/src/Silex/ServiceProviderInterface.php
@@ -15,6 +15,7 @@ namespace Silex;
  * Interface that all Silex service providers must implement.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * 
  * @deprecated
  */
 interface ServiceProviderInterface

--- a/tests/Silex/Tests/Fixtures/Provider/Legacy/MonologServiceProvider.php
+++ b/tests/Silex/Tests/Fixtures/Provider/Legacy/MonologServiceProvider.php
@@ -1,0 +1,98 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Tests\Fixtures\Provider\Legacy;
+
+use Monolog\Logger;
+use Monolog\Handler\StreamHandler;
+use Silex\Application;
+use Silex\ServiceProviderInterface;
+use Symfony\Bridge\Monolog\Handler\DebugHandler;
+use Silex\EventListener\LogListener;
+
+/**
+ * Monolog Provider.
+ *
+ * @author Fabien Potencier <fabien@symfony.com>
+ */
+class MonologServiceProvider implements ServiceProviderInterface
+{
+    public function register(Application $app)
+    {
+        $app['logger'] = function () use ($app) {
+            return $app['monolog'];
+        };
+
+        if ($bridge = class_exists('Symfony\Bridge\Monolog\Logger')) {
+            $app['monolog.handler.debug'] = function () use ($app) {
+                $level = MonologServiceProvider::translateLevel($app['monolog.level']);
+
+                return new DebugHandler($level);
+            };
+        }
+
+        $app['monolog.logger.class'] = $bridge ? 'Symfony\Bridge\Monolog\Logger' : 'Monolog\Logger';
+
+        $app['monolog'] = $app->share(function ($app) {
+            $log = new $app['monolog.logger.class']($app['monolog.name']);
+
+            $log->pushHandler($app['monolog.handler']);
+
+            if ($app['debug'] && isset($app['monolog.handler.debug'])) {
+                $log->pushHandler($app['monolog.handler.debug']);
+            }
+
+            return $log;
+        });
+
+        $app['monolog.handler'] = function () use ($app) {
+            $level = MonologServiceProvider::translateLevel($app['monolog.level']);
+
+            return new StreamHandler($app['monolog.logfile'], $level, $app['monolog.bubble'], $app['monolog.permission']);
+        };
+
+        $app['monolog.level'] = function () {
+            return Logger::DEBUG;
+        };
+
+        $app['monolog.listener'] = $app->share(function () use ($app) {
+            return new LogListener($app['logger']);
+        });
+
+        $app['monolog.name'] = 'myapp';
+        $app['monolog.bubble'] = true;
+        $app['monolog.permission'] = null;
+    }
+
+    public function boot(Application $app)
+    {
+        if (isset($app['monolog.listener'])) {
+            $app['dispatcher']->addSubscriber($app['monolog.listener']);
+        }
+    }
+
+    public static function translateLevel($name)
+    {
+        // level is already translated to logger constant, return as-is
+        if (is_int($name)) {
+            return $name;
+        }
+
+        $levels = Logger::getLevels();
+        $upper = strtoupper($name);
+
+        if (!isset($levels[$upper])) {
+            throw new \InvalidArgumentException("Provided logging level '$name' does not exist. Must be a valid monolog logging level.");
+        }
+
+        return $levels[$upper];
+    }
+}

--- a/tests/Silex/Tests/Legacy/SharedServiceTest.php
+++ b/tests/Silex/Tests/Legacy/SharedServiceTest.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Legacy;
+
+use Silex\Legacy\SharedService;
+
+class SharedServiceTest extends \PHPUnit_Framework_TestCase
+{
+    public function testGetCallable()
+    {
+        $callable = function () {};
+        $sharedService = new SharedService($callable);
+        $this->assertSame($callable, $sharedService->getCallable());
+    }
+}

--- a/tests/Silex/Tests/Provider/Legacy/MonologServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/Legacy/MonologServiceProviderTest.php
@@ -1,0 +1,198 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Provider\Legacy;
+
+use Monolog\Handler\TestHandler;
+use Monolog\Logger;
+use Silex\Application;
+use Silex\Tests\Fixtures\Provider\Legacy\MonologServiceProvider;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * MonologProvider test cases.
+ *
+ * @author Igor Wiedler <igor@wiedler.ch>
+ */
+class MonologServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    public function testRequestLogging()
+    {
+        $app = $this->getApplication();
+
+        $app->get('/foo', function () use ($app) {
+            return 'foo';
+        });
+
+        $this->assertFalse($app['monolog.handler']->hasInfoRecords());
+
+        $request = Request::create('/foo');
+        $app->handle($request);
+
+        $this->assertTrue($app['monolog.handler']->hasInfo('> GET /foo'));
+        $this->assertTrue($app['monolog.handler']->hasInfo('< 200'));
+
+        $records = $app['monolog.handler']->getRecords();
+        $this->assertContains('Matched route "GET_foo"', $records[0]['message']);
+    }
+
+    public function testManualLogging()
+    {
+        $app = $this->getApplication();
+
+        $app->get('/log', function () use ($app) {
+            $app['monolog']->addDebug('logging a message');
+        });
+
+        $this->assertFalse($app['monolog.handler']->hasDebugRecords());
+
+        $request = Request::create('/log');
+        $app->handle($request);
+
+        $this->assertTrue($app['monolog.handler']->hasDebug('logging a message'));
+    }
+
+    public function testErrorLogging()
+    {
+        $app = $this->getApplication();
+
+        $app->error(function (\Exception $e) {
+            return 'error handled';
+        });
+
+        /*
+         * Simulate 404, logged to error level
+         */
+        $this->assertFalse($app['monolog.handler']->hasErrorRecords());
+
+        $request = Request::create('/error');
+        $app->handle($request);
+
+        $records = $app['monolog.handler']->getRecords();
+        $pattern = "#Symfony\\\\Component\\\\HttpKernel\\\\Exception\\\\NotFoundHttpException: No route found for \"GET /error\" \(uncaught exception\) at .* line \d+#";
+        $this->assertMatchingRecord($pattern, Logger::ERROR, $app['monolog.handler']);
+
+        /*
+         * Simulate unhandled exception, logged to critical
+         */
+        $app->get('/error', function () {
+            throw new \RuntimeException('very bad error');
+        });
+
+        $this->assertFalse($app['monolog.handler']->hasCriticalRecords());
+
+        $request = Request::create('/error');
+        $app->handle($request);
+
+        $pattern = "#RuntimeException: very bad error \(uncaught exception\) at .* line \d+#";
+        $this->assertMatchingRecord($pattern, Logger::CRITICAL, $app['monolog.handler']);
+    }
+
+    public function testRedirectLogging()
+    {
+        $app = $this->getApplication();
+
+        $app->get('/foo', function () use ($app) {
+            return new RedirectResponse('/bar', 302);
+        });
+
+        $this->assertFalse($app['monolog.handler']->hasInfoRecords());
+
+        $request = Request::create('/foo');
+        $app->handle($request);
+
+        $this->assertTrue($app['monolog.handler']->hasInfo('< 302 /bar'));
+    }
+
+    public function testErrorLoggingGivesWayToSecurityExceptionHandling()
+    {
+        $app = $this->getApplication();
+        $app['monolog.level'] = Logger::ERROR;
+
+        $app->register(new \Silex\Provider\SecurityServiceProvider(), array(
+            'security.firewalls' => array(
+                'admin' => array(
+                    'pattern' => '^/admin',
+                    'http' => true,
+                    'users' => array(),
+                ),
+            ),
+        ));
+
+        $app->get('/admin', function () {
+            return 'SECURE!';
+        });
+
+        $request = Request::create('/admin');
+        $app->run($request);
+
+        $this->assertEmpty($app['monolog.handler']->getRecords(), 'Expected no logging to occur');
+    }
+
+    public function testStringErrorLevel()
+    {
+        $app = $this->getApplication();
+        $app['monolog.level'] = 'info';
+
+        $this->assertSame(Logger::INFO, $app['monolog.handler']->getLevel());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Provided logging level 'foo' does not exist. Must be a valid monolog logging level.
+     */
+    public function testNonExistentStringErrorLevel()
+    {
+        $app = $this->getApplication();
+        $app['monolog.level'] = 'foo';
+
+        $app['monolog.handler']->getLevel();
+    }
+
+    public function testDisableListener()
+    {
+        $app = $this->getApplication();
+        unset($app['monolog.listener']);
+
+        $app->handle(Request::create('/404'));
+
+        $this->assertEmpty($app['monolog.handler']->getRecords(), 'Expected no logging to occur');
+    }
+
+    protected function assertMatchingRecord($pattern, $level, $handler)
+    {
+        $found = false;
+        $records = $handler->getRecords();
+        foreach ($records as $record) {
+            if (preg_match($pattern, $record['message']) && $record['level'] == $level) {
+                $found = true;
+                continue;
+            }
+        }
+        $this->assertTrue($found, "Trying to find record matching $pattern with level $level");
+    }
+
+    protected function getApplication()
+    {
+        $app = new Application();
+
+        $app->registerLegacy(new MonologServiceProvider());
+
+        $app['monolog.handler'] = $app->share(function () use ($app) {
+            $level = MonologServiceProvider::translateLevel($app['monolog.level']);
+
+            return new TestHandler($level);
+        });
+
+        return $app;
+    }
+}

--- a/tests/Silex/Tests/Provider/Legacy/MonologServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/Legacy/MonologServiceProviderTest.php
@@ -187,11 +187,11 @@ class MonologServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app->registerLegacy(new MonologServiceProvider());
 
-        $app['monolog.handler'] = $app->share(function () use ($app) {
+        $app['monolog.handler'] = function () use ($app) {
             $level = MonologServiceProvider::translateLevel($app['monolog.level']);
 
             return new TestHandler($level);
-        });
+        };
 
         return $app;
     }

--- a/tests/Silex/Tests/Provider/Legacy/MonologServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/Legacy/MonologServiceProviderTest.php
@@ -38,8 +38,8 @@ class MonologServiceProviderTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo');
         $app->handle($request);
 
-        $this->assertTrue($app['monolog.handler']->hasInfo('> GET /foo'));
-        $this->assertTrue($app['monolog.handler']->hasInfo('< 200'));
+        $this->assertTrue($app['monolog.handler']->hasDebug('> GET /foo'));
+        $this->assertTrue($app['monolog.handler']->hasDebug('< 200'));
 
         $records = $app['monolog.handler']->getRecords();
         $this->assertContains('Matched route "GET_foo"', $records[0]['message']);
@@ -110,7 +110,7 @@ class MonologServiceProviderTest extends \PHPUnit_Framework_TestCase
         $request = Request::create('/foo');
         $app->handle($request);
 
-        $this->assertTrue($app['monolog.handler']->hasInfo('< 302 /bar'));
+        $this->assertTrue($app['monolog.handler']->hasDebug('< 302 /bar'));
     }
 
     public function testErrorLoggingGivesWayToSecurityExceptionHandling()


### PR DESCRIPTION
Hello @stof 

I tried to create a legacy provider support as we discus about today. Its in a early stage and not working correctly at the moment.

One problem for example would be provider which tried to create new \Pimple instances.

https://github.com/silexphp/Silex/blob/1.3/src/Silex/Provider/DoctrineServiceProvider.php#L65

Regards @dominikzogg