### PR TITLE
Fix env variable in travis.yaml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,6 @@ matrix:
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=2.8
         - php: 5.6
-          env: SYMFONY_DEPS_VERSION=3
+          env: SYMFONY_DEPS_VERSION=3.0
         - php: 7.0
         - php: hhvm


### PR DESCRIPTION
SYMFONY_DEPS_VERSION=3 was never evaluated correctly as the before_scripts are comparing with 3.0
The tests were still installing 3.0, as minimumStability=dev, but maybe it is nice fixing that.