### PR TITLE
add a namedForm() method in FormTrait

### DIFF
--- a/src/Silex/Application/FormTrait.php
+++ b/src/Silex/Application/FormTrait.php
@@ -39,7 +39,7 @@ trait FormTrait
 
         return $this['form.factory']->createBuilder($type, $data, $options);
     }
-    
+
     /**
      * Creates and returns a named form builder instance.
      *
@@ -56,8 +56,8 @@ trait FormTrait
             // BC with Symfony < 2.8
             $type = class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
         }
-    
+
         return $this['form.factory']->createNamedBuilder($name, $type, $data, $options);
     }
-    
+
 }

--- a/src/Silex/Application/FormTrait.php
+++ b/src/Silex/Application/FormTrait.php
@@ -17,6 +17,7 @@ use Symfony\Component\Form\FormBuilder;
  * Form trait.
  *
  * @author Fabien Potencier <fabien@symfony.com>
+ * @author David Berlioz <berliozdavid@gmail.com>
  */
 trait FormTrait
 {
@@ -38,4 +39,25 @@ trait FormTrait
 
         return $this['form.factory']->createBuilder($type, $data, $options);
     }
+    
+    /**
+     * Creates and returns a named form builder instance.
+     *
+     * @param string                   $name
+     * @param mixed                    $data    The initial data for the form
+     * @param array                    $options Options for the form
+     * @param string|FormTypeInterface $type    Type of the form
+     *
+     * @return \Symfony\Component\Form\FormBuilder
+     */
+    public function namedForm($name, $data = null, array $options = array(), $type = null)
+    {
+        if (null === $type) {
+            // BC with Symfony < 2.8
+            $type = class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
+        }
+    
+        return $this['form.factory']->createNamedBuilder($name, $type, $data, $options);
+    }
+    
 }


### PR DESCRIPTION
I do prefer using the namedForm builder.

Just add the `$this['form.factory']->createNamedBuilder(...)` in `Silex\Application\FormTrait`:

```php
    /**
     * Creates and returns a named form builder instance.
     *
     * @param string                   $name
     * @param mixed                    $data    The initial data for the form
     * @param array                    $options Options for the form
     * @param string|FormTypeInterface $type    Type of the form
     *
     * @return \Symfony\Component\Form\FormBuilder
     */
    public function namedForm($name, $data = null, array $options = array(), $type = null)
    {
        if (null === $type) {
            // BC with Symfony < 2.8
            $type = class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form';
        }
    
        return $this['form.factory']->createNamedBuilder($name, $type, $data, $options);
    }
```