### PR TITLE
Flush the routes on boot

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -105,6 +105,9 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         }
 
         $this->booted = true;
+        
+        // Flush the routes to a RouteCollection
+        $this->flush();
 
         foreach ($this->providers as $provider) {
             if ($provider instanceof EventListenerProviderInterface) {
@@ -490,8 +493,6 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         if (!$this->booted) {
             $this->boot();
         }
-
-        $this->flush();
 
         return $this['kernel']->handle($request, $type, $catch);
     }


### PR DESCRIPTION
This allows for better middleware since the routeCollection is exposed early on compared to (currently) only being available after handling a request. Middleware authors that depend on the RouteCollection used to depend on the third party's ability to call the flush() method manually, which is not wanted.