### PR TITLE
Request hash with monolog

### DIFF
--- a/doc/cookbook/index.rst
+++ b/doc/cookbook/index.rst
@@ -15,6 +15,7 @@ The cookbook section contains recipes for solving specific problems.
     error_handler
     multiple_loggers
     assets
+    monolog_request_hash
 
 Recipes
 -------
@@ -36,5 +37,7 @@ Recipes
 * :doc:`Converting Errors to Exceptions <error_handler>`.
 
 * :doc:`Using multiple Monolog Loggers <multiple_loggers>`.
+
+* :doc:`Adding a request hash to logs with Monolog <monolog_request_hash>`.
 
 * :doc:`Managing Assets in Templates <assets>`.

--- a/doc/cookbook/monolog_request_hash.rst
+++ b/doc/cookbook/monolog_request_hash.rst
@@ -1,0 +1,84 @@
+Adding a request hash using Monolog
+===================================
+
+Often times is useful to add some sort of hash or identifier to each request
+in the logs so it's easier to aggregate or filter its lines with tools like grep
+or more advanced ones like `Logstash
+<https://www.elastic.co/products/logstash>`_.
+
+This is something simple to achieve with Monolog by means of its Formatters and
+Processors.
+
+First up, we need to create a new Monolog Processor which is going to slightly
+transform the record to be logged before it actually gets logged. At this stage,
+we'll create the request hash if it hasn't been created already.
+
+.. code-block:: php
+
+    final class TokenProcessor
+    {
+        private $token = null;
+
+        public function __invoke(array $record)
+        {
+            if (is_null($this->token)) {
+                $this->token = uniqid();
+            }
+
+            $record['extra']['token'] = $this->token;
+
+            return $record;
+        }
+    }
+
+We're implementing the processor in a class instead of a function to keep the
+same hash during the whole request every time a record is written in the log.
+We also use a little trick to make the class a "callable" by implementing the
+"__invoke" magic method.
+
+Next step, is to create a Monolog Formatter that actually makes use of the
+token created in the Processor. In this case, we're only going to extend the
+existing "LineFormatter" but changing its default format.
+
+.. code-block:: php
+
+    final class TokenLineFormatter extends Monolog\Formatter\LineFormatter
+    {
+        const TOKEN_FORMAT = "[%datetime%][%extra.token%] %channel%.%level_name%: %message% %context%\n";
+
+        public function __construct()
+        {
+            parent::__construct(self::TOKEN_FORMAT);
+        }
+    }
+
+Finally, the only thing left to do is to link everything together in Monolog's
+provider configuration. In order to do this, we need to extend Monolog's default
+setup by adding our custom Processor and also extending the default Handler to
+provide ours instead.
+
+.. code-block:: php
+
+    //Modify these use statements if necessary to adapt them to your namespace
+    use Monolog\Formatter\TokenLineFormatter;
+    use Monolog\Processor\TokenProcessor;
+
+    $app->register(new Silex\Provider\MonologServiceProvider(), array(
+        'monolog.logfile' => __DIR__.'/development.log',
+    ));
+
+    $app['monolog'] = $app->share($app->extend('monolog', function (Monolog\Logger $monolog) {
+        $monolog->pushProcessor(new TokenProcessor());
+        return $monolog;
+    }));
+
+    $app['monolog.handler'] = $app->share($app->extend('monolog.handler', function (Monolog\Handler\HandlerInterface $handler) {
+        $handler->setFormatter(new TokenLineFormatter());
+        return $handler;
+    }));
+
+Once all this is done, your logs will include a request hash like the following::
+
+    [2016-01-01 00:00:00][5698bb8036da8] myapp.INFO: Matched route "POST_endpoint". {"route_parameters":{"_controller":"controller:endpoint","_route":"POST_endpoint"},"request_uri":"http://localhost:8000/endpoint"}
+    [2016-01-01 00:00:01][5698bb8036da8] myapp.INFO: > POST /endpoint []
+    [2016-01-01 00:00:02][5698bb8036da8] myapp.INFO: < 200 []


### PR DESCRIPTION
I recently found myself in the need of adding a request hash into the logs of a Silex project. I could not find anywhere a cookbook or documentation on how to do this, so I documented the way I solved it.

It's actually pretty similar (if not the same) solution as proposed in the Symfony docs:
http://symfony.com/doc/current/cookbook/logging/monolog.html#adding-a-session-request-token
I've simplified it the best I could.

This should help the next poor soul trying to achieve this.

I'm asking this to be merged into 1.3 since it's only documentation and not a new feature.

Thanks
