### PR TITLE
Updated composer.json to include phpunit/phpunit ~5.7 as a dev requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ before_script:
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.8|^3\.0/2.8.*@dev/g' composer.json; composer update; fi"
     - composer install
 
-script: phpunit
+script: 
+    - vendor/bin/phpunit
 
 matrix:
     include:

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "twig/twig": "~1.28|~2.0",
         "doctrine/dbal": "~2.2",
         "swiftmailer/swiftmailer": "~5",
-        "monolog/monolog": "^1.4.1"
+        "monolog/monolog": "^1.4.1",
+        "phpunit/phpunit": "~5.7"
     },
     "replace": {
         "silex/api": "self.version",

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
         "doctrine/dbal": "~2.2",
         "swiftmailer/swiftmailer": "~5",
         "monolog/monolog": "^1.4.1",
-        "phpunit/phpunit": "~5.7"
+        "phpunit/phpunit": "~4.8|~5.7"
     },
     "replace": {
         "silex/api": "self.version",


### PR DESCRIPTION
`PHPUnit_Framework_TestCase` from PHPUnit is required in `WebTestCase.php` and Silex includes a `phpunit.xml.dist`

PHPUnit 6.0 which is now the main stable release is not compatible with Silex due to the removal of `PHPUnit_Framework_TestCase` in favor of `PHPUnit\Framework\TestCase`

This resolves issue #1483 and partially re-implements pull request #1075.