### PR TITLE
Added parameters to configure the Twig core extension behavior

### DIFF
--- a/doc/providers/twig.rst
+++ b/doc/providers/twig.rst
@@ -24,6 +24,28 @@ Parameters
   ``bootstrap_3_layout.html.twig``, and
   ``bootstrap_3_horizontal_layout.html.twig``.
 
+* **twig.date.format** (optional): Default format used by the ``date``
+  filter. The format string must conform to the format accepted by
+  `date() <http://www.php.net/date>`_.
+
+* **twig.date.interval_format** (optional): Default format used by the
+  ``date`` filter when the filtered data is of type `DateInterval <http://www.php.net/DateInterval>`_.
+  The format string must conform to the format accepted by
+  `DateInterval::format() <http://www.php.net/DateInterval.format>`_.
+
+* **twig.date.timezone** (optional): Default timezone used when formatting
+  dates. If set to ``null`` the timezone returned by `date_default_timezone_get() <http://www.php.net/date_default_timezone_get>`_
+  is used.
+
+* **twig.number_format.decimals** (optional): Default number of decimals
+  displayed by the ``number_format`` filter.
+
+* **twig.number_format.decimal_point** (optional): Default separator for
+  the decimal point used by the ``number_format`` filter.
+
+* **twig.number_format.thousands_separator** (optional): Default thousands
+  separator used by the ``number_format`` filter.
+
 Services
 --------
 
@@ -80,7 +102,7 @@ additional capabilities.
   <http://symfony.com/doc/current/book/routing.html#generating-urls-from-a-template>`_:
 
   .. code-block:: jinja
-  
+
       {{ path('homepage') }}
       {{ url('homepage') }} {# generates the absolute url http://example.org/ #}
       {{ path('hello', {name: 'Fabien'}) }}

--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -41,6 +41,14 @@ class TwigServiceProvider implements ServiceProviderInterface
         $app['twig.path'] = array();
         $app['twig.templates'] = array();
 
+        $app['twig.date.format'] = 'F j, Y H:i';
+        $app['twig.date.interval_format'] = '%d days';
+        $app['twig.date.timezone'] = null;
+
+        $app['twig.number_format.decimals'] = 0;
+        $app['twig.number_format.decimal_point'] = '.';
+        $app['twig.number_format.thousands_separator'] = ',';
+
         $app['twig'] = function ($app) {
             $app['twig.options'] = array_replace(
                 array(
@@ -54,6 +62,16 @@ class TwigServiceProvider implements ServiceProviderInterface
             // registered for BC, but should not be used anymore
             // deprecated and should probably be removed in Silex 3.0
             $twig->addGlobal('app', $app);
+
+            $coreExtension = $twig->getExtension('Twig_Extension_Core');
+
+            $coreExtension->setDateFormat($app['twig.date.format'], $app['twig.date.interval_format']);
+
+            if (null !== $app['twig.date.timezone']) {
+                $coreExtension->setTimezone($app['twig.date.timezone']);
+            }
+
+            $coreExtension->setNumberFormat($app['twig.number_format.decimals'], $app['twig.number_format.decimal_point'], $app['twig.number_format.thousands_separator']);
 
             if ($app['debug']) {
                 $twig->addExtension(new \Twig_Extension_Debug());

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -116,4 +116,26 @@ class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf('Twig_Environment', $app['twig']);
     }
+
+    public function testFormatParameters()
+    {
+        $app = new Application();
+
+        $timezone = new \DateTimeZone('Europe/Paris');
+
+        $app->register(new TwigServiceProvider(), array(
+            'twig.date.format' => 'Y-m-d',
+            'twig.date.interval_format' => '%h hours',
+            'twig.date.timezone' => $timezone,
+            'twig.number_format.decimals' => 2,
+            'twig.number_format.decimal_point' => ',',
+            'twig.number_format.thousands_separator' => ' ',
+        ));
+
+        $twig = $app['twig'];
+
+        $this->assertSame(array('Y-m-d', '%h hours'), $twig->getExtension('Twig_Extension_Core')->getDateFormat());
+        $this->assertSame($timezone, $twig->getExtension('Twig_Extension_Core')->getTimezone());
+        $this->assertSame(array(2, ',', ' '), $twig->getExtension('Twig_Extension_Core')->getNumberFormat());
+    }
 }


### PR DESCRIPTION
This adds the following parameters to configure `Twig_Extension_Core`:

- `twig.date.format` (default `date` format)
- `twig.date.interval_format` (default `date` format for intervals)
- `twig.date.timezone` (default timezone)
- `twig.number_format.decimals` (default number of decimals for `number_format`)
- `twig.number_format.decimal_point` (default decimals separator for `number_format`)
- `twig.number_format.thousands_separator` (default thousands separator for `number_format`)
