### PR TITLE
Update testing.rst - preventing Fatal Error: Class 'Silex\WebTestCase' not found

### DIFF
--- a/doc/testing.rst
+++ b/doc/testing.rst
@@ -191,6 +191,7 @@ look like this:
              processIsolation="false"
              stopOnFailure="false"
              syntaxCheck="false"
+             bootstrap="vendor/autoload.php"
     >
         <testsuites>
             <testsuite name="YourApp Test Suite">


### PR DESCRIPTION
Taken from:
https://github.com/silexphp/Silex-Skeleton/blob/master/phpunit.xml.dist

Not adding bootstrap segment to phpunit.xml.dist causes Fatal Error: Class 'Silex\WebTestCase' not found