### PR TITLE
Remove outdated example code from documentation

### DIFF
--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -675,9 +675,7 @@ Traits
 
 .. code-block:: php
 
-    $user = $app->user();
-
-    $encoded = $app->encodePassword($user, 'foo');
+    $encoded = $app->encodePassword($app['user'], 'foo');
 
 ``Silex\Route\SecurityTrait`` adds the following methods to the controllers:
 


### PR DESCRIPTION
The `user` method hasn't been part of the security
trait since 7052d97 over 2 years ago.