### PR TITLE
Bootstrap composer autoload in PHPUnit

### DIFF
--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -182,7 +182,8 @@ look like this:
 .. code-block:: xml
 
     <?xml version="1.0" encoding="UTF-8"?>
-    <phpunit backupGlobals="false"
+    <phpunit bootstrap="./vendor/autoload.php"
+             backupGlobals="false"
              backupStaticAttributes="false"
              colors="true"
              convertErrorsToExceptions="true"


### PR DESCRIPTION
Avoid to require autoload in test class.