### PR TITLE
fix lazy evaluation of 'monolog.use_error_handler'

### DIFF
--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -106,7 +106,7 @@ class MonologServiceProvider implements ServiceProviderInterface, BootableProvid
         $app['monolog.permission'] = null;
         $app['monolog.exception.logger_filter'] = null;
         $app['monolog.logfile'] = null;
-        $app['monolog.use_error_handler'] = function($app) {
+        $app['monolog.use_error_handler'] = function ($app) {
             return !$app['debug'];
         };
     }

--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -106,7 +106,9 @@ class MonologServiceProvider implements ServiceProviderInterface, BootableProvid
         $app['monolog.permission'] = null;
         $app['monolog.exception.logger_filter'] = null;
         $app['monolog.logfile'] = null;
-        $app['monolog.use_error_handler'] = !$app['debug'];
+        $app['monolog.use_error_handler'] = function($app) {
+            return !$app['debug'];
+        };
     }
 
     public function boot(Application $app)


### PR DESCRIPTION
the value of 'debug' could be set after registering the serviceprovider.