### PR TITLE
Change 'swiftmailer.plugins' to Pimple container

### DIFF
--- a/doc/providers/swiftmailer.rst
+++ b/doc/providers/swiftmailer.rst
@@ -47,16 +47,6 @@ Parameters
   ``delivery_addresses``. If set, emails matching any of these patterns will be
   delivered like normal, as well as being sent to ``delivery_addresses``.
 
-* **swiftmailer.plugins**: Array of SwiftMailer plugins.
-
-  Example usage::
-
-    $app['swiftmailer.plugins'] = function ($app) {
-        return array(
-            new \Swift_Plugins_PopBeforeSmtpPlugin('pop3.example.com'),
-        );
-    };
-
 Services
 --------
 
@@ -82,6 +72,14 @@ Services
 
 * **swiftmailer.transport.eventdispatcher**: Internal event
   dispatcher used by Swiftmailer.
+
+* **swiftmailer.plugins**: SwiftMailer plugins to register.
+
+  Example usage::
+
+    $app['swiftmailer.plugins']['foo'] = function ($app) {
+        return new \Swift_Plugins_PopBeforeSmtpPlugin('pop3.example.com');
+    };
 
 Registering
 -----------

--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -91,26 +91,28 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface, EventListe
 
             $plugins = $app['swiftmailer.plugins'];
 
-            if (null !== $app['swiftmailer.sender_address']) {
-                $plugins[] = new \Swift_Plugins_ImpersonatePlugin($app['swiftmailer.sender_address']);
-            }
-
-            if (!empty($app['swiftmailer.delivery_addresses'])) {
-                $plugins[] = new \Swift_Plugins_RedirectingPlugin(
-                    $app['swiftmailer.delivery_addresses'],
-                    $app['swiftmailer.delivery_whitelist']
-                );
-            }
-
-            foreach ($plugins as $plugin) {
-                $dispatcher->bindEventListener($plugin);
+            foreach ($plugins->keys() as $key) {
+                $dispatcher->bindEventListener($plugins[$key]);
             }
 
             return $dispatcher;
         };
 
         $app['swiftmailer.plugins'] = function ($app) {
-            return array();
+            $plugins = new Container();
+
+            if (null !== $app['swiftmailer.sender_address']) {
+                $plugins['sender_address'] = new \Swift_Plugins_ImpersonatePlugin($app['swiftmailer.sender_address']);
+            }
+
+            if (!empty($app['swiftmailer.delivery_addresses'])) {
+                $plugins['delivery_addresses'] = new \Swift_Plugins_RedirectingPlugin(
+                    $app['swiftmailer.delivery_addresses'],
+                    $app['swiftmailer.delivery_whitelist']
+                );
+            }
+
+            return $plugins;
         };
 
         $app['swiftmailer.sender_address'] = null;

--- a/tests/Silex/Tests/Provider/SwiftmailerServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SwiftmailerServiceProviderTest.php
@@ -122,8 +122,8 @@ class SwiftmailerServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $app->register(new SwiftmailerServiceProvider());
 
-        $app['swiftmailer.plugins'] = function ($app) use ($plugin) {
-            return array($plugin);
+        $app['swiftmailer.plugins']['foo'] = function () use ($plugin) {
+            return $plugin;
         };
 
         $dispatcher = $app['swiftmailer.transport.eventdispatcher'];


### PR DESCRIPTION
In #1456, it was made possible to register Swiftmailer plugins by populating `$app['swiftmailer.plugins']`.

In order to make it easy for other providers to add plugins, I suggest changing `$app['swiftmailer.plugins']` to a Pimple container. This allows a looser coupling than $app->extend() that requires the providers to be registered in a specific correct order.