### PR TITLE
Add the possibility to register forms as services

### DIFF
--- a/doc/providers/form.rst
+++ b/doc/providers/form.rst
@@ -142,8 +142,12 @@ form by adding constraints on the fields::
 
 You can register form types by extending ``form.types``::
 
-    $app['form.types'] = $app->share($app->extend('form.types', function ($types) use ($app) {
+    $app['your.type.service'] = function ($app) {
+        return new YourServiceFormType();
+    };
+    $app->extend('form.types', function ($types) use ($app) {
         $types[] = new YourFormType();
+        $types[] = 'your.type.service';
 
         return $types;
     }));
@@ -159,16 +163,24 @@ You can register form extensions by extending ``form.extensions``::
 
 You can register form type extensions by extending ``form.type.extensions``::
 
+    $app['your.type.extension.service'] = function ($app) {
+        return new YourServiceFormTypeExtension();
+    };
     $app->extend('form.type.extensions', function ($extensions) use ($app) {
         $extensions[] = new YourFormTypeExtension();
+        $extensions[] = 'your.type.extension.service';
 
         return $extensions;
     });
 
 You can register form type guessers by extending ``form.type.guessers``::
 
+    $app['your.type.guesser.service'] = function ($app) {
+        return new YourServiceFormTypeGuesser();
+    };
     $app->extend('form.type.guessers', function ($guessers) use ($app) {
         $guessers[] = new YourFormTypeGuesser();
+        $guessers[] = 'your.type.guesser.service';
 
         return $guessers;
     });

--- a/src/Silex/Provider/Form/SilexFormExtension.php
+++ b/src/Silex/Provider/Form/SilexFormExtension.php
@@ -11,23 +11,23 @@
 
 namespace Silex\Provider\Form;
 
-use Silex\Application;
+use Pimple\Container;
 use Symfony\Component\Form\Exception\InvalidArgumentException;
 use Symfony\Component\Form\FormExtensionInterface;
 use Symfony\Component\Form\FormTypeGuesserChain;
 
 class SilexFormExtension implements FormExtensionInterface
 {
-    private $silex;
+    private $app;
     private $types;
     private $typeExtensions;
     private $guessers;
     private $guesserLoaded = false;
     private $guesser;
 
-    public function __construct(Application $silex, array $types, array $typeExtensions, array $guessers)
+    public function __construct(Container $app, array $types, array $typeExtensions, array $guessers)
     {
-        $this->silex = $silex;
+        $this->app = $app;
         $this->setTypes($types);
         $this->setTypeExtensions($typeExtensions);
         $this->setGuessers($guessers);
@@ -39,7 +39,7 @@ class SilexFormExtension implements FormExtensionInterface
             throw new InvalidArgumentException(sprintf('The type "%s" is not the name of a registered form type.', $name));
         }
         if (!is_object($this->types[$name])) {
-            $this->types[$name] = $this->silex[$this->types[$name]];
+            $this->types[$name] = $this->app[$this->types[$name]];
         }
 
         return $this->types[$name];
@@ -69,7 +69,7 @@ class SilexFormExtension implements FormExtensionInterface
                 $guessers = [];
                 foreach ($this->guessers as $guesser) {
                     if (!is_object($guesser)) {
-                        $guesser = $this->silex[$guesser];
+                        $guesser = $this->app[$guesser];
                     }
                     $guessers[] = $guesser;
                 }
@@ -87,7 +87,7 @@ class SilexFormExtension implements FormExtensionInterface
         $this->types = [];
         foreach ($types as $type) {
             if (!is_object($type)) {
-                if (!isset($this->silex[$type])) {
+                if (!isset($this->app[$type])) {
                     throw new InvalidArgumentException(sprintf('Invalid form type. The silex service "%s" does not exist.', $type));
                 }
                 $this->types[$type] = $type;
@@ -102,10 +102,10 @@ class SilexFormExtension implements FormExtensionInterface
         $this->typeExtensions = [];
         foreach ($typeExtensions as $extension) {
             if (!is_object($extension)) {
-                if (!isset($this->silex[$extension])) {
+                if (!isset($this->app[$extension])) {
                     throw new InvalidArgumentException(sprintf('Invalid form type extension. The silex service "%s" does not exist.', $extension));
                 }
-                $extension = $this->silex[$extension];
+                $extension = $this->app[$extension];
             }
             $this->typeExtensions[$extension->getExtendedType()][] = $extension;
         }
@@ -115,7 +115,7 @@ class SilexFormExtension implements FormExtensionInterface
     {
         $this->guessers = [];
         foreach ($guessers as $guesser) {
-            if (!is_object($guesser) && !isset($this->silex[$guesser])) {
+            if (!is_object($guesser) && !isset($this->app[$guesser])) {
                 throw new InvalidArgumentException(sprintf('Invalid form type guesser. The silex service "%s" does not exist.', $guesser));
             }
             $this->guessers[] = $guesser;

--- a/src/Silex/Provider/Form/SilexFormExtension.php
+++ b/src/Silex/Provider/Form/SilexFormExtension.php
@@ -25,7 +25,6 @@ class SilexFormExtension implements FormExtensionInterface
     private $guesserLoaded = false;
     private $guesser;
 
-
     public function __construct(Application $silex, array $types, array $typeExtensions, array $guessers)
     {
         $this->silex = $silex;
@@ -42,6 +41,7 @@ class SilexFormExtension implements FormExtensionInterface
         if (!is_object($this->types[$name])) {
             $this->types[$name] = $this->silex[$this->types[$name]];
         }
+
         return $this->types[$name];
     }
 
@@ -76,6 +76,7 @@ class SilexFormExtension implements FormExtensionInterface
                 $this->guesser = new FormTypeGuesserChain($guessers);
             }
         }
+
         return $this->guesser;
     }
 

--- a/src/Silex/Provider/Form/SilexFormExtension.php
+++ b/src/Silex/Provider/Form/SilexFormExtension.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Provider\Form;
+
+use Silex\Application;
+use Symfony\Component\Form\Exception\InvalidArgumentException;
+use Symfony\Component\Form\FormExtensionInterface;
+use Symfony\Component\Form\FormTypeGuesserChain;
+
+class SilexFormExtension implements FormExtensionInterface
+{
+    private $silex;
+    private $types;
+    private $typeExtensions;
+    private $guessers;
+    private $guesserLoaded = false;
+    private $guesser;
+
+
+    public function __construct(Application $silex, array $types, array $typeExtensions, array $guessers)
+    {
+        $this->silex = $silex;
+        $this->setTypes($types);
+        $this->setTypeExtensions($typeExtensions);
+        $this->setGuessers($guessers);
+    }
+
+    public function getType($name)
+    {
+        if (!isset($this->types[$name])) {
+            throw new InvalidArgumentException(sprintf('The type "%s" is not the name of a registered form type.', $name));
+        }
+        if (!is_object($this->types[$name])) {
+            $this->types[$name] = $this->silex[$this->types[$name]];
+        }
+        return $this->types[$name];
+    }
+
+    public function hasType($name)
+    {
+        return isset($this->types[$name]);
+    }
+
+    public function getTypeExtensions($name)
+    {
+        return isset($this->typeExtensions[$name]) ? $this->typeExtensions[$name] : [];
+    }
+
+    public function hasTypeExtensions($name)
+    {
+        return isset($this->typeExtensions[$name]);
+    }
+
+    public function getTypeGuesser()
+    {
+        if (!$this->guesserLoaded) {
+            $this->guesserLoaded = true;
+
+            if ($this->guessers) {
+                $guessers = [];
+                foreach ($this->guessers as $guesser) {
+                    if (!is_object($guesser)) {
+                        $guesser = $this->silex[$guesser];
+                    }
+                    $guessers[] = $guesser;
+                }
+                $this->guesser = new FormTypeGuesserChain($guessers);
+            }
+        }
+        return $this->guesser;
+    }
+
+    private function setTypes(array $types)
+    {
+        $isForm28 = class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType');
+
+        $this->types = [];
+        foreach ($types as $type) {
+            if (!is_object($type)) {
+                if (!isset($this->silex[$type])) {
+                    throw new InvalidArgumentException(sprintf('Invalid form type. The silex service "%s" does not exist.', $type));
+                }
+                $this->types[$type] = $type;
+            } else {
+                $this->types[$isForm28 ? get_class($type) : $type->getName()] = $type;
+            }
+        }
+    }
+
+    private function setTypeExtensions(array $typeExtensions)
+    {
+        $this->typeExtensions = [];
+        foreach ($typeExtensions as $extension) {
+            if (!is_object($extension)) {
+                if (!isset($this->silex[$extension])) {
+                    throw new InvalidArgumentException(sprintf('Invalid form type extension. The silex service "%s" does not exist.', $extension));
+                }
+                $extension = $this->silex[$extension];
+            }
+            $this->typeExtensions[$extension->getExtendedType()][] = $extension;
+        }
+    }
+
+    private function setGuessers(array $guessers)
+    {
+        $this->guessers = [];
+        foreach ($guessers as $guesser) {
+            if (!is_object($guesser) && !isset($this->silex[$guesser])) {
+                throw new InvalidArgumentException(sprintf('Invalid form type guesser. The silex service "%s" does not exist.', $guesser));
+            }
+            $this->guessers[] = $guesser;
+        }
+    }
+}

--- a/src/Silex/Provider/Form/SilexFormExtension.php
+++ b/src/Silex/Provider/Form/SilexFormExtension.php
@@ -82,8 +82,6 @@ class SilexFormExtension implements FormExtensionInterface
 
     private function setTypes(array $types)
     {
-        $isForm28 = class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType');
-
         $this->types = [];
         foreach ($types as $type) {
             if (!is_object($type)) {
@@ -92,7 +90,7 @@ class SilexFormExtension implements FormExtensionInterface
                 }
                 $this->types[$type] = $type;
             } else {
-                $this->types[$isForm28 ? get_class($type) : $type->getName()] = $type;
+                $this->types[get_class($type)] = $type;
             }
         }
     }

--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -63,8 +63,13 @@ class FormServiceProvider implements ServiceProviderInterface
             return new CsrfExtension($app['csrf.token_manager']);
         };
 
+        $app['form.extension.silex'] = function ($app) {
+            return new Form\SilexFormExtension($app, $app['form.types'], $app['form.type.extensions'], $app['form.type.guessers']);
+        };
+
         $app['form.extensions'] = function ($app) {
             $extensions = array(
+                $app['form.extension.silex'],
                 new HttpFoundationExtension(),
             );
 
@@ -82,9 +87,6 @@ class FormServiceProvider implements ServiceProviderInterface
         $app['form.factory'] = function ($app) {
             return Forms::createFormFactoryBuilder()
                 ->addExtensions($app['form.extensions'])
-                ->addTypes($app['form.types'])
-                ->addTypeExtensions($app['form.type.extensions'])
-                ->addTypeGuessers($app['form.type.guessers'])
                 ->setResolvedTypeFactory($app['form.resolved_type_factory'])
                 ->getFormFactory()
             ;

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -53,6 +53,49 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Form\Form', $form);
     }
 
+    public function testFormServiceProviderWillLoadTypesServices()
+    {
+        $app = new Application();
+
+        $app->register(new FormServiceProvider());
+
+        $app['dummy'] = function () {
+            return new DummyFormType();
+        };
+        $app->extend('form.types', function ($extensions) {
+            $extensions[] = 'dummy';
+            return $extensions;
+        });
+
+        $form = $app['form.factory']
+            ->createBuilder(class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array())
+            ->add('dummy', 'dummy')
+            ->getForm();
+
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $form);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid form type. The silex service "dummy" does not exist.
+     */
+    public function testNonExistentTypeService()
+    {
+        $app = new Application();
+
+        $app->register(new FormServiceProvider());
+
+        $app->extend('form.types', function ($extensions) {
+            $extensions[] = 'dummy';
+            return $extensions;
+        });
+
+        $app['form.factory']
+            ->createBuilder(class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array())
+            ->add('dummy', 'dummy')
+            ->getForm();
+    }
+
     public function testFormServiceProviderWillLoadTypeExtensions()
     {
         $app = new Application();
@@ -72,6 +115,49 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Form\Form', $form);
     }
 
+    public function testFormServiceProviderWillLoadTypeExtensionsServices()
+    {
+        $app = new Application();
+
+        $app->register(new FormServiceProvider());
+
+        $app['dummy.form.type.extension'] = function () {
+            return new DummyFormTypeExtension();
+        };
+        $app->extend('form.type.extensions', function ($extensions) {
+            $extensions[] = 'dummy.form.type.extension';
+            return $extensions;
+        });
+
+        $form = $app['form.factory']
+            ->createBuilder(class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array())
+            ->add('file', class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FileType' : 'file', array('image_path' => 'webPath'))
+            ->getForm();
+
+        $this->assertInstanceOf('Symfony\Component\Form\Form', $form);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid form type extension. The silex service "dummy.form.type.extension" does not exist.
+     */
+    public function testNonExistentTypeExtensionService()
+    {
+        $app = new Application();
+
+        $app->register(new FormServiceProvider());
+
+        $app->extend('form.type.extensions', function ($extensions) {
+            $extensions[] = 'dummy.form.type.extension';
+            return $extensions;
+        });
+
+        $app['form.factory']
+            ->createBuilder(class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array())
+            ->add('dummy', 'dummy.form.type')
+            ->getForm();
+    }
+
     public function testFormServiceProviderWillLoadTypeGuessers()
     {
         $app = new Application();
@@ -85,6 +171,42 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         });
 
         $this->assertInstanceOf('Symfony\Component\Form\FormFactory', $app['form.factory']);
+    }
+
+    public function testFormServiceProviderWillLoadTypeGuessersServices()
+    {
+        $app = new Application();
+
+        $app->register(new FormServiceProvider());
+
+        $app['dummy.form.type.guesser'] = function () {
+            return new FormTypeGuesserChain(array());
+        };
+        $app->extend('form.type.guessers', function ($guessers) {
+            $guessers[] = 'dummy.form.type.guesser';
+
+            return $guessers;
+        });
+
+        $this->assertInstanceOf('Symfony\Component\Form\FormFactory', $app['form.factory']);
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Form\Exception\InvalidArgumentException
+     * @expectedExceptionMessage Invalid form type guesser. The silex service "dummy.form.type.guesser" does not exist.
+     */
+    public function testNonExistentTypeGuesserService()
+    {
+        $app = new Application();
+
+        $app->register(new FormServiceProvider());
+
+        $app->extend('form.type.guessers', function ($extensions) {
+            $extensions[] = 'dummy.form.type.guesser';
+            return $extensions;
+        });
+
+        $factory = $app['form.factory'];
     }
 
     public function testFormServiceProviderWillUseTranslatorIfAvailable()
@@ -159,8 +281,22 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
     }
 }
 
-class DummyFormType extends AbstractType
-{
+if (!class_exists('Symfony\Component\Form\Deprecated\FormEvents')) {
+    class DummyFormType extends AbstractType
+    {
+    }
+} else {
+    // FormTypeInterface::getName() is needed by the form component 2.8.x
+    class DummyFormType extends AbstractType
+    {
+        /**
+         * @return string The name of this type
+         */
+        public function getName()
+        {
+            return 'dummy';
+        }
+    }
 }
 
 if (method_exists('Symfony\Component\Form\AbstractType', 'configureOptions')) {

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -64,6 +64,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         };
         $app->extend('form.types', function ($extensions) {
             $extensions[] = 'dummy';
+
             return $extensions;
         });
 
@@ -87,6 +88,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app->extend('form.types', function ($extensions) {
             $extensions[] = 'dummy';
+
             return $extensions;
         });
 
@@ -126,6 +128,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         };
         $app->extend('form.type.extensions', function ($extensions) {
             $extensions[] = 'dummy.form.type.extension';
+
             return $extensions;
         });
 
@@ -149,6 +152,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app->extend('form.type.extensions', function ($extensions) {
             $extensions[] = 'dummy.form.type.extension';
+
             return $extensions;
         });
 
@@ -203,6 +207,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app->extend('form.type.guessers', function ($extensions) {
             $extensions[] = 'dummy.form.type.guesser';
+
             return $extensions;
         });
 

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -69,7 +69,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         });
 
         $form = $app['form.factory']
-            ->createBuilder(class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array())
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', array())
             ->add('dummy', 'dummy')
             ->getForm();
 
@@ -93,7 +93,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         });
 
         $app['form.factory']
-            ->createBuilder(class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array())
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', array())
             ->add('dummy', 'dummy')
             ->getForm();
     }
@@ -133,8 +133,8 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         });
 
         $form = $app['form.factory']
-            ->createBuilder(class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array())
-            ->add('file', class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FileType' : 'file', array('image_path' => 'webPath'))
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', array())
+            ->add('file', 'Symfony\Component\Form\Extension\Core\Type\FileType', array('image_path' => 'webPath'))
             ->getForm();
 
         $this->assertInstanceOf('Symfony\Component\Form\Form', $form);
@@ -157,7 +157,7 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         });
 
         $app['form.factory']
-            ->createBuilder(class_exists('Symfony\Component\Form\Extension\Core\Type\RangeType') ? 'Symfony\Component\Form\Extension\Core\Type\FormType' : 'form', array())
+            ->createBuilder('Symfony\Component\Form\Extension\Core\Type\FormType', array())
             ->add('dummy', 'dummy.form.type')
             ->getForm();
     }


### PR DESCRIPTION
This allows you to register your form types / form types extensions / form types guessers as Silex services:
```php
    $app['your.type.service'] = function ($app) {
        return new YourServiceFormType();
    };
    $app->extend('form.types', function ($types) use ($app) {
        $types[] = 'your.type.service';
        return $types;
    }));
    ...
    $builder = $app['form.factory']->createBuilder('your.type.service');
```
This is particularly useful for users of Symfony 3.x, now that `FormFactory::createBuilder()` and friends don't allow you to pass an instance of `FormTypeInterface` anymore, preventing you from loading form types that require constructor arguments lazily (without the patch you have to add objects to the `form.types` / `form.type.extensions` / `form.type.guessers` parameters which means every single form of your application will have to get instantiated whenever you use the form component).

The patch contains a new `SilexFormExtension` extension class that handles the dereferencing of services names / lazy loading, new tests, and documentation fixes.

Other quick notes:
* No type checking is performed by the extension, but that's consistent with the way the `FormServiceProvider` works without the patch. Nevertheless, I believe this should be enhanced and will be ready to work on this after the merge if you reckon that would be a good idea.
* I had to change the `DummyFormType` declaration in the tests. You used a class with a `getName()` method with Symfony < 2.8 and one without the method with 2.8+. Now the problem is that the `FormRegistry` from 2.8.x still uses the `getName()` method to store form types, which means it is still needed in some cases. Thus for my tests to pass I had to make sure the class with `getName()` was used with any 2.x version while the one without it was only used with 3.x