### PR TITLE
Fixed var name in organizing controllers

### DIFF
--- a/doc/organizing_controllers.rst
+++ b/doc/organizing_controllers.rst
@@ -26,9 +26,9 @@ group them logically::
     $app->mount('/forum', $forum);
 
     // define controllers for a admin
-    $app->mount('/admin', function ($api) {
+    $app->mount('/admin', function ($admin) {
         // recursively mount
-        $api->mount('/blog', function ($user) {
+        $admin->mount('/blog', function ($user) {
             $user->get('/', function () {
                 return 'Admin Blog home page';
             });


### PR DESCRIPTION
Updated the var name in the organizing controllers documenation
in order be consistent with the variable naming throughout the
code sample.

Signed-off-by: RJ Garcia <rj@bighead.net>