### PR TITLE
Error using EsiFragment with provider and twig functions

### DIFF
--- a/src/Silex/Provider/HttpFragmentServiceProvider.php
+++ b/src/Silex/Provider/HttpFragmentServiceProvider.php
@@ -51,7 +51,7 @@ class HttpFragmentServiceProvider implements ServiceProviderInterface, EventList
         };
 
         $app['fragment.renderer.esi'] = function ($app) {
-            $renderer = new EsiFragmentRenderer($app['http_cache.esi'], $app['fragment.renderer.inline']);
+            $renderer = new EsiFragmentRenderer($app['http_cache.esi'], $app['fragment.renderer.inline'], $app['uri_signer']);
             $renderer->setFragmentPath($app['fragment.path']);
 
             return $renderer;


### PR DESCRIPTION
Trying to use twig functions "controller" and "render_esi" like [Symfony esi reference](http://symfony.com/doc/current/http_cache/esi.html) , i've noticed the following error:
An exception has been thrown during the rendering of a template ("You must use a URI when using the ESI rendering strategy or set a URL signer.").

It's the lack of a UriSigner on the constructor.