### PR TITLE
Fixed WebTestCase compatibility with PHPUnit 6+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
         "monolog/monolog": "^1.4.1",
         "symfony/web-link": "^3.3"
     },
+    "conflict": {
+        "phpunit/phpunit": "<4.8.35 || >= 5.0, <5.4.3"
+    },
     "replace": {
         "silex/api": "self.version",
         "silex/providers": "self.version"

--- a/src/Silex/WebTestCase.php
+++ b/src/Silex/WebTestCase.php
@@ -11,6 +11,7 @@
 
 namespace Silex;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
@@ -19,7 +20,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-abstract class WebTestCase extends \PHPUnit_Framework_TestCase
+abstract class WebTestCase extends TestCase
 {
     /**
      * HttpKernelInterface instance.


### PR DESCRIPTION
Makes `WebTestCase` inherit from `PHPUnit\Framework\TestCase` instead of `PHPUnit_Framework_TestCase`.

Strictly speaking it's a BC break, but as the namespaced class is now available in PHPUnit 4.8.35, 5.4+ and 6.x it's probable safe.