### PR TITLE
Fix duck type in MiddlewareListener constructor

### DIFF
--- a/src/Silex/EventListener/MiddlewareListener.php
+++ b/src/Silex/EventListener/MiddlewareListener.php
@@ -11,12 +11,12 @@
 
 namespace Silex\EventListener;
 
+use Pimple\Container;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Silex\Application;
 
 /**
  * Manages the route middlewares.
@@ -30,9 +30,9 @@ class MiddlewareListener implements EventSubscriberInterface
     /**
      * Constructor.
      *
-     * @param Application $app An Application instance
+     * @param Container $app A Container instance
      */
-    public function __construct(Application $app)
+    public function __construct(Container $app)
     {
         $this->app = $app;
     }


### PR DESCRIPTION
The typehint in the MiddlewareListener constructor should be `Container` and not `Application` (must be a leftover from Silex 1.x).

It's instantiated from `HttpKernelServiceProvider::subscribe(Container $app, EventDispatcherInterface $dispatcher)`.

(The failures are unrelated, due to #1510)