### PR TITLE
Clarify documentations around protected closures.

### DIFF
--- a/doc/services.rst
+++ b/doc/services.rst
@@ -159,7 +159,7 @@ using the ``protect`` method::
     // calling it now
     echo $add(2, 3);
 
-Note that protected closures do not get access to the container.
+Note that the container is not provided as an argument to protected closures (but you can access it via `use($app)`).
 
 Core services
 -------------


### PR DESCRIPTION
The docs state that "protected closures do not get access to the container", but this is somewhat misleading (it confused me for a quite some time). It's true that protected closures are not passed the container as a function argument, but they can access the container via `use ($app)`.