### PR TITLE
Use the simple-phpunit script in Travis and add PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_script:
     - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.8|^3\.0/2.8.*@dev/g' composer.json; composer update; fi"
     - composer install
 
-script: phpunit
+script: ./vendor/bin/simple-phpunit
 
 matrix:
     include:
@@ -36,4 +36,9 @@ matrix:
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.2
         - php: 7.0
+        - php: 7.1
         - php: hhvm
+
+cache:
+    directories:
+        - .phpunit

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "symfony/monolog-bridge": "~2.8|^3.0",
         "symfony/doctrine-bridge": "~2.8|^3.0",
         "symfony/options-resolver": "~2.8|^3.0",
-        "symfony/phpunit-bridge": "~2.8|^3.0",
+        "symfony/phpunit-bridge": "^3.2",
         "symfony/process": "~2.8|^3.0",
         "symfony/serializer": "~2.8|^3.0",
         "symfony/translation": "~2.8|^3.0",


### PR DESCRIPTION
This will fix the Travis build issues with PHP 7.

I upped the `symfony/phpunit-bridge` version requirement so we can use the `simple-phpunit` script that was added in 3.2.0, and updated the `script` config value.

While I was at it, I also added PHP 7.1 to the matrix (hopefully it's ok to do this in the same PR).