### PR TITLE
Docs: Update interface reference for csrf.token_manager

### DIFF
--- a/doc/providers/csrf.rst
+++ b/doc/providers/csrf.rst
@@ -13,10 +13,9 @@ Services
 --------
 
 * **csrf.token_manager**: An instance of an implementation of the
-  `CsrfProviderInterface
-  <http://api.symfony.com/master/Symfony/Component/Form/Extension/Csrf/CsrfProvider/CsrfProviderInterface.html>`_,
-  defaults to a `DefaultCsrfProvider
-  <http://api.symfony.com/master/Symfony/Component/Form/Extension/Csrf/CsrfProvider/DefaultCsrfProvider.html>`_.
+  `CsrfTokenManagerInterface
+  <http://api.symfony.com/master/Symfony/Component/Security/Csrf/CsrfTokenManagerInterface.html>`_,
+  
 
 Registering
 -----------
@@ -44,9 +43,11 @@ When the CSRF Service Provider is registered, all forms created via the Form
 Service Provider are protected against CSRF by default.
 
 You can also use the CSRF protection even without using the Symfony Form
-component. If, for example, you're doing a DELETE action, you can check the
-CSRF token::
+component. If, for example, you're doing a DELETE action, you can create a token::
 
-    use Symfony\Component\Security\Csrf\CsrfToken;
+      use Symfony\Component\Security\Csrf\CsrfToken;
+      $csrfToken = $app['csrf.token_manager']->getToken('token_id'); //'TOKEN'
 
-    $app['csrf.token_manager']->isTokenValid(new CsrfToken('token_id', 'TOKEN'));
+then you can check the CSRF token::
+
+      $app['csrf.token_manager']->isTokenValid(new CsrfToken('token_id', 'TOKEN'));


### PR DESCRIPTION
The csrf.token_manager is an implementation of CsrfTokenManagerInterface
Fix the label and link to the reference
Update Usage section to include creation of a new token