### PR TITLE
Added option validator.mapping.use_annotation

### DIFF
--- a/doc/providers/validator.rst
+++ b/doc/providers/validator.rst
@@ -11,6 +11,14 @@ Parameters
 * **validator.validator_service_ids**: An array of service names representing
   validators.
 
+* **validator.mapping.use_annotation**: A boolean used to define if metadata should be readed through annotations.
+  By default the validator will read the metadata from classes that implement a static ``loadValidatorMetadata`` method.
+  Setting this property to true allows the validator to read from annotations. Defaults to null.
+
+* **validator.mapping.cache**: A class implementing `Symfony\\Component\\Validator\\Mapping\\Cache\\CacheInterface
+  <http://api.symfony.com/master/Symfony/Component/Validator/Mapping/Cache/CacheInterface.html>`_.
+  When given the metadata will be cached using this class. Defaults to null.
+
 Services
 --------
 

--- a/src/Silex/Provider/ValidatorServiceProvider.php
+++ b/src/Silex/Provider/ValidatorServiceProvider.php
@@ -18,6 +18,8 @@ use Symfony\Component\Validator\Validator;
 use Symfony\Component\Validator\Mapping\Factory\LazyLoadingMetadataFactory;
 use Symfony\Component\Validator\Mapping\Loader\StaticMethodLoader;
 use Symfony\Component\Validator\Validation;
+use Doctrine\Common\Annotations\AnnotationReader;
+use Symfony\Component\Validator\Mapping\Loader\AnnotationLoader;
 
 /**
  * Symfony Validator component Provider.
@@ -46,7 +48,21 @@ class ValidatorServiceProvider implements ServiceProviderInterface
         };
 
         $app['validator.mapping.class_metadata_factory'] = function ($app) {
-            return new LazyLoadingMetadataFactory(new StaticMethodLoader());
+            $loader = null;
+
+            if ($app->offsetExists('validator.mapping.use_annotation') && $app['validator.mapping.use_annotation'] === true) {
+                $loader = new AnnotationLoader(new AnnotationReader());
+            } else {
+                $loader = new StaticMethodLoader();
+            }
+
+            $cache = null;
+
+            if ($app->offsetExists('validator.mapping.cache')) {
+                $cache = $app['validator.mapping.cache'];
+            }
+
+            return new LazyLoadingMetadataFactory($loader, $cache);
         };
 
         $app['validator.validator_factory'] = function () use ($app) {

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use Doctrine\Common\Cache\ArrayCache;
 use Silex\Application;
 use Silex\Provider\TranslationServiceProvider;
 use Silex\Provider\ValidatorServiceProvider;
@@ -55,6 +56,21 @@ class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
         return $app;
     }
 
+    public function testRegisterWithAnnotationLoader()
+    {
+        $app = new Application();
+
+        $app['validator.mapping.use_annotation'] = true;
+
+        $app['validator.mapping.cache'] = function () {
+            return new ArrayCache();
+        };
+
+        $app->register(new ValidatorServiceProvider());
+
+        return $app;
+    }
+
     /**
      * @depends testRegisterWithCustomValidators
      */
@@ -81,7 +97,7 @@ class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
      */
     public function testValidatorServiceIsAValidator($app)
     {
-        $this->assertTrue($app['validator'] instanceof ValidatorInterface || $app['validator'] instanceof LegacyValidatorInterface );
+        $this->assertTrue($app['validator'] instanceof ValidatorInterface || $app['validator'] instanceof LegacyValidatorInterface);
     }
 
     /**


### PR DESCRIPTION
Added option validator.mapping.use_annotation to change the default usage of StaticMethodLoader to AnnotationLoader.

Added option validator.mapping.cache to allow passing a CacheInterface for usage in the mapping loader.

This should simplify the creation of a validator that reads annotations instead of static methods.