### PR TITLE
[WIP] Added support for an EmptyPathRoute

### DIFF
--- a/app.php
+++ b/app.php
@@ -1,0 +1,19 @@
+<?php
+
+// php -S localhost:8000 app.php
+
+require_once __DIR__.'/vendor/autoload.php';
+
+$app = new Silex\Application();
+$app['route_class'] = Silex\Route\EmptyPathRoute::class;
+
+$app->mount('/blog', function ($blog) {
+    $blog->get('', function () {
+        return 'blog main';
+    });
+    $blog->get('/path', function () {
+        return 'blog path';
+    });
+});
+
+$app->run();

--- a/src/Silex/Route/EmptyPathRoute.php
+++ b/src/Silex/Route/EmptyPathRoute.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Route;
+
+use Silex\Route as BaseRoute;
+
+/**
+ * Allows Empty Paths in routes. Useful for mounting.
+ *
+ * @author RJ Garcia <rj@bighead.net>
+ */
+class EmptyPathRoute extends BaseRoute
+{
+    private $pathIsEmpty = false;
+
+    public function getPath()
+    {
+        if (!$this->pathIsEmpty) {
+            return parent::getPath();
+        }
+
+        return '';
+    }
+
+    public function setPath($path)
+    {
+        $this->pathIsEmpty = $path === '';
+
+        return parent::setPath($path);
+    }
+
+    public function serialize()
+    {
+        $data = unserialize(parent::serialize());
+        $data['path_is_empty'] = $this->pathIsEmpty;
+
+        return serialize($data);
+    }
+
+    public function unserialize($serialized)
+    {
+        $data = unserialize($serialized);
+        $this->pathIsEmpty = $data['path_is_empty'];
+
+        parent::unserialize($serialized);
+    }
+}

--- a/tests/Silex/Tests/Route/EmptyPathRouteTest.php
+++ b/tests/Silex/Tests/Route/EmptyPathRouteTest.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Route;
+
+use Silex\Route\EmptyPathRoute;
+
+/**
+ * @author RJ Garcia <rj@bighead.net>
+ */
+class EmptyPathRouteTest extends \PHPUnit_Framework_TestCase
+{
+    public function testConstruct()
+    {
+        $route = new EmptyPathRoute('');
+        $this->assertEquals('', $route->getPath());
+    }
+
+    /**
+     * @dataProvider pathProvider
+     */
+    public function testPath(EmptyPathRoute $route, $path, $expected)
+    {
+        $route->setPath($path);
+        $this->assertEquals($expected, $route->getPath());
+    }
+
+    public function pathProvider()
+    {
+        $route = new EmptyPathRoute('/');
+
+        return [
+            [$route, '', ''],
+            [$route, '/path', '/path'],
+            [$route, '', ''],
+            [$route, 'path', '/path'],
+        ];
+    }
+
+    public function testSerialize()
+    {
+        $route = new EmptyPathRoute('', ['key' => 'val']);
+        $new_route = new EmptyPathRoute('/path');
+        $new_route->unserialize($route->serialize());
+
+        $this->assertEquals('val', $new_route->getDefault('key'));
+        $this->assertEquals('', $new_route->getPath());
+    }
+}


### PR DESCRIPTION
This would potentially resolve #149 allowing empty paths.

Usage would be like so:

``` php
<?php

// php -S localhost:8000 app.php

require_once __DIR__ . '/vendor/autoload.php';

$app = new Silex\Application();
$app['route_class'] = Silex\Route\EmptyPathRoute::class;


$app->mount('/blog', function($blog) {
    $blog->get('', function() {
        return 'blog main';
    });
    $blog->get('/path', function() {
        return 'blog path';
    });
});

$app->run();
```

I haven't added documentation on this feature, and I'll have to remove the app.php file that I added (it's there for demo/testing purposes). 

There are a lot of directions this can go.
- This can be a third party library that people integrate with (so not apart of the silex core). 
- Or we could keep it like the example shows right now
- Or we can add a parameter in the app named `allow_empty_paths` and that will trigger the route class to use EmptyPathRoute or the normal Route
- Or we can make the EmptyPathRoute the standard Route (meaning, we apply the changes in empty path route to the `Silex\Route` class)
- Or We could only allow empty path routes on nested controllers, and transparently change the base route for nested routes.
