### PR TITLE
Added the FormRegistry as a service to enable the extension point

### DIFF
--- a/src/Silex/Provider/FormServiceProvider.php
+++ b/src/Silex/Provider/FormServiceProvider.php
@@ -16,7 +16,8 @@ use Pimple\ServiceProviderInterface;
 use Symfony\Component\Form\Extension\Csrf\CsrfExtension;
 use Symfony\Component\Form\Extension\HttpFoundation\HttpFoundationExtension;
 use Symfony\Component\Form\Extension\Validator\ValidatorExtension as FormValidatorExtension;
-use Symfony\Component\Form\Forms;
+use Symfony\Component\Form\FormFactory;
+use Symfony\Component\Form\FormRegistry;
 use Symfony\Component\Form\ResolvedFormTypeFactory;
 
 /**
@@ -74,11 +75,11 @@ class FormServiceProvider implements ServiceProviderInterface
         };
 
         $app['form.factory'] = function ($app) {
-            return Forms::createFormFactoryBuilder()
-                ->addExtensions($app['form.extensions'])
-                ->setResolvedTypeFactory($app['form.resolved_type_factory'])
-                ->getFormFactory()
-            ;
+            return new FormFactory($app['form.registry'], $app['form.resolved_type_factory']);
+        };
+
+        $app['form.registry'] = function ($app) {
+            return new FormRegistry($app['form.extensions'], $app['form.resolved_type_factory']);
         };
 
         $app['form.resolved_type_factory'] = function ($app) {

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -34,6 +34,13 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Symfony\Component\Form\FormFactory', $app['form.factory']);
     }
 
+    public function testFormRegistryServiceIsFormRegistry()
+    {
+        $app = new Application();
+        $app->register(new FormServiceProvider());
+        $this->assertInstanceOf('Symfony\Component\Form\FormRegistry', $app['form.registry']);
+    }
+
     public function testFormServiceProviderWillLoadTypes()
     {
         $app = new Application();


### PR DESCRIPTION
Closes https://github.com/symfony/symfony/issues/21199.

This PR makes the form configuration aligned with the symfony full stack, see https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/Resources/config/form.xml#L11-L29.