### PR TITLE
fix header format check strpos argument order

### DIFF
--- a/doc/cookbook/guard_authentication.rst
+++ b/doc/cookbook/guard_authentication.rst
@@ -52,7 +52,7 @@ AbstractGuardAuthenticator. This requires you to implement six methods:
             }
 
             // Parse the header or ignore it if the format is incorrect.
-            if (false === strpos(':', $token)) {
+            if (false === strpos($token, ':')) {
                 return;
             }
             list($username, $secret) = explode(':', $token, 2);


### PR DESCRIPTION
The argument order for strpos in the Guard Authentication example was mixed up