### PR TITLE
Remove overwriting of $app['swiftmailer.options']

### DIFF
--- a/src/Silex/Provider/SwiftmailerServiceProvider.php
+++ b/src/Silex/Provider/SwiftmailerServiceProvider.php
@@ -28,7 +28,6 @@ class SwiftmailerServiceProvider implements ServiceProviderInterface, EventListe
 {
     public function register(Container $app)
     {
-        $app['swiftmailer.options'] = array();
         $app['swiftmailer.use_spool'] = true;
 
         $app['mailer.initialized'] = false;


### PR DESCRIPTION
When registering the SwiftMailerServiceProvider, $app['swiftmailer.options'] is immediately reset to an empty array so any configuration has to be loaded after the provider has been registered (which is not the same behavior as the other providers - at least of the ones I have used so far).

In line 64, we are expecting the same array to be populated and replaced into the final options array so it seems odd that we would want to 'initialize' that array at the beginning of the registration call:

```
 $options = $app['swiftmailer.options'] = array_replace(array(
                'host' => 'localhost',
                'port' => 25,
                'username' => '',
                'password' => '',
                'encryption' => null,
                'auth_mode' => null,
            ), $app['swiftmailer.options']);
```