### PR TITLE
Fix VarDumping

### DIFF
--- a/src/Silex/Provider/AssetServiceProvider.php
+++ b/src/Silex/Provider/AssetServiceProvider.php
@@ -14,7 +14,6 @@ namespace Silex\Provider;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Symfony\Component\Asset\Packages;
-use Symfony\Component\Asset\Package;
 use Symfony\Component\Asset\PathPackage;
 use Symfony\Component\Asset\UrlPackage;
 use Symfony\Component\Asset\Context\RequestStackContext;

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -118,7 +118,10 @@ class TwigServiceProvider implements ServiceProviderInterface
                 }
 
                 if (isset($app['var_dumper.cloner'])) {
-                    $twig->addExtension(new DumpExtension($app['var_dumper.cloner']));
+                    $twig->addExtension(new DumpExtension(
+                        $app['var_dumper.cloner'],
+                        $app['var_dumper.html_dumper']
+                    ));
                 }
 
                 if (class_exists(HttpKernelRuntime::class)) {

--- a/src/Silex/Provider/VarDumperServiceProvider.php
+++ b/src/Silex/Provider/VarDumperServiceProvider.php
@@ -55,7 +55,7 @@ class VarDumperServiceProvider implements ServiceProviderInterface, BootableProv
         // This code is here to lazy load the dump stack.
         VarDumper::setHandler(function ($var) use ($app) {
             $handler = function ($var) use ($app) {
-                $env = null === $app['var_dumper.env'] ? PHP_SAPI : $app['var_dumper.env'];
+                $env = null === $app['var_dumper.env'] ? \PHP_SAPI : $app['var_dumper.env'];
                 'cli' === $env
                     ? $app['var_dumper.cli_dumper']->dump($app['var_dumper.cloner']->cloneVar($var))
                     : $app['var_dumper.html_dumper']->dump($app['var_dumper.cloner']->cloneVar($var))

--- a/src/Silex/Provider/VarDumperServiceProvider.php
+++ b/src/Silex/Provider/VarDumperServiceProvider.php
@@ -13,12 +13,12 @@ namespace Silex\Provider;
 
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
-use Silex\Application;
 use Silex\Api\BootableProviderInterface;
-use Symfony\Component\VarDumper\Dumper\HtmlDumper;
-use Symfony\Component\VarDumper\VarDumper;
+use Silex\Application;
 use Symfony\Component\VarDumper\Cloner\VarCloner;
 use Symfony\Component\VarDumper\Dumper\CliDumper;
+use Symfony\Component\VarDumper\Dumper\HtmlDumper;
+use Symfony\Component\VarDumper\VarDumper;
 
 /**
  * Symfony Var Dumper component Provider.
@@ -41,6 +41,8 @@ class VarDumperServiceProvider implements ServiceProviderInterface, BootableProv
             return new VarCloner();
         };
 
+        $app['var_dumper.env'] = null;
+
         $app['var_dumper.dump_destination'] = null;
     }
 
@@ -53,11 +55,13 @@ class VarDumperServiceProvider implements ServiceProviderInterface, BootableProv
         // This code is here to lazy load the dump stack.
         VarDumper::setHandler(function ($var) use ($app) {
             $handler = function ($var) use ($app) {
-                'cli' === PHP_SAPI
+                $env = null === $app['var_dumper.env'] ? PHP_SAPI : $app['var_dumper.env'];
+                'cli' === $env
                     ? $app['var_dumper.cli_dumper']->dump($app['var_dumper.cloner']->cloneVar($var))
                     : $app['var_dumper.html_dumper']->dump($app['var_dumper.cloner']->cloneVar($var))
                 ;
             };
+
             $handler($var);
         });
     }

--- a/tests/Silex/Tests/Provider/VarDumperServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/VarDumperServiceProviderTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Provider;
+
+use Silex\Application;
+use Silex\Provider\VarDumperServiceProvider;
+use Symfony\Component\HttpFoundation\Request;
+
+/**
+ * @author SpacePossum
+ *
+ * @internal
+ */
+final class VarDumperServiceProviderTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param string $env
+     * @param string $expectedRegExp
+     *
+     * @dataProvider provideDumpCases
+     */
+    public function testDump($env, $expectedRegExp)
+    {
+        $output = '';
+        $app = new Application();
+        $app['debug'] = true;
+        $app->register(
+            new VarDumperServiceProvider(),
+            array(
+                'var_dumper.env' => $env,
+                'var_dumper.dump_destination' => $app->protect(
+                    function($line, $depth, $indentPad) use (&$output) {
+                        $output .= sprintf("%s|%d|%s\n", $line, $depth, $indentPad);
+                    }
+                ),
+            )
+        );
+
+        $app->get('/', function () {
+            dump(false);
+
+            return '';
+        });
+
+        $request = Request::create('/');
+        $app->handle($request);
+
+        $this->assertRegExp($expectedRegExp, $output);
+    }
+
+    public function provideDumpCases()
+    {
+        $expectedRegExMessageCLI = '#^false\|0\|  [\n]\|-1\|  [\n]$#s';
+
+        return array(
+            array(null, $expectedRegExMessageCLI),
+            array('cli', $expectedRegExMessageCLI),
+            array('fpm-fcgi', '#<script> Sfdump.*#'),
+        );
+    }
+}

--- a/tests/Silex/Tests/Provider/VarDumperServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/VarDumperServiceProviderTest.php
@@ -38,7 +38,7 @@ final class VarDumperServiceProviderTest extends \PHPUnit_Framework_TestCase
             array(
                 'var_dumper.env' => $env,
                 'var_dumper.dump_destination' => $app->protect(
-                    function($line, $depth, $indentPad) use (&$output) {
+                    function ($line, $depth, $indentPad) use (&$output) {
                         $output .= sprintf("%s|%d|%s\n", $line, $depth, $indentPad);
                     }
                 ),


### PR DESCRIPTION
To reproduce

composer.json
```json
{
  "require": {
    "silex/silex": "v2.0.2"
  },
  "require-dev": {
    "symfony/var-dumper": "v3.1.2"
  }
}

```

index.php
```php
<?php
require_once __DIR__.'/../vendor/autoload.php';

$app = new Silex\Application();
$app['debug'] = true;
$app->register(new Silex\Provider\VarDumperServiceProvider());

$app->get('/', function() {
    dump(false);
    return '1';
});

$app->run();
```

Output (in browser) does not contain the `dump` output, as it is outputted for CLI.
This only happens when `$app['debug']` is set to `true`.
This PR addresses that in a way the service provider becomes more independent of the `Application` execution, which is in line with most providers being aware of a `Container` but being framework agnostic.

Other issue addressed is to allow for different output selection for the `dump` function.
Kindly note that this doesn't work yet when using `dump` in a template when using the `TwigServiceProvider` because [DumpExtension](https://github.com/symfony/symfony/blob/v3.1.7/src/Symfony/Bridge/Twig/Extension/DumpExtension.php#L69) changes the output for some reason.

(last thingy is a dead import removed)

cc @tiemevanveen as he ran into this issue before me