### PR TITLE
Fix exception hander test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,7 @@ matrix:
         - php: 7.0
         - php: 7.1
         - php: hhvm
+          dist: trusty
 
 cache:
     directories:

--- a/tests/Silex/Tests/ExceptionHandlerTest.php
+++ b/tests/Silex/Tests/ExceptionHandlerTest.php
@@ -35,7 +35,7 @@ class ExceptionHandlerTest extends TestCase
 
         $request = Request::create('/foo');
         $response = $app->handle($request);
-        $this->assertContains('<h1>Whoops, looks like something went wrong.</h1>', $response->getContent());
+        $this->assertContains('Whoops, looks like something went wrong.', $response->getContent());
         $this->assertEquals(500, $response->getStatusCode());
     }
 
@@ -62,7 +62,7 @@ class ExceptionHandlerTest extends TestCase
 
         $request = Request::create('/foo');
         $response = $app->handle($request);
-        $this->assertContains('<h1>Sorry, the page you are looking for could not be found.</h1>', $response->getContent());
+        $this->assertContains('Sorry, the page you are looking for could not be found.', $response->getContent());
         $this->assertEquals(404, $response->getStatusCode());
     }
 
@@ -86,7 +86,7 @@ class ExceptionHandlerTest extends TestCase
 
         $request = Request::create('/foo', 'POST');
         $response = $app->handle($request);
-        $this->assertContains('<h1>Whoops, looks like something went wrong.</h1>', $response->getContent());
+        $this->assertContains('Whoops, looks like something went wrong.', $response->getContent());
         $this->assertEquals(405, $response->getStatusCode());
         $this->assertEquals('GET', $response->headers->get('Allow'));
     }


### PR DESCRIPTION
In symfony 3.3.0, the markup of the error wording has been changed.

https://github.com/symfony/symfony/pull/22838

3.2.x
`<h1>$title</h1>`

3.3.0
`<h1 class="break-long-words exception-message">$title</h1>`

Therefore, in the symfony 3.3.0 environment, ExceptionHandlerTest fails.

```
1) Silex \ Tests \ ExceptionHandlerTest :: testExceptionHandlerExceptionNoDebug
Failed asserting that '<! DOCTYPE html>

...

Contains "<h1> Whoops, looks like something went wrong. </h1>".
```

https://github.com/symfony/symfony/pull/22838/files#diff-5a9ac37e71d14aa261fe6f68848a6277L42

I deleted `<h1>` by referring to it.