### PR TITLE
Allowing callables for mount

### DIFF
--- a/doc/organizing_controllers.rst
+++ b/doc/organizing_controllers.rst
@@ -25,6 +25,16 @@ group them logically::
     $app->mount('/blog', $blog);
     $app->mount('/forum', $forum);
 
+    // define controllers for a admin
+    $app->mount('/admin', function ($api) {
+        // recursively mount
+        $api->mount('/blog', function ($user) {
+            $user->get('/', function () {
+                return 'Admin Blog home page';
+            });
+        });
+    });
+
 .. note::
 
     ``$app['controllers_factory']`` is a factory that returns a new instance
@@ -32,7 +42,8 @@ group them logically::
 
 ``mount()`` prefixes all routes with the given prefix and merges them into the
 main Application. So, ``/`` will map to the main home page, ``/blog/`` to the
-blog home page, and ``/forum/`` to the forum home page.
+blog home page, ``/forum/`` to the forum home page, and ``/admin/blog/`` to the
+admin blog home page.
 
 .. caution::
 

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -437,8 +437,8 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
     /**
      * Mounts controllers under the given route prefix.
      *
-     * @param string                                           $prefix      The route prefix
-     * @param ControllerCollection|ControllerProviderInterface $controllers A ControllerCollection or a ControllerProviderInterface instance
+     * @param string                                                    $prefix      The route prefix
+     * @param ControllerCollection|callable|ControllerProviderInterface $controllers A ControllerCollection, a callable, or a ControllerProviderInterface instance
      *
      * @return Application
      *
@@ -454,8 +454,8 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
             }
 
             $controllers = $connectedControllers;
-        } elseif (!$controllers instanceof ControllerCollection) {
-            throw new \LogicException('The "mount" method takes either a "ControllerCollection" or a "ControllerProviderInterface" instance.');
+        } elseif (!$controllers instanceof ControllerCollection && !is_callable($controllers)) {
+            throw new \LogicException('The "mount" method takes either a "ControllerCollection" instance, "ControllerProviderInterface" instance, or a callable.');
         }
 
         $this['controllers']->mount($prefix, $controllers);

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -44,11 +44,13 @@ class ControllerCollection
     protected $defaultController;
     protected $prefix;
     protected $routesFactory;
+    protected $controllersFactory;
 
-    public function __construct(Route $defaultRoute, $routesFactory = null)
+    public function __construct(Route $defaultRoute, RouteCollection $routesFactory = null, $controllersFactory = null)
     {
         $this->defaultRoute = $defaultRoute;
         $this->routesFactory = $routesFactory;
+        $this->controllersFactory = $controllersFactory;
         $this->defaultController = function (Request $request) {
             throw new \LogicException(sprintf('The "%s" route must have code to run when it matches.', $request->attributes->get('_route')));
         };
@@ -57,11 +59,21 @@ class ControllerCollection
     /**
      * Mounts controllers under the given route prefix.
      *
-     * @param string               $prefix      The route prefix
-     * @param ControllerCollection $controllers A ControllerCollection instance
+     * @param string                        $prefix      The route prefix
+     * @param ControllerCollection|callable $controllers A ControllerCollection instance or a callable for defining routes
+     *
+     * @throws \LogicException
      */
-    public function mount($prefix, ControllerCollection $controllers)
+    public function mount($prefix, $controllers)
     {
+        if (is_callable($controllers)) {
+            $collection = $this->controllersFactory ? call_user_func($this->controllersFactory) : new static(new Route(), new RouteCollection());
+            call_user_func($controllers, $collection);
+            $controllers = $collection;
+        } elseif (!$controllers instanceof self) {
+            throw new \LogicException('The "mount" method takes either a "ControllerCollection" instance or callable.');
+        }
+
         $controllers->prefix = $prefix;
 
         $this->controllers[] = $controllers;

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -66,9 +66,10 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
             return $app['controllers_factory'];
         };
 
-        $app['controllers_factory'] = $app->factory(function ($app) {
-            return new ControllerCollection($app['route_factory'], $app['routes_factory']);
-        });
+        $controllers_factory = function () use ($app, &$controllers_factory) {
+            return new ControllerCollection($app['route_factory'], $app['routes_factory'], $controllers_factory);
+        };
+        $app['controllers_factory'] = $app->factory($controllers_factory);
 
         $app['routing.listener'] = function ($app) {
             $urlMatcher = new LazyRequestMatcher(function () use ($app) {

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -464,7 +464,7 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
 
     /**
      * @expectedException        \LogicException
-     * @expectedExceptionMessage The "mount" method takes either a "ControllerCollection" or a "ControllerProviderInterface" instance.
+     * @expectedExceptionMessage The "mount" method takes either a "ControllerCollection" instance, "ControllerProviderInterface" instance, or a callable.
      */
     public function testMountNullException()
     {
@@ -480,6 +480,18 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
     {
         $app = new Application();
         $app->mount('/exception', new IncorrectControllerCollection());
+    }
+
+    public function testMountCallable()
+    {
+        $app = new Application();
+        $app->mount('/prefix', function (ControllerCollection $coll) {
+            $coll->get('/path');
+        });
+
+        $app->flush();
+
+        $this->assertEquals(1, $app['routes']->count());
     }
 
     public function testSendFile()

--- a/tests/Silex/Tests/Provider/RoutingServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/RoutingServiceProviderTest.php
@@ -11,7 +11,9 @@
 
 namespace Silex\Tests\Provider;
 
+use Pimple\Container;
 use Silex\Application;
+use Silex\Provider\RoutingServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -105,5 +107,15 @@ class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
         $response = $app->handle($request);
 
         $this->assertEquals('https://localhost/secure', $response->getContent());
+    }
+
+    public function testControllersFactory()
+    {
+        $app = new Container();
+        $app->register(new RoutingServiceProvider());
+        $coll = $app['controllers_factory'];
+        $coll->mount('/blog', function ($blog) {
+            $this->assertInstanceOf('Silex\ControllerCollection', $blog);
+        });
     }
 }


### PR DESCRIPTION
- Added the ability to pass callables into the controller collection
    mount method.
- Updated documentation to show usage of new callables in mount and
    recursive mounting.
- Added appropriate tests

This addresses #1262 and #1290 

Signed-off-by: RJ Garcia <rj@bighead.net>