### PR TITLE
Fix deprecation notice with symfony/twig-bridge 3.2+ in TwigServiceProvider

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -109,7 +109,7 @@ class TwigServiceProvider implements ServiceProviderInterface
                         return new TwigRenderer($app['twig.form.engine'], $csrfTokenManager);
                     };
 
-                    $twig->addExtension(new FormExtension($app['twig.form.renderer']));
+                    $twig->addExtension(new FormExtension(class_exists(HttpKernelRuntime::class) ? null : $app['twig.form.renderer']));
 
                     // add loader for Symfony built-in form templates
                     $reflected = new \ReflectionClass('Symfony\Bridge\Twig\Extension\FormExtension');


### PR DESCRIPTION
Fixes the deprecation triggered when instantiating `FormExtension` twig-bridge with 3.2+.

I check for the existence of `Symfony\Bridge\Twig\Extension\HttpKernelRuntime` to determine if we're using 3.2 as it was added in 3.2.0-beta1.