### PR TITLE
Add symfony/twig-bridge to Asset provider documentation

### DIFF
--- a/doc/providers/asset.rst
+++ b/doc/providers/asset.rst
@@ -48,6 +48,14 @@ Usage
 
 The AssetServiceProvider is mostly useful with the Twig provider:
 
+.. note::
+
+    Add the Symfony Twig Bridge Component as a dependency:
+
+    .. code-block:: bash
+
+        composer require symfony/twig-bridge
+
 .. code-block:: jinja
 
     {{ asset('/css/foo.png') }}


### PR DESCRIPTION
Add symfony/twig-bridge to Asset provider documentation. I found that it wasn't clear that twig-bridge was necessary to be able to use {{  asset() }} in twig files.