### PR TITLE
Replace binary gender examples with something that is actually single-choice

### DIFF
--- a/doc/providers/form.rst
+++ b/doc/providers/form.rst
@@ -91,8 +91,8 @@ example::
         $form = $app['form.factory']->createBuilder('form', $data)
             ->add('name')
             ->add('email')
-            ->add('gender', 'choice', array(
-                'choices' => array(1 => 'male', 2 => 'female'),
+            ->add('billing_plan', 'choice', array(
+                'choices' => array(1 => 'free', 2 => 'small_business', 3 => 'corporate'),
                 'expanded' => true,
             ))
             ->getForm();
@@ -139,10 +139,10 @@ form by adding constraints on the fields::
         ->add('email', 'text', array(
             'constraints' => new Assert\Email()
         ))
-        ->add('gender', 'choice', array(
-            'choices' => array(1 => 'male', 2 => 'female'),
+        ->add('billing_plan', 'choice', array(
+            'choices' => array(1 => 'free', 2 => 'small_business', 3 => 'corporate'),
             'expanded' => true,
-            'constraints' => new Assert\Choice(array(1, 2)),
+            'constraints' => new Assert\Choice(array(1, 2, 3)),
         ))
         ->getForm();
 


### PR DESCRIPTION
In order to include people who do not fit into the gender binary, gender fields really should be a free-form text field. As such, this patch changes the `choices` example to use a billing plan instead.

# References

* http://gender.wikia.com/wiki/Non-binary
* https://en.wikipedia.org/wiki/Genderqueer
* https://modelviewculture.com/pieces/the-argument-for-free-form-input
* https://www.facebook.com/