### PR TITLE
Add support for the Guard component to the SecurityServiceProvider

### DIFF
--- a/doc/cookbook/guard_authentication.rst
+++ b/doc/cookbook/guard_authentication.rst
@@ -1,0 +1,40 @@
+How to Create a Custom Authentication System with Guard
+=======================================================
+
+TODO: This cookbook will be inspired by the Symfony cookbook.
+http://symfony.com/doc/current/cookbook/security/guard-authentication
+
+Step 1) Create the Authenticator Class
+--------------------------------------
+
+TODO: Same as the Symfony cookbook, but Doctrine ORM is not recommanded with Silex.
+
+Step 2) Configure the Authenticator
+-----------------------------------
+
+To finish this, register the class as a service:
+
+.. code-block:: php
+
+    $app['app.token_authenticator'] = function ($app) {
+        return new App\Security\TokenAuthenticator();
+    }
+
+
+Finally, configure your firewalls key to use this authenticator:
+
+.. code-block:: php
+
+    $app['security.firewalls'] => array(
+        'main' => array(
+            'anonymous' => true,
+
+            'guard' => array(
+                'authenticators' => array(
+                    'app.token_authenticator'
+                ),
+            ),
+        ),
+    );
+
+

--- a/doc/cookbook/guard_authentication.rst
+++ b/doc/cookbook/guard_authentication.rst
@@ -33,8 +33,13 @@ Finally, configure your firewalls key to use this authenticator:
                 'authenticators' => array(
                     'app.token_authenticator'
                 ),
+
+                // Using more than 1 authenticator, you must specify
+                // which one is used as entry point.
+                'entry_point' => 'app.token_authenticator',
             ),
         ),
     );
 
+Note: You can use many authenticators, they are executed by if the order they are configured.
 

--- a/doc/cookbook/guard_authentication.rst
+++ b/doc/cookbook/guard_authentication.rst
@@ -1,16 +1,25 @@
 How to Create a Custom Authentication System with Guard
 =======================================================
 
-Whether you need to build a traditional login form, an API token authentication system or you need to integrate with some proprietary single-sign-on system, the Guard component can make it easy... and fun!
+Whether you need to build a traditional login form, an API token
+authentication system or you need to integrate with some proprietary
+single-sign-on system, the Guard component can make it easy... and fun!
 
-In this example, you'll build an API token authentication system and learn how to work with Guard.
+In this example, you'll build an API token authentication system and
+learn how to work with Guard.
 
 Step 1) Create the Authenticator Class
 --------------------------------------
 
-Suppose you have an API where your clients will send an X-AUTH-TOKEN header on each request. This token is composed of the username followed by a password, separated by a colon. Your job is to read this, find the associated user (if any) and check the password.
+Suppose you have an API where your clients will send an X-AUTH-TOKEN
+header on each request. This token is composed of the username followed
+by a password, separated by a colon (e.g. ``X-AUTH-TOKEN: coolguy:awesomepassword``).
+Your job is to read this, find theassociated user (if any) and check
+the password.
 
-To create a custom authentication system, just create a class and make it implement GuardAuthenticatorInterface. Or, extend the simpler AbstractGuardAuthenticator. This requires you to implement six methods:
+To create a custom authentication system, just create a class and make
+it implement GuardAuthenticatorInterface. Or, extend the simpler
+AbstractGuardAuthenticator. This requires you to implement six methods:
 
 .. code-block:: php
 
@@ -28,12 +37,24 @@ To create a custom authentication system, just create a class and make it implem
 
     class TokenAuthenticator extends AbstractGuardAuthenticator
     {
+        private $encoderFactory;
+
+        public function __construct(EncoderFactoryInterface $encoderFactory)
+        {
+            $this->encoderFactory = $encoderFactory;
+        }
+
         public function getCredentials(Request $request)
         {
+            // Checks if the credential header is provided
             if (!$token = $request->headers->get('X-AUTH-TOKEN')) {
                 return;
             }
 
+            // Parse the header or ignore it if the format is incorrect.
+            if (false === strpos(':', $token)) {
+                return;
+            }
             list($username, $secret) = explode(':', $token, 2);
 
             return array(
@@ -50,10 +71,15 @@ To create a custom authentication system, just create a class and make it implem
         public function checkCredentials($credentials, UserInterface $user)
         {
             // check credentials - e.g. make sure the password is valid
-            // no credential check is needed in this case
-
             // return true to cause authentication success
-            return $user->getPassword() === $credentials['secret'];
+
+            $encoder = $this->encoderFactory->getEncoder($user);
+
+            return $encoder->isPasswordValid(
+                $user->getPassword(),
+                $credentials['secret'],
+                $user->getSalt()
+            );
         }
 
         public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
@@ -102,8 +128,8 @@ To finish this, register the class as a service:
 .. code-block:: php
 
     $app['app.token_authenticator'] = function ($app) {
-        return new App\Security\TokenAuthenticator();
-    }
+        return new App\Security\TokenAuthenticator($app['security.encoder_factory']);
+    };
 
 
 Finally, configure your `security.firewalls` key to use this authenticator:
@@ -121,17 +147,22 @@ Finally, configure your `security.firewalls` key to use this authenticator:
                 // which one is used as entry point.
                 // 'entry_point' => 'app.token_authenticator',
             ),
+            // configure where your users come from. Hardcode them, or load them from somewhere
+            // http://silex.sensiolabs.org/doc/providers/security.html#defining-a-custom-user-provider
             'users' => array(
                 'victoria' => array('ROLE_USER', 'randomsecret'),
             ),
+            // 'anonymous' => true
         ),
     );
 
 .. note::
-    You can use many authenticators, they are executed by if the order they are configured.
+    You can use many authenticators, they are executed by the order
+    they are configured.
 
-You did it! You now have a fully-working API token authentication system. If your homepage required ROLE_USER, then you could test it under different conditions:
-
+You did it! You now have a fully-working API token authentication
+system. If your homepage required ROLE_USER, then you could test it
+under different conditions:
 
 .. code-block:: bash
 
@@ -147,4 +178,5 @@ You did it! You now have a fully-working API token authentication system. If you
     curl -H "X-AUTH-TOKEN: victoria:ransomsecret" http://localhost:8000/
     # the homepage controller is executed: the page loads normally
 
-For more details read the Symfony cookbook entry on `How to Create a Custom Authentication System with Guard  <http://symfony.com/doc/current/cookbook/security/guard-authentication.html>`_.
+For more details read the Symfony cookbook entry on
+`How to Create aCustom Authentication System with Guard <http://symfony.com/doc/current/cookbook/security/guard-authentication.html>`_.

--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -618,6 +618,13 @@ argument of your authentication factory (see above).
 This example uses the authentication provider classes as described in the
 Symfony `cookbook`_.
 
+
+.. note::
+
+    Since Symfony 2.8, the Guard component simplify the creation of custom
+    authentication providers.
+    :doc:`How to Create a Custom Authentication System with Guard <cookbook/guard_authentication>`
+
 Stateless Authentication
 ~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -59,6 +59,7 @@ use Symfony\Component\Security\Http\Logout\DefaultLogoutSuccessHandler;
 use Symfony\Component\Security\Http\AccessMap;
 use Symfony\Component\Security\Http\HttpUtils;
 use Symfony\Component\Security\Guard\GuardAuthenticatorHandler;
+use Symfony\Component\Security\Guard\Firewall\GuardAuthenticationListener;
 use Symfony\Component\Security\Guard\Provider\GuardAuthenticationProvider;
 
 /**
@@ -294,7 +295,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                         $listener = $app[$listenerId];
 
                         if (isset($app['security.remember_me.service.'.$name])) {
-                            if ($listener instanceof AbstractAuthenticationListener) {
+                            if ($listener instanceof AbstractAuthenticationListener || $listener instanceof GuardAuthenticationListener) {
                                 $listener->setRememberMeServices($app['security.remember_me.service.'.$name]);
                             }
                             if ($listener instanceof LogoutListener) {

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -441,9 +441,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $authenticators[] = $app[$authenticatorId];
                 }
 
-                $class = isset($options['listener_class']) ? $options['listener_class'] : 'Symfony\\Component\\Security\\Guard\\Firewall\\GuardAuthenticationListener';
-
-                return new $class(
+                return new GuardAuthenticationListener(
                     $app['security.authentication.guard_handler'],
                     $app['security.authentication_manager'],
                     $providerKey,
@@ -586,7 +584,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
             $authenticatorIds = $options['authenticators'];
             if (count($authenticatorIds) == 1) {
                 // if there is only one authenticator, use that as the entry point
-                return $app[array_shift($authenticatorIds)];
+                return $app[reset($authenticatorIds)];
             }
             // we have multiple entry points - we must ask them to configure one
             throw new \LogicException(sprintf(

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
@@ -122,6 +122,11 @@ class SecurityServiceProviderTest extends WebTestCase
 
     public function testGuardAuthentication()
     {
+        if (!class_exists('Symfony\\Component\\Security\\Guard\\AbstractGuardAuthenticator')) {
+            $this->markTestSkipped(
+              'The guard component require Symfony 2.8+'
+            );
+        }
         $app = $this->createApplication('guard');
 
         $client = new Client($app);

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
@@ -120,6 +120,28 @@ class SecurityServiceProviderTest extends WebTestCase
         $this->assertEquals('admin', $client->getResponse()->getContent());
     }
 
+    public function testGuardAuthentication()
+    {
+        $app = $this->createApplication('guard');
+
+        $client = new Client($app);
+
+        $client->request('get', '/');
+        $this->assertEquals(401, $client->getResponse()->getStatusCode(), 'The entry point is configured');
+        $this->assertEquals('{"message":"Authentication Required"}', $client->getResponse()->getContent());
+
+        $client->request('get', '/', array(), array(), array('HTTP_X_AUTH_TOKEN' => 'lili:not the secret'));
+        $this->assertEquals(403, $client->getResponse()->getStatusCode(), 'User not found');
+        $this->assertEquals('{"message":"Username could not be found."}', $client->getResponse()->getContent());
+
+        $client->request('get', '/', array(), array(), array('HTTP_X_AUTH_TOKEN' => 'victoria:not the secret'));
+        $this->assertEquals(403, $client->getResponse()->getStatusCode(), 'Invalid credentials');
+        $this->assertEquals('{"message":"Invalid credentials."}', $client->getResponse()->getContent());
+
+        $client->request('get', '/', array(), array(), array('HTTP_X_AUTH_TOKEN' => 'victoria:victoriasecret'));
+        $this->assertEquals('victoria', $client->getResponse()->getContent());
+    }
+
     public function testUserPasswordValidatorIsRegistered()
     {
         $app = new Application();
@@ -353,6 +375,40 @@ class SecurityServiceProviderTest extends WebTestCase
         $app->get('/admin', function () use ($app) {
             return 'admin';
         });
+
+        return $app;
+    }
+
+    private function addGuardAuthentication($app)
+    {
+        $app['app.authenticator.token'] = function ($app) {
+            return new SecurityServiceProviderTest\TokenAuthenticator($app);
+        };
+
+        $app->register(new SecurityServiceProvider(), array(
+            'security.firewalls' => array(
+                'guard' => array(
+                    'pattern' => '^.*$',
+                    'form' => true,
+                    'guard' => array(
+                        'authenticators' => array(
+                            'app.authenticator.token',
+                        ),
+                    ),
+                    'users' => array(
+                        'victoria' => array('ROLE_USER', 'victoriasecret'),
+                    ),
+                ),
+            ),
+        ));
+
+        $app->get('/', function () use ($app) {
+            $user = $app['security.token_storage']->getToken()->getUser();
+
+            $content = is_object($user) ? $user->getUsername() : 'ANONYMOUS';
+
+            return $content;
+        })->bind('homepage');
 
         return $app;
     }

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest/TokenAuthenticator.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest/TokenAuthenticator.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Provider\SecurityServiceProviderTest;
+
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Security\Core\User\UserProviderInterface;
+use Symfony\Component\Security\Guard\AbstractGuardAuthenticator;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Core\Exception\AuthenticationException;
+
+/**
+ * This class is used to test "guard" authentication with the SecurityServiceProvider.
+ */
+class TokenAuthenticator extends AbstractGuardAuthenticator
+{
+    public function getCredentials(Request $request)
+    {
+        if (!$token = $request->headers->get('X-AUTH-TOKEN')) {
+            return;
+        }
+
+        list($username, $secret) = explode(':', $token);
+
+        return array(
+            'username' => $username,
+            'secret' => $secret,
+        );
+    }
+
+    public function getUser($credentials, UserProviderInterface $userProvider)
+    {
+        return $userProvider->loadUserByUsername($credentials['username']);
+    }
+
+    public function checkCredentials($credentials, UserInterface $user)
+    {
+        return $user->getPassword() === $credentials['secret'];
+    }
+
+    public function onAuthenticationSuccess(Request $request, TokenInterface $token, $providerKey)
+    {
+        return;
+    }
+
+    public function onAuthenticationFailure(Request $request, AuthenticationException $exception)
+    {
+        $data = array(
+            'message' => strtr($exception->getMessageKey(), $exception->getMessageData()),
+        );
+
+        return new JsonResponse($data, 403);
+    }
+
+    public function start(Request $request, AuthenticationException $authException = null)
+    {
+        $data = array(
+            'message' => 'Authentication Required',
+        );
+
+        return new JsonResponse($data, 401);
+    }
+
+    public function supportsRememberMe()
+    {
+        return false;
+    }
+}

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest/TokenAuthenticator.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest/TokenAuthenticator.php
@@ -45,6 +45,7 @@ class TokenAuthenticator extends AbstractGuardAuthenticator
 
     public function checkCredentials($credentials, UserInterface $user)
     {
+        // This is not a safe way of validating a password.
         return $user->getPassword() === $credentials['secret'];
     }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | #1260
| License       | MIT
| Doc PR        | included

Services configuration are extracted from the SecurityBundle [`guard.xml`](https://github.com/symfony/symfony/blob/3.0/src/Symfony/Bundle/SecurityBundle/Resources/config/guard.xml) and [`GuardAuthenticationFactory`](https://github.com/symfony/symfony/blob/3.0/src/Symfony/Bundle/SecurityBundle/DependencyInjection/Security/Factory/GuardAuthenticationFactory.php)

Usage is quite simple, the `guard` type can be configured in the firewall like other ones.

```php
$app['app.authenticator'] = function ($app) {
    return new Authenticator();
};

$app->register(new Silex\Provider\SecurityServiceProvider(), [
    'security.firewalls' => [
        'main' => [
            'pattern' => '^/admin',
            'guard' => [
                'authenticators' => [
                    'app.authenticator'
                ]
            ]
        ]
    ]
]);
```