### PR TITLE
Add ControllerServiceProviderInterface for Application::registerAndMount

### DIFF
--- a/src/Silex/Api/ControllerServiceProviderInterface.php
+++ b/src/Silex/Api/ControllerServiceProviderInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Api;
+
+use Pimple\ServiceProviderInterface;
+
+/**
+ * Interface for controller service providers.
+ */
+interface ControllerServiceProviderInterface extends ControllerProviderInterface, ServiceProviderInterface
+{
+}

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -30,6 +30,7 @@ use Symfony\Component\HttpFoundation\JsonResponse;
 use Silex\Api\BootableProviderInterface;
 use Silex\Api\EventListenerProviderInterface;
 use Silex\Api\ControllerProviderInterface;
+use Silex\Api\ControllerServiceProviderInterface;
 use Silex\Provider\ExceptionHandlerServiceProvider;
 use Silex\Provider\RoutingServiceProvider;
 use Silex\Provider\HttpKernelServiceProvider;
@@ -459,6 +460,25 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         }
 
         $this['controllers']->mount($prefix, $controllers);
+
+        return $this;
+    }
+
+    /**
+     * Registers a controller provider and mounts it under a route prefix.
+     *
+     * @param string                             $prefix   The route prefix
+     * @param ControllerServiceProviderInterface $provider A ControllerServiceProviderInterface instance
+     * @param array                              $values   An array of values that customizes the provider
+     *
+     * @return Application
+     *
+     * @throws \LogicException
+     */
+    public function registerAndMount($prefix, ControllerServiceProviderInterface $provider, array $values = array())
+    {
+        $this->register($provider, $values);
+        $this->mount($prefix, $provider);
 
         return $this;
     }

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -503,6 +503,23 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $app['routes']->count());
     }
 
+    public function testRegisterAndMountShouldReturnSelf()
+    {
+        $app = new Application();
+        $provider = $this->getMock('Silex\Api\ControllerServiceProviderInterface');
+
+        $mounted = new ControllerCollection(new Route());
+        $mounted->get('/{name}', function ($name) { return new Response($name); });
+
+        $provider->expects($this->once())
+            ->method('connect')
+            ->with($app)
+            ->will($this->returnValue($mounted))
+        ;
+
+        $this->assertSame($app, $app->registerAndMount('/hello', $provider));
+    }
+
     public function testSendFile()
     {
         $app = new Application();


### PR DESCRIPTION
Simplifies the setup for service providers which also provide controllers, which is possible as mentioned in the documentation at [http://silex.sensiolabs.org/doc/master/providers.html](http://silex.sensiolabs.org/doc/master/providers.html). This PR also formalizes this behaviour with an interface that combines Pimple's `ServiceProviderInterface` and Silex's `ControllerProviderInterface`.

If you use quite a few of these in a larger application, your app.php ends up having a lot of

``` php
$app->register($fooProvider = new Bar\FooProvider());
$app->mount('/foo', $fooProvider);
```

instead of which you can use

``` php
$app->registerAndMount('/foo', new Bar\FooProvider());
```

Not sure if you think this is superfluous, but I find this a bit more convient, and it's a rather small addition.
