### PR TITLE
Fix installation instruction in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ The recommended way to install Silex is through `Composer`_:
 
 .. code-block:: bash
 
-    composer require silex/silex "~2.0@dev"
+    composer require silex/silex "~2.0"
 
 Alternatively, you can download the `silex.zip`_ file and extract it.
 


### PR DESCRIPTION
Silex 2 has been released yesterday so `@dev` should be removed from the composer version string.