### PR TITLE
Specify relation of twig-bridge to symfony/config

### DIFF
--- a/doc/providers/form.rst
+++ b/doc/providers/form.rst
@@ -60,7 +60,7 @@ Registering
 
     .. code-block:: bash
 
-        composer require symfony/twig-bridge symfony/translation
+        composer require symfony/twig-bridge symfony/config symfony/translation
 
 Usage
 -----


### PR DESCRIPTION
When I install `symfony/twig-bridge` I've got `Class 'Symfony\Component\Config\Util\XmlUtils' not found in /vendor/symfony/translation/Loader/XliffFileLoader.php on line 53`

It's kinda related to comment https://github.com/symfony/symfony/issues/13194#issuecomment-90893304