### PR TITLE
Move setting $app['twig.app_variable'] after 'Symfony\Bridge\Twig' check

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -39,19 +39,6 @@ class TwigServiceProvider implements ServiceProviderInterface
         $app['twig.path'] = array();
         $app['twig.templates'] = array();
 
-        $app['twig.app_variable'] = function ($app) {
-            $var = new AppVariable();
-            if (isset($app['security.token_storage'])) {
-                $var->setTokenStorage($app['security.token_storage']);
-            }
-            if (isset($app['request_stack'])) {
-                $var->setRequestStack($app['request_stack']);
-            }
-            $var->setDebug($app['debug']);
-
-            return $var;
-        };
-
         $app['twig'] = function ($app) {
             $app['twig.options'] = array_replace(
                 array(
@@ -71,6 +58,19 @@ class TwigServiceProvider implements ServiceProviderInterface
             }
 
             if (class_exists('Symfony\Bridge\Twig\Extension\RoutingExtension')) {
+                $app['twig.app_variable'] = function ($app) {
+                    $var = new AppVariable();
+                    if (isset($app['security.token_storage'])) {
+                        $var->setTokenStorage($app['security.token_storage']);
+                    }
+                    if (isset($app['request_stack'])) {
+                        $var->setRequestStack($app['request_stack']);
+                    }
+                    $var->setDebug($app['debug']);
+
+                    return $var;
+                };
+
                 $twig->addGlobal('global', $app['twig.app_variable']);
 
                 if (isset($app['request_stack'])) {


### PR DESCRIPTION
Currently `TwigServiceProvider ` sets `$app['twig.app_variable']` to be function that has a dependency on classes that are not required by Silex. This will fail if the user then calls that function. This happens for example when the [silex-pimple-dumper](https://github.com/Sorien/silex-pimple-dumper) maps over the app and tries to dump it's content. 

This PR fixes that by moving this in the `class_exists('Symfony\Bridge\Twig\Extension\RoutingExtension')` check. 

I've also added comment because at first it wasn't clear for me that this check for the `RoutingExtension` was the check for the whole Twig bridge. Please feel free to rebase and remove it it you don't like it or I misinterpreted it.

Keep up the good work! 👍 