### PR TITLE
Adding a flag to disable the Monolog error handler

### DIFF
--- a/doc/providers/monolog.rst
+++ b/doc/providers/monolog.rst
@@ -31,6 +31,14 @@ Parameters
 * **monolog.exception.logger_filter** (optional): An anonymous function that
   filters which exceptions should be logged.
 
+* **monolog.use_error_handler** (optional): Whether errors and uncaught exceptions
+  should be handled by the Monolog ``ErrorHandler`` class and added to the log.
+  By default the error handler is enabled unless the application ``debug`` parameter
+  is set to true.
+
+  Please note that enabling the error handler may silence some errors,
+  ignoring the PHP ``display_errors`` configuration setting.
+
 Services
 --------
 

--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -106,11 +106,14 @@ class MonologServiceProvider implements ServiceProviderInterface, BootableProvid
         $app['monolog.permission'] = null;
         $app['monolog.exception.logger_filter'] = null;
         $app['monolog.logfile'] = null;
+        $app['monolog.use_error_handler'] = !$app['debug'];
     }
 
     public function boot(Application $app)
     {
-        ErrorHandler::register($app['monolog']);
+        if ($app['monolog.use_error_handler']) {
+            ErrorHandler::register($app['monolog']);
+        }
 
         if (isset($app['monolog.listener'])) {
             $app['dispatcher']->addSubscriber($app['monolog.listener']);


### PR DESCRIPTION
The monolog error handler can now be disabled by setting the value of the new `monolog.use_error_handler` parameter to false (since it was added in  a53ce5902983493c53eea61f6cf1e304c0aa6409 it was always enabled).

The error handler is disabled by default when the application `debug` parameter is set to true, to ensure it won't silence exceptions and/or errors. 

Without the flag, an uncaught exception thrown during boot on `master` will just result in a white page, even when using `debug` and `error_reporting` (because the error handler calls `exit` after logging exceptions).