### PR TITLE
Add PHP 7.1 to the build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ matrix:
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.2
         - php: 7.0
+        - php: 7.1
         - php: hhvm


### PR DESCRIPTION
Tests on >=7.0 are depending on PHPUnit version lock, this requires  https://github.com/silexphp/Silex/pull/1487 merging first.