### PR TITLE
Update csrf.rst

### DIFF
--- a/doc/providers/csrf.rst
+++ b/doc/providers/csrf.rst
@@ -45,7 +45,7 @@ Service Provider are protected against CSRF by default.
 
 You can also use the CSRF protection even without using the Symfony Form
 component. If, for example, you're doing a DELETE action, you can check the
-CSRF token::
+CSRF token:
 
 .. code-block:: php
 


### PR DESCRIPTION
code block is broken here, in Usage section http://silex.sensiolabs.org/doc/master/providers/csrf.html 
seems to be redundant colon