### PR TITLE
Add Symfony Twig Brigde installation in asset doc

### DIFF
--- a/doc/providers/asset.rst
+++ b/doc/providers/asset.rst
@@ -43,6 +43,13 @@ Registering
 
         composer require symfony/asset
 
+    If you want to use assets in your Twig templates, you must also install the
+    Symfony Twig Bridge:
+
+    .. code-block:: bash
+
+        composer require symfony/twig-bridge
+
 Usage
 -----
 


### PR DESCRIPTION
Add Symfony Twig Brigde installation in asset doc, I have the following error otherwise : `Unknown "asset" function`
Made it clearer that twig-bridge is required.

