### PR TITLE
Added a default kernel.root_dir value

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -65,6 +65,7 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         $this['debug'] = false;
         $this['charset'] = 'UTF-8';
         $this['logger'] = null;
+        $this['kernel.root_dir'] = dirname(dirname(dirname(dirname(dirname(dirname(__FILE__)))))).DIRECTORY_SEPARATOR.'app';
 
         $this->register(new HttpKernelServiceProvider());
         $this->register(new RoutingServiceProvider());


### PR DESCRIPTION
This add a default kernel.root_dir value that can be used by the FileLinkFormater. See https://github.com/silexphp/Silex-WebProfiler/pull/99 for details.

With a default value, the https://github.com/silexphp/Silex-WebProfiler/pull/99 will work out of the box.