### PR TITLE
Added WebLink component integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
         "twig/twig": "~1.28|~2.0",
         "doctrine/dbal": "~2.2",
         "swiftmailer/swiftmailer": "~5",
-        "monolog/monolog": "^1.4.1"
+        "monolog/monolog": "^1.4.1",
+        "symfony/web-link": "^3.3"
     },
     "replace": {
         "silex/api": "self.version",

--- a/doc/providers/twig.rst
+++ b/doc/providers/twig.rst
@@ -80,7 +80,7 @@ additional capabilities.
   <http://symfony.com/doc/current/book/routing.html#generating-urls-from-a-template>`_:
 
   .. code-block:: jinja
-  
+
       {{ path('homepage') }}
       {{ url('homepage') }} {# generates the absolute url http://example.org/ #}
       {{ path('hello', {name: 'Fabien'}) }}
@@ -111,6 +111,15 @@ If you are using the ``SecurityServiceProvider``, you will have access to the
 ``is_granted()`` function in templates. You can find more information in the
 `Symfony Security documentation
 <http://symfony.com/doc/current/book/security.html#access-control-in-templates>`_.
+
+Web Link Support
+~~~~~~~~~~~~~~~~
+
+If you are using the ``symfony/web-link`` component, you will have access to the
+``preload()``, ``prefetch()``, ``prerender()``, ``dns_prefetch()``,
+``preconnect()`` and ``link()`` functions in templates. You can find more
+information in the `Symfony WebLink documentation
+<https://symfony.com/doc/current/components/weblink/introduction.html>`_.
 
 Global Variable
 ~~~~~~~~~~~~~~~

--- a/src/Silex/Provider/HttpKernelServiceProvider.php
+++ b/src/Silex/Provider/HttpKernelServiceProvider.php
@@ -24,6 +24,8 @@ use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadataFactory;
 use Symfony\Component\HttpKernel\EventListener\ResponseListener;
 use Symfony\Component\HttpKernel\HttpKernel;
 use Symfony\Component\HttpKernel\Kernel;
+use Symfony\Component\WebLink\EventListener\AddLinkHeaderListener;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 class HttpKernelServiceProvider implements ServiceProviderInterface, EventListenerProviderInterface
 {
@@ -91,5 +93,9 @@ class HttpKernelServiceProvider implements ServiceProviderInterface, EventListen
         $dispatcher->addSubscriber(new MiddlewareListener($app));
         $dispatcher->addSubscriber(new ConverterListener($app['routes'], $app['callback_resolver']));
         $dispatcher->addSubscriber(new StringToResponseListener());
+
+        if (class_exists(HttpHeaderSerializer::class)) {
+            $dispatcher->addSubscriber(new AddLinkHeaderListener());
+        }
     }
 }

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -23,9 +23,11 @@ use Symfony\Bridge\Twig\Extension\FormExtension;
 use Symfony\Bridge\Twig\Extension\SecurityExtension;
 use Symfony\Bridge\Twig\Extension\HttpFoundationExtension;
 use Symfony\Bridge\Twig\Extension\HttpKernelExtension;
+use Symfony\Bridge\Twig\Extension\WebLinkExtension;
 use Symfony\Bridge\Twig\Form\TwigRendererEngine;
 use Symfony\Bridge\Twig\Form\TwigRenderer;
 use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 /**
  * Twig integration for Silex.
@@ -123,6 +125,10 @@ class TwigServiceProvider implements ServiceProviderInterface
 
                 if (class_exists(HttpKernelRuntime::class)) {
                     $twig->addRuntimeLoader($app['twig.runtime_loader']);
+                }
+
+                if (class_exists(HttpHeaderSerializer::class) && class_exists(WebLinkExtension::class)) {
+                    $twig->addExtension(new WebLinkExtension($app['request_stack']));
                 }
             }
 

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -11,6 +11,8 @@
 
 namespace Silex\Tests;
 
+use Fig\Link\GenericLinkProvider;
+use Fig\Link\Link;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\Api\ControllerProviderInterface;
@@ -653,6 +655,22 @@ class ApplicationTest extends \PHPUnit_Framework_TestCase
         $response = $app->handle(Request::create('/foo'));
 
         $this->assertEquals('Hello view listener', $response->getContent());
+    }
+
+    public function testWebLinkListener()
+    {
+        $app = new Application();
+
+        $app->get('/', function () {
+            return 'hello';
+        });
+
+        $request = Request::create('/');
+        $request->attributes->set('_links', (new GenericLinkProvider())->withLink(new Link('preload', '/foo.css')));
+
+        $response = $app->handle($request);
+
+        $this->assertEquals('</foo.css>; rel="preload"', $response->headers->get('Link'));
     }
 
     public function testDefaultRoutesFactory()


### PR DESCRIPTION
I made the necessary changes to support the new WebLink component:

- `HttpKernelServiceProvider` registers the `AddLinkHeaderListener` if the component is available
- `TwigServiceProvider` adds the `WebLinkExtension` if the component and the Twig bridge are available
- Both changes are tested
- The documentation has been amended (the link to the Symfony website doesn't work as 3.3 hasn't been released yet but I believe it's the good URL)