### PR TITLE
Allow use of all the RequestMatcher parameters by providing an array

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -325,7 +325,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                         'methods' => null,
                         'ips' => null,
                         'attributes' => null,
-                        'schemes' => null
+                        'schemes' => null,
                     ];
                     $rule[0] = new RequestMatcher($rule[0]['path'], $rule[0]['host'], $rule[0]['methods'], $rule[0]['ips'], $rule[0]['attributes'], $rule[0]['schemes']);
                 }

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -318,6 +318,16 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
             foreach ($app['security.access_rules'] as $rule) {
                 if (is_string($rule[0])) {
                     $rule[0] = new RequestMatcher($rule[0]);
+                } elseif (is_array($rule[0])) {
+                    $rule[0] += [
+                        'path' => null,
+                        'host' => null,
+                        'methods' => null,
+                        'ips' => null,
+                        'attributes' => null,
+                        'schemes' => null
+                    ];
+                    $rule[0] = new RequestMatcher($rule[0]['path'], $rule[0]['host'], $rule[0]['methods'], $rule[0]['ips'], $rule[0]['attributes'], $rule[0]['schemes']);
                 }
 
                 $map->add($rule[0], (array) $rule[1], isset($rule[2]) ? $rule[2] : null);

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -329,7 +329,6 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     ];
                     $rule[0] = new RequestMatcher($rule[0]['path'], $rule[0]['host'], $rule[0]['methods'], $rule[0]['ips'], $rule[0]['attributes'], $rule[0]['schemes']);
                 }
-
                 $map->add($rule[0], (array) $rule[1], isset($rule[2]) ? $rule[2] : null);
             }
 


### PR DESCRIPTION
Provider: Silex\Provider\SecurityServiceProvider
Little patch to make full use of the `RequestMatcher` in `$app['security.access_rules']`

```php
    $app['security.access_rules'] = [
        [[
            'host' => 'symfony.com',
            'ips' => '192.168.0.1',
            ...
         ], 'ROLE_ADMIN'],
        ...
    ];
```