### PR TITLE
Fixed Session Service Provider registry

### DIFF
--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -38,7 +38,7 @@ class SessionServiceProvider implements ServiceProviderInterface, EventListenerP
         $app['session.test'] = false;
 
         $app['session'] = function ($app) {
-            return new Session($app['session.storage']);
+            return new Session($app['session.storage'], $app['session.attribute_bag'], $app['session.flash_bag']);
         };
 
         $app['session.storage'] = function ($app) {
@@ -61,7 +61,7 @@ class SessionServiceProvider implements ServiceProviderInterface, EventListenerP
         };
 
         $app['session.listener'] = function ($app) {
-            return new SessionListener($app, $app['session.attribute_bag'], $app['session.flash_bag']);
+            return new SessionListener($app);
         };
 
         $app['session.storage.test'] = function () {

--- a/tests/Silex/Tests/Provider/SessionServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SessionServiceProviderTest.php
@@ -15,6 +15,7 @@ use Silex\Application;
 use Silex\WebTestCase;
 use Silex\Provider\SessionServiceProvider;
 use Symfony\Component\HttpKernel\Client;
+use Symfony\Component\HttpFoundation\Session;
 
 /**
  * SessionProvider test cases.
@@ -103,5 +104,23 @@ class SessionServiceProviderTest extends WebTestCase
 
         $client->request('get', '/robots.txt');
         $this->assertEquals('Informations for robots.', $client->getResponse()->getContent());
+    }
+
+    public function testSessionRegister()
+    {
+        $app = new Application();
+
+        $attrs = new Session\Attribute\AttributeBag();
+        $flash = new Session\Flash\FlashBag();
+        $app->register(new SessionServiceProvider(), array(
+            'session.attribute_bag' => $attrs,
+            'session.flash_bag' => $flash,
+            'session.test' => true,
+        ));
+
+        $session = $app['session'];
+
+        $this->assertSame($flash, $session->getBag('flashes'));
+        $this->assertSame($attrs, $session->getBag('attributes'));
     }
 }


### PR DESCRIPTION
The service provider was registering the wrong parameters
to the session listener instead of the actual session class

This fixes #1342 

Signed-off-by: RJ Garcia <rj@bighead.net>