### PR TITLE
The services must be set only if HttpKernelRuntime exists

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -122,6 +122,21 @@ class TwigServiceProvider implements ServiceProviderInterface
                 }
 
                 if (class_exists(HttpKernelRuntime::class)) {
+                    $app['twig.runtime.httpkernel'] = function ($app) {
+                        return new HttpKernelRuntime($app['fragment.handler']);
+                    };
+
+                    $app['twig.runtimes'] = function ($app) {
+                        return array(
+                            HttpKernelRuntime::class => 'twig.runtime.httpkernel',
+                            TwigRenderer::class => 'twig.form.renderer',
+                        );
+                    };
+
+                    $app['twig.runtime_loader'] = function ($app) {
+                        return new RuntimeLoader($app, $app['twig.runtimes']);
+                    };
+
                     $twig->addRuntimeLoader($app['twig.runtime_loader']);
                 }
             }
@@ -147,20 +162,5 @@ class TwigServiceProvider implements ServiceProviderInterface
         $app['twig.environment_factory'] = $app->protect(function ($app) {
             return new \Twig_Environment($app['twig.loader'], $app['twig.options']);
         });
-
-        $app['twig.runtime.httpkernel'] = function ($app) {
-            return new HttpKernelRuntime($app['fragment.handler']);
-        };
-
-        $app['twig.runtimes'] = function ($app) {
-            return array(
-                HttpKernelRuntime::class => 'twig.runtime.httpkernel',
-                TwigRenderer::class => 'twig.form.renderer',
-            );
-        };
-
-        $app['twig.runtime_loader'] = function ($app) {
-            return new RuntimeLoader($app, $app['twig.runtimes']);
-        };
     }
 }

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -116,4 +116,13 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Twig_Environment', $app['twig']);
     }
+
+    public function testServices()
+    {
+        $app = new Application();
+        $app->register(new TwigServiceProvider());
+        foreach ($app->keys() as $id) {
+            $app[$id];
+        }
+    }
 }


### PR DESCRIPTION
Some services are broken if HttpKernelRuntime does not exist.