### PR TITLE
Fix AssetServiceProviderTest::testGenerateAssetUrl

### DIFF
--- a/tests/Silex/Tests/Provider/AssetServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/AssetServiceProviderTest.php
@@ -29,7 +29,7 @@ class AssetServiceProviderTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertEquals('/foo.png?version=v1', $app['assets.packages']->getUrl('/foo.png'));
-        $this->assertEquals('/whatever-makes-sense/foo.css?css2', $app['assets.packages']->getUrl('/foo.css', 'css'));
+        $this->assertEquals('/whatever-makes-sense/foo.css?css2', $app['assets.packages']->getUrl('foo.css', 'css'));
         $this->assertEquals('https://img.example.com/foo.png', $app['assets.packages']->getUrl('/foo.png', 'images'));
     }
 }


### PR DESCRIPTION
The test broke when symfony/symfony#22528 got merged. 

I added one check without the starting slash (the returned path should be relative to `base_path`) and modified the expectation of the check with the starting slash (the returned path should not be relative).

```
There was 1 failure:

1) Silex\Tests\Provider\AssetServiceProviderTest::testGenerateAssetUrl
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/whatever-makes-sense/foo.css?css2'
+'/foo.css?css2'
```