### PR TITLE
Fixing TwigServiceProvider when used with FormServiceProvider but without CsrfServiceProvider

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -102,7 +102,9 @@ class TwigServiceProvider implements ServiceProviderInterface
                     };
 
                     $app['twig.form.renderer'] = function ($app) {
-                        return new TwigRenderer($app['twig.form.engine'], $app['csrf.token_manager']);
+                        $csrfTokenManager = isset($app['csrf.token_manager']) ? $app['csrf.token_manager'] : null;
+
+                        return new TwigRenderer($app['twig.form.engine'], $csrfTokenManager);
                     };
 
                     $twig->addExtension(new FormExtension($app['twig.form.renderer']));

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -107,4 +107,13 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Bridge\Twig\Form\TwigRendererEngine', $app['twig.form.engine'], 'Service twig.form.engine is created successful.');
         $this->assertInstanceOf('Symfony\Bridge\Twig\Form\TwigRenderer', $app['twig.form.renderer'], 'Service twig.form.renderer is created successful.');
     }
+
+    public function testFormWithoutCsrf()
+    {
+        $app = new Application();
+        $app->register(new FormServiceProvider());
+        $app->register(new TwigServiceProvider());
+
+        $this->assertInstanceOf('Twig_Environment', $app['twig']);
+    }
 }


### PR DESCRIPTION
Trivial fix for #1331, with test.