### PR TITLE
Test all the 3.x branches in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,31 @@ env:
 cache:
     directories:
       - $HOME/.composer/cache/files
+      - .phpunit
 
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
 
 before_script:
-    # symfony/*
-    - sh -c "if [ '$TWIG_VERSION' != '2.0' ]; then sed -i 's/~1.8|~2.0/~1.8/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.0' ]; then sed -i 's/~2\.8|^3\.0/3.0.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.1' ]; then sed -i 's/~2\.8|^3\.0/3.1.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.2' ]; then sed -i 's/~2\.8|^3\.0/3.2.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.8|^3\.0/2.8.*@dev/g' composer.json; composer update; fi"
-    - composer install
+    # Twig 1.x
+    - if [[ $TWIG_VERSION != 2.0 ]]; then sed -i 's/~1.8|~2.0/~1.8/g' composer.json; fi
+
+    # Symfony 2.8
+    - if [[ $SYMFONY_DEPS_VERSION = 2.8 ]]; then sed -i 's/~2\.8|^3\.0/2.8.*@dev/g' composer.json; fi
+    # Symfony 3.0
+    - if [[ $SYMFONY_DEPS_VERSION = 3.0 ]]; then sed -i 's/~2\.8|^3\.0/3.0.*@dev/g' composer.json; fi
+    # Symfony 3.1
+    - if [[ $SYMFONY_DEPS_VERSION = 3.1 ]]; then sed -i 's/~2\.8|^3\.0/3.1.*@dev/g' composer.json; fi
+    # Symfony 3.2
+    - if [[ $SYMFONY_DEPS_VERSION = 3.2 ]]; then sed -i 's/~2\.8|^3\.0/3.2.*@dev/g' composer.json; fi
+    # Symfony 3.3
+    - |
+      if [[ $SYMFONY_DEPS_VERSION = 3.3 ]]; then
+          sed -i 's/~2\.8|^3\.0/3.3.*@dev/g' composer.json;
+          composer require --dev --no-update symfony/web-link:3.3.*
+      fi
+
+    - composer update --no-suggest
 
 script: ./vendor/bin/simple-phpunit
 
@@ -30,15 +43,16 @@ matrix:
         - php: 5.6
           env: TWIG_VERSION=2.0
         - php: 5.6
+          env: SYMFONY_DEPS_VERSION=2.8
+        - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.0
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.1
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.2
+        - php: 5.6
+          env: SYMFONY_DEPS_VERSION=3.3
+        - php: 5.6
         - php: 7.0
         - php: 7.1
         - php: hhvm
-
-cache:
-    directories:
-        - .phpunit

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 /**
  * Application test cases.
@@ -660,6 +661,10 @@ class ApplicationTest extends TestCase
 
     public function testWebLinkListener()
     {
+        if (!class_exists(HttpHeaderSerializer::class)) {
+            self::markTestSkipped('Symfony WebLink component is required.');
+        }
+
         $app = new Application();
 
         $app->get('/', function () {

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -20,6 +20,7 @@ use Silex\Provider\TwigServiceProvider;
 use Silex\Provider\AssetServiceProvider;
 use Symfony\Bridge\Twig\Extension\WebLinkExtension;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 /**
  * TwigProvider test cases.
@@ -144,7 +145,7 @@ class TwigServiceProviderTest extends TestCase
 
     public function testWebLinkIntegration()
     {
-        if (!class_exists(WebLinkExtension::class)) {
+        if (!class_exists(HttpHeaderSerializer::class) || !class_exists(WebLinkExtension::class)) {
             $this->markTestSkipped('Twig WebLink extension not available.');
         }
 


### PR DESCRIPTION
I enhanced the Travis config to ensure the tests are run against all the available 3.x branches.

Before the changes:
- The tests were run against `2.8` when `$SYMFONY_DEPS_VERSION` was unset
- There were additional envs for `3.0`, `3.1` and `3.2`

After the changes:
- When `$SYMFONY_DEPS_VERSION` is unset, `composer.json` is left unchanged and the tests are run against the most recent `3.x-dev` branch (what you'd get by running phpunit locally)
- There are envs to test all the symfony branches from `2.8` to `3.3`

I also fixed the cache (there were two `cache/directories` sections) and made the syntax more consistent overall.

This changes the behaviors of the build: before, `Twig 2.x` was tested with `2.8`. Now, it is tested alongside the most recent `3.x`. I believe it makes more sense like this, however if the old behavior was on purpose (i.e because `2.8` is still the most recent _lts_), I can still switch back and add envs for `3.3` and `3.4` instead.

Regarding the changes to the tests:

I originally removed `symfony/web-link` from the list of dependencies when testing against `< 3.3`, as something like this will be necessary later when adding `symfony/cache` support which conflicts with `symfony/var-dumper < 3.3`. 

However, as this was not necessary and actually prevented us to check that the WebLink integration didn't break when the component was available but associated with an old version of the `twig-bridge`, I ultimately rolled back the change. Yet, I kept the checks in the tests as they are cleaner this way IMO (anyway they're in a separate commit so I could just remove them too if you want).