### PR TITLE
Add hint to install browser-kit to use WebTestCase

### DIFF
--- a/src/Silex/WebTestCase.php
+++ b/src/Silex/WebTestCase.php
@@ -55,6 +55,10 @@ abstract class WebTestCase extends \PHPUnit_Framework_TestCase
      */
     public function createClient(array $server = array())
     {
+        if (!class_exists('Symfony\Component\BrowserKit\Client')) {
+            throw new \LogicException('Component "symfony/browser-kit" is required by WebTestCase.'.PHP_EOL.'Run composer require symfony/browser-kit');
+        }
+
         return new Client($this->app, $server);
     }
 }


### PR DESCRIPTION
`Silex/WebTestCase` have a requirement for `symfony/browser-kit`.
This PR give instructions to the developer when PHPUnit is run and this dependency is missing.

Before:
```
PHP Fatal error:  Class 'Symfony\Component\BrowserKit\Client' not found in vendor/symfony/symfony/src/Symfony/Component/HttpKernel/Client.php on line 32
PHP Stack trace:
PHP   1. {main}() /usr/bin/phpunit:0
PHP   2. PHPUnit_TextUI_Command::main() /usr/bin/phpunit:547
PHP   3. PHPUnit_TextUI_Command->run() phar:///usr/bin/phpunit/phar/phpunit/TextUI/Command.php:100
PHP   4. PHPUnit_TextUI_TestRunner->doRun() phar:///usr/bin/phpunit/phar/phpunit/TextUI/Command.php:148
PHP   5. PHPUnit_Framework_TestSuite->run() phar:///usr/bin/phpunit/phar/phpunit/TextUI/TestRunner.php:432
PHP   6. PHPUnit_Framework_TestCase->run() phar:///usr/bin/phpunit/phar/phpunit/Framework/TestSuite.php:735
PHP   7. PHPUnit_Framework_TestResult->run() phar:///usr/bin/phpunit/phar/phpunit/Framework/TestCase.php:702
PHP   8. PHPUnit_Framework_TestCase->runBare() phar:///usr/bin/phpunit/phar/phpunit/Framework/TestResult.php:601
PHP   9. PHPUnit_Framework_TestCase->runTest() phar:///usr/bin/phpunit/phar/phpunit/Framework/TestCase.php:746
PHP  10. ReflectionMethod->invokeArgs() phar:///usr/bin/phpunit/phar/phpunit/Framework/TestCase.php:881
```

After:
```
There was 1 error:

1) FunctionalTest::testAction
LogicException: Component "symfony/browser-kit" is required by WebTestCase.
Run composer require symfony/browser-kit

vendor/silex/silex/src/Silex/WebTestCase.php:59
tests/FunctionalTest.php:14
```

Resolves #1293