### PR TITLE
Use PHPUnit\Framework\TestCase in Silex tests

### DIFF
--- a/tests/Silex/Tests/Application/FormTraitTest.php
+++ b/tests/Silex/Tests/Application/FormTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\FormServiceProvider;
 
 /**
@@ -18,7 +19,7 @@ use Silex\Provider\FormServiceProvider;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class FormTraitTest extends \PHPUnit_Framework_TestCase
+class FormTraitTest extends TestCase
 {
     public function testForm()
     {

--- a/tests/Silex/Tests/Application/MonologTraitTest.php
+++ b/tests/Silex/Tests/Application/MonologTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\MonologServiceProvider;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -20,7 +21,7 @@ use Monolog\Logger;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class MonologTraitTest extends \PHPUnit_Framework_TestCase
+class MonologTraitTest extends TestCase
 {
     public function testLog()
     {

--- a/tests/Silex/Tests/Application/SecurityTraitTest.php
+++ b/tests/Silex/Tests/Application/SecurityTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\SecurityServiceProvider;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class SecurityTraitTest extends \PHPUnit_Framework_TestCase
+class SecurityTraitTest extends TestCase
 {
     public function testEncodePassword()
     {

--- a/tests/Silex/Tests/Application/SwiftmailerTraitTest.php
+++ b/tests/Silex/Tests/Application/SwiftmailerTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\SwiftmailerServiceProvider;
 
 /**
@@ -18,7 +19,7 @@ use Silex\Provider\SwiftmailerServiceProvider;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class SwiftmailerTraitTest extends \PHPUnit_Framework_TestCase
+class SwiftmailerTraitTest extends TestCase
 {
     public function testMail()
     {

--- a/tests/Silex/Tests/Application/TranslationTraitTest.php
+++ b/tests/Silex/Tests/Application/TranslationTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\TranslationServiceProvider;
 
 /**
@@ -18,7 +19,7 @@ use Silex\Provider\TranslationServiceProvider;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class TranslationTraitTest extends \PHPUnit_Framework_TestCase
+class TranslationTraitTest extends TestCase
 {
     public function testTrans()
     {

--- a/tests/Silex/Tests/Application/TwigTraitTest.php
+++ b/tests/Silex/Tests/Application/TwigTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\TwigServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class TwigTraitTest extends \PHPUnit_Framework_TestCase
+class TwigTraitTest extends TestCase
 {
     public function testRender()
     {

--- a/tests/Silex/Tests/Application/UrlGeneratorTraitTest.php
+++ b/tests/Silex/Tests/Application/UrlGeneratorTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
@@ -18,7 +19,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class UrlGeneratorTraitTest extends \PHPUnit_Framework_TestCase
+class UrlGeneratorTraitTest extends TestCase
 {
     public function testUrl()
     {

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -13,6 +13,7 @@ namespace Silex\Tests;
 
 use Fig\Link\GenericLinkProvider;
 use Fig\Link\Link;
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\ControllerCollection;
 use Silex\Api\ControllerProviderInterface;
@@ -30,7 +31,7 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     public function testMatchReturnValue()
     {

--- a/tests/Silex/Tests/CallbackResolverTest.php
+++ b/tests/Silex/Tests/CallbackResolverTest.php
@@ -11,10 +11,11 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 use Silex\CallbackResolver;
 
-class CallbackResolverTest extends \PHPUnit_Framework_Testcase
+class CallbackResolverTest extends Testcase
 {
     private $app;
     private $resolver;

--- a/tests/Silex/Tests/CallbackServicesTest.php
+++ b/tests/Silex/Tests/CallbackServicesTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Silex\Provider\ServiceControllerServiceProvider;
@@ -20,7 +21,7 @@ use Silex\Provider\ServiceControllerServiceProvider;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class CallbackServicesTest extends \PHPUnit_Framework_TestCase
+class CallbackServicesTest extends TestCase
 {
     public $called = array();
 

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Controller;
 use Silex\ControllerCollection;
@@ -23,7 +24,7 @@ use Symfony\Component\Routing\RouteCollection;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
+class ControllerCollectionTest extends TestCase
 {
     public function testGetRouteCollectionWithNoRoutes()
     {

--- a/tests/Silex/Tests/ControllerResolverTest.php
+++ b/tests/Silex/Tests/ControllerResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\ControllerResolver;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ControllerResolverTest extends \PHPUnit_Framework_TestCase
+class ControllerResolverTest extends TestCase
 {
     /**
      * @group legacy

--- a/tests/Silex/Tests/ControllerTest.php
+++ b/tests/Silex/Tests/ControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Controller;
 use Silex\Route;
 
@@ -19,7 +20,7 @@ use Silex\Route;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ControllerTest extends \PHPUnit_Framework_TestCase
+class ControllerTest extends TestCase
 {
     public function testBind()
     {

--- a/tests/Silex/Tests/EventListener/LogListenerTest.php
+++ b/tests/Silex/Tests/EventListener/LogListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\EventListener;
 
+use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Silex\EventListener\LogListener;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
@@ -28,7 +29,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  *
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
-class LogListenerTest extends \PHPUnit_Framework_TestCase
+class LogListenerTest extends TestCase
 {
     public function testRequestListener()
     {

--- a/tests/Silex/Tests/ExceptionHandlerTest.php
+++ b/tests/Silex/Tests/ExceptionHandlerTest.php
@@ -308,7 +308,6 @@ class ExceptionHandlerTest extends TestCase
         // Since we throw a standard Exception above only
         // the second error handler should fire
         $app->error(function (\LogicException $e) { // Extends \Exception
-
             return 'Caught LogicException';
         });
         $app->error(function (\Exception $e) {
@@ -334,7 +333,6 @@ class ExceptionHandlerTest extends TestCase
         // Since we throw a LogicException above
         // the first error handler should fire
         $app->error(function (\LogicException $e) { // Extends \Exception
-
             return 'Caught LogicException';
         });
         $app->error(function (\Exception $e) {
@@ -365,7 +363,6 @@ class ExceptionHandlerTest extends TestCase
             return 'Caught Exception';
         });
         $app->error(function (\LogicException $e) { // Extends \Exception
-
             return 'Caught LogicException';
         });
 

--- a/tests/Silex/Tests/ExceptionHandlerTest.php
+++ b/tests/Silex/Tests/ExceptionHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
+class ExceptionHandlerTest extends TestCase
 {
     public function testExceptionHandlerExceptionNoDebug()
     {

--- a/tests/Silex/Tests/FunctionalTest.php
+++ b/tests/Silex/Tests/FunctionalTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Route;
 use Silex\ControllerCollection;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class FunctionalTest extends \PHPUnit_Framework_TestCase
+class FunctionalTest extends TestCase
 {
     public function testBind()
     {

--- a/tests/Silex/Tests/JsonTest.php
+++ b/tests/Silex/Tests/JsonTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 
 /**
@@ -18,7 +19,7 @@ use Silex\Application;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class JsonTest extends \PHPUnit_Framework_TestCase
+class JsonTest extends TestCase
 {
     public function testJsonReturnsJsonResponse()
     {

--- a/tests/Silex/Tests/LazyDispatcherTest.php
+++ b/tests/Silex/Tests/LazyDispatcherTest.php
@@ -11,10 +11,11 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 
-class LazyDispatcherTest extends \PHPUnit_Framework_TestCase
+class LazyDispatcherTest extends TestCase
 {
     /** @test */
     public function beforeMiddlewareShouldNotCreateDispatcherEarly()

--- a/tests/Silex/Tests/LazyRequestMatcherTest.php
+++ b/tests/Silex/Tests/LazyRequestMatcherTest.php
@@ -23,7 +23,7 @@ use Silex\Provider\Routing\LazyRequestMatcher;
 class LazyRequestMatcherTest extends TestCase
 {
     /**
-     * @covers Silex\LazyRequestMatcher::getRequestMatcher
+     * @covers \Silex\LazyRequestMatcher::getRequestMatcher
      */
     public function testUserMatcherIsCreatedLazily()
     {
@@ -43,7 +43,7 @@ class LazyRequestMatcherTest extends TestCase
     }
 
     /**
-     * @expectedException LogicException
+     * @expectedException \LogicException
      * @expectedExceptionMessage Factory supplied to LazyRequestMatcher must return implementation of Symfony\Component\Routing\RequestMatcherInterface.
      */
     public function testThatCanInjectRequestMatcherOnly()
@@ -57,7 +57,7 @@ class LazyRequestMatcherTest extends TestCase
     }
 
     /**
-     * @covers Silex\LazyRequestMatcher::matchRequest
+     * @covers \Silex\LazyRequestMatcher::matchRequest
      */
     public function testMatchIsProxy()
     {

--- a/tests/Silex/Tests/LazyRequestMatcherTest.php
+++ b/tests/Silex/Tests/LazyRequestMatcherTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Silex\Provider\Routing\LazyRequestMatcher;
 
@@ -19,7 +20,7 @@ use Silex\Provider\Routing\LazyRequestMatcher;
  *
  * @author Leszek Prabucki <leszek.prabucki@gmail.com>
  */
-class LazyRequestMatcherTest extends \PHPUnit_Framework_TestCase
+class LazyRequestMatcherTest extends TestCase
 {
     /**
      * @covers Silex\LazyRequestMatcher::getRequestMatcher

--- a/tests/Silex/Tests/LocaleTest.php
+++ b/tests/Silex/Tests/LocaleTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\LocaleServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class LocaleTest extends \PHPUnit_Framework_TestCase
+class LocaleTest extends TestCase
 {
     public function testLocale()
     {

--- a/tests/Silex/Tests/MiddlewareTest.php
+++ b/tests/Silex/Tests/MiddlewareTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class MiddlewareTest extends \PHPUnit_Framework_TestCase
+class MiddlewareTest extends TestCase
 {
     public function testBeforeAndAfterFilter()
     {

--- a/tests/Silex/Tests/Provider/AssetServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/AssetServiceProviderTest.php
@@ -11,10 +11,11 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\AssetServiceProvider;
 
-class AssetServiceProviderTest extends \PHPUnit_Framework_TestCase
+class AssetServiceProviderTest extends TestCase
 {
     public function testGenerateAssetUrl()
     {

--- a/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
@@ -44,7 +44,7 @@ class DoctrineServiceProviderTest extends TestCase
 
         $db = $app['db'];
         $params = $db->getParams();
-        $this->assertTrue(array_key_exists('memory', $params));
+        $this->assertArrayHasKey('memory', $params);
         $this->assertTrue($params['memory']);
         $this->assertInstanceof('Doctrine\DBAL\Driver\PDOSqlite\Driver', $db->getDriver());
         $this->assertEquals(22, $app['db']->fetchColumn('SELECT 22'));
@@ -68,7 +68,7 @@ class DoctrineServiceProviderTest extends TestCase
 
         $db = $app['db'];
         $params = $db->getParams();
-        $this->assertTrue(array_key_exists('memory', $params));
+        $this->assertArrayHasKey('memory', $params);
         $this->assertTrue($params['memory']);
         $this->assertInstanceof('Doctrine\DBAL\Driver\PDOSqlite\Driver', $db->getDriver());
         $this->assertEquals(22, $app['db']->fetchColumn('SELECT 22'));
@@ -77,7 +77,7 @@ class DoctrineServiceProviderTest extends TestCase
 
         $db2 = $app['dbs']['sqlite2'];
         $params = $db2->getParams();
-        $this->assertTrue(array_key_exists('path', $params));
+        $this->assertArrayHasKey('path', $params);
         $this->assertEquals(sys_get_temp_dir().'/silex', $params['path']);
     }
 

--- a/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 use Silex\Application;
 use Silex\Provider\DoctrineServiceProvider;
@@ -20,7 +21,7 @@ use Silex\Provider\DoctrineServiceProvider;
  *
  * Fabien Potencier <fabien@symfony.com>
  */
-class DoctrineServiceProviderTest extends \PHPUnit_Framework_TestCase
+class DoctrineServiceProviderTest extends TestCase
 {
     public function testOptionsInitializer()
     {

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\FormServiceProvider;
 use Silex\Provider\CsrfServiceProvider;
@@ -25,7 +26,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 use Symfony\Component\Translation\Exception\NotFoundResourceException;
 
-class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
+class FormServiceProviderTest extends TestCase
 {
     public function testFormFactoryServiceIsFormFactory()
     {

--- a/tests/Silex/Tests/Provider/HttpCacheServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/HttpCacheServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\HttpCacheServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class HttpCacheServiceProviderTest extends \PHPUnit_Framework_TestCase
+class HttpCacheServiceProviderTest extends TestCase
 {
     public function testRegister()
     {

--- a/tests/Silex/Tests/Provider/HttpFragmentServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/HttpFragmentServiceProviderTest.php
@@ -11,13 +11,14 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\HttpCacheServiceProvider;
 use Silex\Provider\HttpFragmentServiceProvider;
 use Silex\Provider\TwigServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
 
-class HttpFragmentServiceProviderTest extends \PHPUnit_Framework_TestCase
+class HttpFragmentServiceProviderTest extends TestCase
 {
     public function testRenderFunction()
     {

--- a/tests/Silex/Tests/Provider/MonologServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/MonologServiceProviderTest.php
@@ -14,6 +14,7 @@ namespace Silex\Tests\Provider;
 use Monolog\Formatter\JsonFormatter;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\MonologServiceProvider;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -26,7 +27,7 @@ use Symfony\Component\HttpKernel\Kernel;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class MonologServiceProviderTest extends \PHPUnit_Framework_TestCase
+class MonologServiceProviderTest extends TestCase
 {
     private $currErrorHandler;
 

--- a/tests/Silex/Tests/Provider/RoutingServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/RoutingServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Pimple\Container;
 use Silex\Application;
 use Silex\Provider\RoutingServiceProvider;
@@ -22,7 +23,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class RoutingServiceProviderTest extends \PHPUnit_Framework_TestCase
+class RoutingServiceProviderTest extends TestCase
 {
     public function testRegister()
     {

--- a/tests/Silex/Tests/Provider/SerializerServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SerializerServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\SerializerServiceProvider;
 
@@ -19,7 +20,7 @@ use Silex\Provider\SerializerServiceProvider;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class SerializerServiceProviderTest extends \PHPUnit_Framework_TestCase
+class SerializerServiceProviderTest extends TestCase
 {
     public function testRegister()
     {

--- a/tests/Silex/Tests/Provider/SwiftmailerServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SwiftmailerServiceProviderTest.php
@@ -11,11 +11,12 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\SwiftmailerServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
 
-class SwiftmailerServiceProviderTest extends \PHPUnit_Framework_TestCase
+class SwiftmailerServiceProviderTest extends TestCase
 {
     public function testSwiftMailerServiceIsSwiftMailer()
     {

--- a/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\TranslationServiceProvider;
 use Silex\Provider\LocaleServiceProvider;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Daniel Tschinder <daniel@tschinder.de>
  */
-class TranslationServiceProviderTest extends \PHPUnit_Framework_TestCase
+class TranslationServiceProviderTest extends TestCase
 {
     /**
      * @return Application

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -12,6 +12,7 @@
 namespace Silex\Tests\Provider;
 
 use Fig\Link\Link;
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\CsrfServiceProvider;
 use Silex\Provider\FormServiceProvider;
@@ -25,7 +26,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
+class TwigServiceProviderTest extends TestCase
 {
     public function testRegisterAndRender()
     {

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\TranslationServiceProvider;
 use Silex\Provider\ValidatorServiceProvider;
@@ -27,7 +28,7 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  *
  * Javier Lopez <f12loalf@gmail.com>
  */
-class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
+class ValidatorServiceProviderTest extends TestCase
 {
     public function testRegister()
     {

--- a/tests/Silex/Tests/Route/SecurityTraitTest.php
+++ b/tests/Silex/Tests/Route/SecurityTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Route;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\SecurityServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class SecurityTraitTest extends \PHPUnit_Framework_TestCase
+class SecurityTraitTest extends TestCase
 {
     public function testSecureWithNoAuthenticatedUser()
     {

--- a/tests/Silex/Tests/RouterTest.php
+++ b/tests/Silex/Tests/RouterTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class RouterTest extends \PHPUnit_Framework_TestCase
+class RouterTest extends TestCase
 {
     public function testMapRouting()
     {

--- a/tests/Silex/Tests/ServiceControllerResolverTest.php
+++ b/tests/Silex/Tests/ServiceControllerResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\ServiceControllerResolver;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
  * Unit tests for ServiceControllerResolver, see ServiceControllerResolverRouterTest for some
  * integration tests.
  */
-class ServiceControllerResolverTest extends \PHPUnit_Framework_Testcase
+class ServiceControllerResolverTest extends Testcase
 {
     private $app;
     private $mockCallbackResolver;

--- a/tests/Silex/Tests/StreamTest.php
+++ b/tests/Silex/Tests/StreamTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -19,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class StreamTest extends \PHPUnit_Framework_TestCase
+class StreamTest extends TestCase
 {
     public function testStreamReturnsStreamingResponse()
     {


### PR DESCRIPTION
I changed all the tests so they use the namespaced class instead of `PHPUnit_Framework_TestCase`.

That doesn't really bring anything, but will be one less thing to change when Silex switches to PHP7/PHPUnit 6.