### PR TITLE
RequestStack link in Services documentation is broken

### DIFF
--- a/doc/services.rst
+++ b/doc/services.rst
@@ -167,7 +167,7 @@ Core services
 Silex defines a range of services.
 
 * **request_stack**: Controls the lifecycle of requests, an instance of
-  `RequestStack <http://api.symfony.com/master/Symfony/Component/HttpFoundation/RequestStack.html>` _.
+  `RequestStack <http://api.symfony.com/master/Symfony/Component/HttpFoundation/RequestStack.html>`_.
   It gives you access to ``GET``, ``POST`` parameters and lots more!
 
   Example usage::


### PR DESCRIPTION
There was an extra space breaking the URL formatting