### PR TITLE
RedirectableUrlMatcher needs to return a proper array with the _route parameter

### DIFF
--- a/src/Silex/Provider/Routing/RedirectableUrlMatcher.php
+++ b/src/Silex/Provider/Routing/RedirectableUrlMatcher.php
@@ -48,6 +48,7 @@ class RedirectableUrlMatcher extends BaseRedirectableUrlMatcher
 
         return array(
             '_controller' => function ($url) { return new RedirectResponse($url, 301); },
+            '_route' => $route,
             'url' => $url,
         );
     }


### PR DESCRIPTION
Symfony's HttpUtils's checkRequestPath() expects RedirectableUrlMatcher to return an array with '_route'. This throws a notice `Undefined index: _route`:

```
        $coll = new RouteCollection();
        $coll->add('foo', new Route('/foo', array(), array(), array(), '', array('https')));
        $matcher = new RedirectableUrlMatcher($coll, new RequestContext());
        $httpUtils = new HttpUtils(null, $matcher);
        $request = Request::create('http://example.com/foo');
        $httpUtils->checkRequestPath($request, 'foo');
```

It's an issue with my app although I haven't yet taken the time to make a simplified app to show the issue besides the above.