### PR TITLE
Add symfony/cache service provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,18 +9,31 @@ env:
 cache:
     directories:
       - $HOME/.composer/cache/files
+      - .phpunit
 
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
 
 before_script:
-    # symfony/*
-    - sh -c "if [ '$TWIG_VERSION' != '2.0' ]; then sed -i 's/~1.8|~2.0/~1.8/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.0' ]; then sed -i 's/~2\.8|^3\.0/3.0.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.1' ]; then sed -i 's/~2\.8|^3\.0/3.1.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.2' ]; then sed -i 's/~2\.8|^3\.0/3.2.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.8|^3\.0/2.8.*@dev/g' composer.json; composer update; fi"
-    - composer install
+    # Twig 1.x
+    - if [[ $TWIG_VERSION != 2.0 ]]; then sed -i 's/~1.8|~2.0/~1.8/g' composer.json; fi
+
+    # Symfony 2.8
+    - if [[ $SYMFONY_DEPS_VERSION = 2.8 ]]; then sed -i 's/~2\.8|^3\.0/2.8.*@dev/g' composer.json; fi
+    # Symfony 3.0
+    - if [[ $SYMFONY_DEPS_VERSION = 3.0 ]]; then sed -i 's/~2\.8|^3\.0/3.0.*@dev/g' composer.json; fi
+    # Symfony 3.1
+    - if [[ $SYMFONY_DEPS_VERSION = 3.1 ]]; then sed -i 's/~2\.8|^3\.0/3.1.*@dev/g' composer.json; fi
+    # Symfony 3.2
+    - if [[ $SYMFONY_DEPS_VERSION = 3.2 ]]; then sed -i 's/~2\.8|^3\.0/3.2.*@dev/g' composer.json; fi
+    # Symfony 3.3
+    - |
+      if [[ $SYMFONY_DEPS_VERSION = 3.3 ]]; then
+          sed -i 's/~2\.8|^3\.0/3.3.*@dev/g' composer.json;
+          composer require --dev --no-update symfony/web-link:3.3.*
+      fi
+
+    - composer update --no-suggest
 
 script: ./vendor/bin/simple-phpunit
 
@@ -30,15 +43,16 @@ matrix:
         - php: 5.6
           env: TWIG_VERSION=2.0
         - php: 5.6
+          env: SYMFONY_DEPS_VERSION=2.8
+        - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.0
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.1
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.2
+        - php: 5.6
+          env: SYMFONY_DEPS_VERSION=3.3
+        - php: 5.6
         - php: 7.0
         - php: 7.1
         - php: hhvm
-
-cache:
-    directories:
-        - .phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,18 @@ cache:
       - $HOME/.composer/cache/files
       - .phpunit
 
+services:
+    - memcached
+    - redis-server
+
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
+
+    - INI=~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
+
+    - if [[ $ENABLE_APCU  ]]; then echo apc.enable_cli = 1 >> $INI; fi
+    - if [[ $ENABLE_REDIS ]]; then echo extension = redis.so >> $INI; fi
+    - if [[ $ENABLE_MEMCACHED ]]; then echo extension = memcached.so >> $INI; fi
 
 before_script:
     # Twig 1.x
@@ -23,19 +33,27 @@ before_script:
     # Symfony 3.0
     - if [[ $SYMFONY_DEPS_VERSION = 3.0 ]]; then sed -i 's/~2\.8|^3\.0/3.0.*@dev/g' composer.json; fi
     # Symfony 3.1
-    - if [[ $SYMFONY_DEPS_VERSION = 3.1 ]]; then sed -i 's/~2\.8|^3\.0/3.1.*@dev/g' composer.json; fi
+    - |
+      if [[ $SYMFONY_DEPS_VERSION = 3.1 ]]; then
+          sed -i 's/~2\.8|^3\.0/3.1.*@dev/g' composer.json;
+          composer require --dev --no-update symfony/cache:3.1.*
+      fi
     # Symfony 3.2
-    - if [[ $SYMFONY_DEPS_VERSION = 3.2 ]]; then sed -i 's/~2\.8|^3\.0/3.2.*@dev/g' composer.json; fi
+    - |
+      if [[ $SYMFONY_DEPS_VERSION = 3.2 ]]; then
+          sed -i 's/~2\.8|^3\.0/3.2.*@dev/g' composer.json;
+          composer require --dev --no-update symfony/cache:3.2.*
+      fi
     # Symfony 3.3
     - |
       if [[ $SYMFONY_DEPS_VERSION = 3.3 ]]; then
           sed -i 's/~2\.8|^3\.0/3.3.*@dev/g' composer.json;
-          composer require --dev --no-update symfony/web-link:3.3.*
+          composer require --dev --no-update symfony/web-link:3.3.* symfony/cache:3.3.*
       fi
 
     - composer update --no-suggest
 
-script: ./vendor/bin/simple-phpunit
+script: ./vendor/bin/simple-phpunit -v
 
 matrix:
     include:
@@ -53,6 +71,10 @@ matrix:
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.3
         - php: 5.6
+          env:
+            - ENABLE_APCU=1
+            - ENABLE_REDIS=1
+            - ENABLE_MEMCACHED=1
         - php: 7.0
         - php: 7.1
         - php: hhvm

--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,8 @@
         "doctrine/dbal": "~2.2",
         "swiftmailer/swiftmailer": "~5",
         "monolog/monolog": "^1.4.1",
-        "symfony/web-link": "^3.3"
+        "symfony/web-link": "^3.3",
+        "symfony/cache": "^3.1"
     },
     "conflict": {
         "phpunit/phpunit": "<4.8.35 || >= 5.0, <5.4.3"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -11,6 +11,11 @@
          syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
+    <php>
+        <env name="REDIS_HOST" value="localhost" />
+        <env name="MEMCACHED_HOST" value="localhost" />
+    </php>
+
     <testsuites>
         <testsuite name="Silex Test Suite">
             <directory>./tests/Silex/</directory>

--- a/src/Silex/Provider/CacheServiceProvider.php
+++ b/src/Silex/Provider/CacheServiceProvider.php
@@ -1,0 +1,128 @@
+<?php
+
+namespace Silex\Provider;
+
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+
+/**
+ * Symfony Cache component Provider.
+ */
+class CacheServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $container)
+    {
+        $container['cache.directory'] = null;
+        $container['cache.namespace_prefix'] = null;
+
+        $container['cache.system.namespace'] = 'system';
+        $container['cache.system.default_lifetime'] = 0;
+        $container['cache.system.version'] = null;
+
+        $container['cache.app.namespace'] = 'app';
+        $container['cache.app.default_lifetime'] = 0;
+        $container['cache.app.dsn'] = null;
+        $container['cache.app.connection_options'] = array();
+
+        $container['cache.logger'] = function ($container) {
+            return $container['logger'];
+        };
+
+        $container['cache.pools.options'] = array();
+
+        $container['cache.pools'] = function ($container) {
+            if (!$container['cache.directory']) {
+                throw new \LogicException('You must set the cache.directory parameter to the location of your cache root directory.');
+            }
+
+            $pools = new Container();
+
+            $pools['system'] = function () use ($container) {
+                return $container['cache.system.factory']($container['cache.system.namespace']);
+            };
+            $pools['app'] = function () use ($container) {
+                return $container['cache.app.factory']($container['cache.app.namespace']);
+            };
+
+            foreach ($container['cache.pools.options'] as $name => $options) {
+                if ($name === 'system' || $name === 'app') {
+                    throw new \LogicException('A cache pool cannot be named system or app.');
+                }
+
+                if (is_string($options)) {
+                    $options = array('adapter' => $options);
+                } elseif (!isset($options['adapter'])) {
+                    throw new \LogicException(sprintf('Invalid definition specified for the cache pool %s. You must specify an adapter.', $name));
+                }
+
+                if ($options['adapter'] !== 'app' && $options['adapter'] !== 'system') {
+                    throw new \LogicException(sprintf('Invalid adapter specified for the cache pool %s. Expected app or system, got %s.', $name, is_object($options['adapter']) ? get_class($options['adapter']) : var_export($options['adapter'], true)));
+                }
+
+                $pools[$name] = function () use ($container, $name, $options) {
+                    return $container['cache.'.$options['adapter'].'.factory'](
+                        isset($options['namespace']) ? $options['namespace'] : $container['cache.'.$options['adapter'].'.namespace'].'_'.$name,
+                        isset($options['lifetime']) ? $options['lifetime'] : null
+                    );
+                };
+            }
+
+            return $pools;
+        };
+
+        $container['cache.system.factory'] = $container->protect(function ($namespace, $lifetime = null) use ($container) {
+            return AbstractAdapter::createSystemCache(
+                $container['cache.namespace_prefix'].$namespace,
+                $lifetime !== null ? $lifetime : $container['cache.system.default_lifetime'],
+                $container['cache.system.version'],
+                $container['cache.directory'],
+                $container['cache.logger']
+            );
+        });
+
+        $container['cache.app.provider'] = function ($container) {
+            if (null !== $dsn = $container['cache.app.dsn']) {
+                // Use the AbstractAdapter method on 3.3+
+                return is_callable(AbstractAdapter::class, 'createConnection') ?
+                    AbstractAdapter::createConnection($dsn, $container['cache.app.connection_options']) :
+                    RedisAdapter::createConnection($dsn, $container['cache.app.connection_options']);
+            }
+
+            return null;
+        };
+
+        $container['cache.app.factory'] = $container->protect(function ($namespace, $lifetime = null) use ($container) {
+            $namespace = $container['cache.namespace_prefix'].$namespace;
+            if (null === $lifetime) {
+                $lifetime = $container['cache.app.default_lifetime'];
+            }
+
+            if (null !== $provider = $container['cache.app.provider']) {
+                switch (true) {
+                    case 0 === strpos($container['cache.app.dsn'], 'redis://'):
+                        $adapter = new RedisAdapter($provider, $namespace, $lifetime);
+                        break;
+
+                    case 0 === strpos($container['cache.app.dsn'], 'memcached://'):
+                        $adapter = new MemcachedAdapter($provider, $namespace, $lifetime);
+                        break;
+
+                    default:
+                        throw new \LogicException('Invalid cache DSN. CacheServiceProvider only supports Redis and Memcached providers.');
+                }
+            } else {
+                $adapter = new FilesystemAdapter($namespace, $lifetime, $container['cache.directory']);
+            }
+
+            if (null !== $logger = $container['cache.logger']) {
+                $adapter->setLogger($logger);
+            }
+
+            return $adapter;
+        });
+    }
+}

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -25,6 +25,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\Routing\RouteCollection;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 /**
  * Application test cases.
@@ -660,6 +661,10 @@ class ApplicationTest extends TestCase
 
     public function testWebLinkListener()
     {
+        if (!class_exists(HttpHeaderSerializer::class)) {
+            self::markTestSkipped('Symfony WebLink component is required.');
+        }
+
         $app = new Application();
 
         $app->get('/', function () {

--- a/tests/Silex/Tests/Provider/CacheServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/CacheServiceProviderTest.php
@@ -1,0 +1,496 @@
+<?php
+
+namespace Silex\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Silex\Application;
+use Silex\Provider\CacheServiceProvider;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Adapter\ApcuAdapter;
+use Symfony\Component\Cache\Adapter\FilesystemAdapter;
+use Symfony\Component\Cache\Adapter\MemcachedAdapter;
+use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+
+/**
+ * CacheServiceProvider tests.
+ */
+class CacheServiceProviderTest extends TestCase
+{
+    private static $cacheDir;
+    private static $redisHost;
+    private static $memcachedHost;
+    /**
+     * @var \Redis|null
+     */
+    private static $redis;
+    /**
+     * @var \Memcached|null
+     */
+    private static $memcached;
+
+    public static function setUpBeforeClass()
+    {
+        if (!class_exists(AbstractAdapter::class)) {
+            self::markTestSkipped('Symfony cache component is required.');
+        }
+
+        self::$cacheDir = sys_get_temp_dir().'/silex-cache';
+        self::$redisHost = getenv('REDIS_HOST');
+        self::$memcachedHost = getenv('MEMCACHED_HOST');
+
+        if (extension_loaded('redis')) {
+            $redis = new \Redis();
+            if (@$redis->connect(self::$redisHost)) {
+                self::$redis = $redis;
+            }
+        }
+        if (class_exists(MemcachedAdapter::class) && MemcachedAdapter::isSupported()) {
+            $memcached = AbstractAdapter::createConnection('memcached://'.self::$memcachedHost, array('binary_protocol' => false));
+            $memcached->get('foo');
+            $code = $memcached->getResultCode();
+
+            if (\Memcached::RES_SUCCESS === $code || \Memcached::RES_NOTFOUND === $code) {
+                self::$memcached = $memcached;
+            }
+        }
+    }
+
+    public static function tearDownAfterClass()
+    {
+        self::rmdir(self::$cacheDir);
+
+        if (null !== self::$redis) {
+            self::$redis->flushDB();
+        }
+
+        if (null !== self::$memcached) {
+            self::$memcached->flush();
+        }
+    }
+
+    public static function skipIfApcuIsAvailable()
+    {
+        if (ApcuAdapter::isSupported()) {
+            self::markTestSkipped('Extension APCu is enabled.');
+        }
+    }
+
+    public static function skipIfApcuIsNotAvailable()
+    {
+        if (!ApcuAdapter::isSupported()) {
+            self::markTestSkipped('Extension APCu is required.');
+        }
+    }
+
+    public static function skipIfRedisIsNotAvailable()
+    {
+        if (!extension_loaded('redis')) {
+            self::markTestSkipped('Extension redis is required.');
+        }
+        if (null === self::$redis) {
+            self::markTestSkipped('Connection to redis server is required.');
+        }
+    }
+
+    public static function skipIfMemcachedIsNotAvailable()
+    {
+        if (!class_exists(MemcachedAdapter::class)) {
+            self::markTestSkipped('Symfony cache component >= 3.3.0 is required.');
+        }
+        if (!MemcachedAdapter::isSupported()) {
+            self::markTestSkipped('Extension memcached >=2.2.0 is required.');
+        }
+        if (null === self::$memcached) {
+            self::markTestSkipped('Connection to memcached server is required.');
+        }
+    }
+
+    public static function rmdir($dir)
+    {
+        if (!file_exists($dir)) {
+            return;
+        }
+        if (!$dir || 0 !== strpos(dirname($dir), sys_get_temp_dir())) {
+            throw new \Exception(__METHOD__."() operates only on subdirs of system's temp dir");
+        }
+        $children = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \RecursiveDirectoryIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+        foreach ($children as $child) {
+            if ($child->isDir()) {
+                rmdir($child);
+            } else {
+                unlink($child);
+            }
+        }
+        rmdir($dir);
+    }
+
+    public function testSystemPoolWithApcu()
+    {
+        self::skipIfApcuIsNotAvailable();
+
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.system.namespace' => 'foo',
+            'cache.system.version' => 'test-version',
+        ));
+
+        $pool1 = $app['cache.pools']['system'];
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        $apcu = new ApcuAdapter('test_foo', 0, 'test-version');
+
+        $item2 = $apcu->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+
+        $fs = new FilesystemAdapter('test_foo', 0, self::$cacheDir);
+
+        $item3 = $fs->getItem(__FUNCTION__);
+        $this->assertTrue($item3->isHit());
+        $this->assertSame('bar', $item3->get());
+    }
+
+    public function testSystemPoolWithoutApcu()
+    {
+        self::skipIfApcuIsAvailable();
+
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.system.namespace' => 'foo',
+        ));
+
+        $pool1 = $app['cache.pools']['system'];
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        if (class_exists(PhpFilesAdapter::class) && PhpFilesAdapter::isSupported()) {
+            // symfony/cache 3.2+ uses a PhpFilesAdapter if possible
+            $pool2 = new PhpFilesAdapter('test_foo', 0, self::$cacheDir);
+        } else {
+            $pool2 = new FilesystemAdapter('test_foo', 0, self::$cacheDir);
+        }
+
+        $item2 = $pool2->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+    }
+
+    public function testRedisAppPool()
+    {
+        self::skipIfRedisIsNotAvailable();
+
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.namespace' => str_replace('\\', '.', __CLASS__),
+            'cache.app.dsn' => 'redis://'.self::$redisHost,
+        ));
+
+        $pool1 = $app['cache.pools']['app'];
+
+        $this->assertInstanceOf(RedisAdapter::class, $pool1);
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        $pool2 = new RedisAdapter(self::$redis, 'test_'.str_replace('\\', '.', __CLASS__), 0);
+
+        $item2 = $pool2->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+    }
+
+    /**
+     * Checks if cache.app.connection_options is passed to createConnection().
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage is not a subclass of "Redis" or "Predis\Client"
+     */
+    public function testRedisAppPoolFailsIfInvalidConnectionOptions()
+    {
+        self::skipIfRedisIsNotAvailable();
+
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.dsn' => 'redis://'.self::$redisHost,
+            'cache.app.connection_options' => array('class' => __CLASS__),
+        ));
+
+        $pool1 = $app['cache.pools']['app'];
+    }
+
+    public function testMemcachedAppPool()
+    {
+        self::skipIfMemcachedIsNotAvailable();
+
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.namespace' => str_replace('\\', '.', __CLASS__),
+            'cache.app.dsn' => 'memcached://'.self::$memcachedHost,
+        ));
+
+        $pool1 = $app['cache.pools']['app'];
+
+        $this->assertInstanceOf(MemcachedAdapter::class, $pool1);
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        $pool2 = new MemcachedAdapter(self::$memcached, 'test_'.str_replace('\\', '.', __CLASS__), 0);
+
+        $item2 = $pool2->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+    }
+
+    public function testFilesystemAppPool()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.namespace' => 'foo',
+        ));
+
+        $pool1 = $app['cache.pools']['app'];
+
+        $this->assertInstanceOf(FilesystemAdapter::class, $pool1);
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        $fs = new FilesystemAdapter('test_foo', 0, self::$cacheDir);
+
+        $item2 = $fs->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+    }
+
+    public function testCustomSystemPoolWithStringOptions()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.system.namespace' => 'foo',
+            'cache.system.version' => __FUNCTION__,
+            'cache.pools.options' => array(
+                'testpool' => 'system',
+            ),
+        ));
+
+        $this->assertTrue(isset($app['cache.pools']['testpool']));
+
+        $pool1 = $app['cache.pools']['testpool'];
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        $pool2 = AbstractAdapter::createSystemCache('test_foo_testpool', 0, __FUNCTION__, self::$cacheDir);
+
+        $item2 = $pool2->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+    }
+
+    public function testCustomSystemPoolWithArrayOptions()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.system.namespace' => 'foo',
+            'cache.system.version' => __FUNCTION__,
+            'cache.pools.options' => array(
+                'testpool' => array(
+                    'adapter' => 'system',
+                    'namespace' => 'mypool',
+                ),
+            ),
+        ));
+
+        $this->assertTrue(isset($app['cache.pools']['testpool']));
+
+        $pool1 = $app['cache.pools']['testpool'];
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        $pool2 = AbstractAdapter::createSystemCache('test_mypool', 0, __FUNCTION__, self::$cacheDir);
+
+        $item2 = $pool2->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+    }
+
+    public function testCustomAppPoolWithStringOptions()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.namespace' => 'foo',
+            'cache.pools.options' => array(
+                'testpool' => 'app',
+            ),
+        ));
+
+        $this->assertTrue(isset($app['cache.pools']['testpool']));
+
+        $pool1 = $app['cache.pools']['testpool'];
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        $pool2 = new FilesystemAdapter('test_foo_testpool', 0, self::$cacheDir);
+
+        $item2 = $pool2->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+    }
+
+    public function testCustomAppPoolWithArrayOptions()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.namespace' => 'foo',
+            'cache.pools.options' => array(
+                'testpool' => array(
+                    'adapter' => 'app',
+                    'namespace' => 'mypool',
+                ),
+            ),
+        ));
+
+        $this->assertTrue(isset($app['cache.pools']['testpool']));
+
+        $pool1 = $app['cache.pools']['testpool'];
+
+        $item1 = $pool1->getItem(__FUNCTION__);
+        $this->assertFalse($item1->isHit());
+        $this->assertTrue($pool1->save($item1->set('bar')));
+
+        $pool2 = new FilesystemAdapter('test_mypool', 0, self::$cacheDir);
+
+        $item2 = $pool2->getItem(__FUNCTION__);
+        $this->assertTrue($item2->isHit());
+        $this->assertSame('bar', $item2->get());
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage You must set the cache.directory parameter to the location of your cache root directory
+     */
+    public function testFailIfCacheDirectoryIsMissing()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.system.namespace' => 'foo',
+        ));
+
+        $pool = $app['cache.pools']['system'];
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage A cache pool cannot be named system or app
+     */
+    public function testFailIfCustomPoolIsNamedSystem()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.system.namespace' => 'foo',
+            'cache.pools.options' => array(
+                'system' => 'system',
+            ),
+        ));
+
+        $pool = $app['cache.pools']['system'];
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage A cache pool cannot be named system or app
+     */
+    public function testFailIfCustomPoolIsNamedApp()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test_',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.namespace' => 'foo',
+            'cache.pools.options' => array(
+                'app' => 'app',
+            ),
+        ));
+
+        $pool = $app['cache.pools']['app'];
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Invalid definition specified for the cache pool testpool. You must specify an adapter
+     */
+    public function testFailIfCustomPoolAdapterIsNotSpecified()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.namespace' => 'foo',
+            'cache.pools.options' => array(
+                'testpool' => array('namespace' => 'foo'),
+            ),
+        ));
+
+        $pool = $app['cache.pools']['testpool'];
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Invalid adapter specified for the cache pool testpool. Expected app or system, got 'invalid'
+     */
+    public function testFailIfCustomPoolHasInvalidAdapter()
+    {
+        $app = new Application();
+        $app->register(new CacheServiceProvider(), array(
+            'cache.namespace_prefix' => 'test',
+            'cache.directory' => self::$cacheDir,
+            'cache.app.namespace' => 'foo',
+            'cache.pools.options' => array(
+                'testpool' => 'invalid',
+            ),
+        ));
+
+        $pool = $app['cache.pools']['testpool'];
+    }
+}

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -20,6 +20,7 @@ use Silex\Provider\TwigServiceProvider;
 use Silex\Provider\AssetServiceProvider;
 use Symfony\Bridge\Twig\Extension\WebLinkExtension;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\WebLink\HttpHeaderSerializer;
 
 /**
  * TwigProvider test cases.
@@ -144,7 +145,7 @@ class TwigServiceProviderTest extends TestCase
 
     public function testWebLinkIntegration()
     {
-        if (!class_exists(WebLinkExtension::class)) {
+        if (!class_exists(HttpHeaderSerializer::class) || !class_exists(WebLinkExtension::class)) {
             $this->markTestSkipped('Twig WebLink extension not available.');
         }
 


### PR DESCRIPTION
I tried to keep it as close to the framework implementation as possible:

- The `system` pool uses `AbstractAdapter::createSystemCache()` 
  (eg: ApcuAdapter, PhpFilesAdapter or FilesystemAdapter depending on what's available)
- The `app` pool uses Redis/Memcached if a DSN has been specified, or FilesystemAdapter
  otherwise
- Users can create additional pools based on `system` or `app` by adding entries to
  `cache.pools.options`

The documentation is missing, but I'd like to get the implementation reviewed first.

### Minimum configuration
```php
$app->register(new CacheServiceProvider(), [
    'cache.directory' => '/path/to/cache',
]);

$pool = $app['cache.pools']['system'];
$item = $pool->getItem('key');
```

### Example usage
```php

$app->register(new CacheServiceProvider(), [
    'cache.directory' => '/path/to/cache',
    'cache.namespace_prefix' => 'prepended_to_namespaces_',

    'cache.system.namespace' => 'system',
    'cache.system.default_lifetime' => 0,
    'cache.system.version' => 'apcu-version-string',

    'cache.app.namespace' => 'app',
    'cache.app.default_lifetime' => 0,
    'cache.app.dsn' => 'redis://localhost',
    'cache.app.connection_options' => ['timeout' => 3],

    'cache.pools.option' => [
        // Build namespace using cache.system.namespace + pool name, use default_lifetime
        'system-based' => 'system',
        // Build namespace using cache.app.namespace + pool name, use default_lifetime
        'app-based' => 'app',
        // Use custom namespace and lifetime
        'custom' => [
            'adapter' => 'app',
            'namespace' => 'custom_ns',
            'lifetime' => 42,
        ],
    ],
]);

// You can override the factories to customize how all the pools of a specific type are created

$app['cache.system.factory'] = $app->protect(function($namespace, $lifetime = null) {
    return new NullAdapter();
});

// Add a custom pool not based on the default system or app adapters

$app->extend('cache.pools', function ($pools) use ($app) {
    $pools['db-cache'] = function () use ($app) {
        return new PdoAdapter('dsn', $app['cache.namespace_prefix'].'foo', 42);
    };

    return $pools;
});

$pool = $app['cache.pools']['system'];
$item = $pool->getItem('key');
```

### About the tests

Instead of adding one environment with APCu, one with Redis, etc... I just 
added one will all the services enabled. In my opinion that should be 
enough to cover all the cases as I'm not trying to test the cache component 
but only that the provider passes the correct parameters to the classes 
it instantiates.

I don't test lifetimes as it's slow... Now I could but that would mean
adding a bunch of `sleep()` calls to the tests.

Note:
- I merged #1523 into this PR to be able to test against 3.3/3.4
- A lot of the tests code (specifically the setUp/tearDown) is directly based on Nicolas' work on `symfony/cache`, so he'll deserve as much (if not more) credit on this one as I barely ported what he had done