### PR TITLE
Clarify purpose of BootableServiceProvider

### DIFF
--- a/src/Silex/Api/BootableProviderInterface.php
+++ b/src/Silex/Api/BootableProviderInterface.php
@@ -14,7 +14,7 @@ namespace Silex\Api;
 use Silex\Application;
 
 /**
- * Interface that must implement all Silex service providers.
+ * Interface for bootable service providers.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */


### PR DESCRIPTION
`BootableServiceProvider` has an outdated description.  This PR brings the comment into line with the rest of the interfaces in `Silex\Api`