### PR TITLE
Added PSR-11 service provider

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "pimple/pimple": "^3.2",
+        "pimple/pimple": "^3.2.1",
         "symfony/event-dispatcher": "~2.8|^3.0",
         "symfony/http-foundation": "~2.8|^3.0",
         "symfony/http-kernel": "~2.8|^3.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "pimple/pimple": "~3.0",
+        "pimple/pimple": "^3.2",
         "symfony/event-dispatcher": "~2.8|^3.0",
         "symfony/http-foundation": "~2.8|^3.0",
         "symfony/http-kernel": "~2.8|^3.0",

--- a/doc/providers/index.rst
+++ b/doc/providers/index.rst
@@ -22,3 +22,4 @@ Built-in Service Providers
     service_controller
     var_dumper
     doctrine
+    psr11

--- a/doc/providers/psr11.rst
+++ b/doc/providers/psr11.rst
@@ -4,10 +4,10 @@ PSR-11
 The *Psr11ServiceProvider* provides a container for accessing your application
 services using the PSR-11 ``ContainerInterface`` interface.
 
-PSR-11 is a standard that describes a common interface for dependency injection
+`PSR-11`_ is a standard that describes a common interface for dependency injection
 containers. Using the PSR-11 container will allow you to:
 
-* Use objects that expect a ``ContainerInterface`` instance.
+* Use objects that expect a ``Psr\Container\ContainerInterface`` instance.
 
 * Decouple your own code from the ``Silex\Application`` class (something that
   could prove useful if you intend to port your application to the Symfony
@@ -16,8 +16,7 @@ containers. Using the PSR-11 container will allow you to:
 Services
 --------
 
-* **container**: A container that implements `ContainerInterface
-  <https://github.com/container-interop/fig-standards/blob/master/proposed/container.md>`_
+* **container**: A container that implements ``Psr\Container\ContainerInterface``
   and give you access to all your services.
 
   Example usage::
@@ -25,8 +24,7 @@ Services
     $container = $app['container'];
     $service = $container->get('service');
 
-* **service_locator.factory**: A factory that creates `PSR-11 service locators
-  <https://github.com/silexphp/Pimple/blob/master/README.rst#using-the-psr-11-servicelocator>`_.
+* **service_locator.factory**: A factory that creates `PSR-11 service locators`_.
 
   Example usage::
 
@@ -103,3 +101,6 @@ instead of the whole container by using the ``convert()`` function:
     })->convert('container', function () use ($app) {
         return $app['service_locator.factory'](array('foo', 'bar'));
     });
+
+.. _PSR-11: https://github.com/container-interop/fig-standards/blob/master/proposed/container.md
+.. _PSR-11 service locators: https://github.com/silexphp/Pimple/blob/master/README.rst#using-the-psr-11-servicelocator

--- a/doc/providers/psr11.rst
+++ b/doc/providers/psr11.rst
@@ -1,0 +1,105 @@
+PSR-11
+======
+
+The *Psr11ServiceProvider* provides a container for accessing your application
+services using the PSR-11 ``ContainerInterface`` interface.
+
+PSR-11 is a standard that describes a common interface for dependency injection
+containers. Using the PSR-11 container will allow you to:
+
+* Use objects that expect a ``ContainerInterface`` instance.
+
+* Decouple your own code from the ``Silex\Application`` class (something that
+  could prove useful if you intend to port your application to the Symfony
+  full-stack framework in the future).
+
+Services
+--------
+
+* **container**: A container that implements `ContainerInterface
+  <https://github.com/container-interop/fig-standards/blob/master/proposed/container.md>`_
+  and give you access to all your services.
+
+  Example usage::
+
+    $container = $app['container'];
+    $service = $container->get('service');
+
+* **service_locator.factory**: A factory that creates `PSR-11 service locators
+  <https://github.com/silexphp/Pimple/blob/master/README.rst#using-the-psr-11-servicelocator>`_.
+
+  Example usage::
+
+    $locator = $app['service_locator.factory'](array('logger', 'dispatcher', 'form.factory'));
+    $service = new MyService($locator);
+
+Registering
+-----------
+
+.. code-block:: php
+
+    $app->register(new Silex\Provider\Psr11ServiceProvider());
+
+Using the Container in Controllers
+----------------------------------
+
+The provider registers an argument value resolver that can resolve controller
+arguments type-hinted with ``Psr\Container\ContainerInterface``.
+
+.. code-block:: php
+
+    use Psr\Container\ContainerInterface;
+
+    $app->get('/', function (ContainerInterface $container) {
+        $container->get('monolog')->debug('Showing the homepage.');
+    });
+
+Using Service Locators
+----------------------
+
+Injecting the entire service container to get only the services you need is
+not recommended because it gives objects a too broad access to the rest of
+the application and it hides their actual dependencies.
+
+Instead, you should consider using a service locator. It will give your
+objects access to a set of predefined services while instantiating them only
+when actually needed:
+
+.. code-block:: php
+
+    use Psr\Container\ContainerInterface;
+
+    class MyService
+    {
+        private $container;
+
+        public function __construct(ContainerInterface $container)
+        {
+            $this->container = $container;
+        }
+
+        public function processFoo()
+        {
+            $this->container->get('foo')->process();
+        }
+
+        public function processBar()
+        {
+            $this->container->get('bar')->process();
+        }
+    }
+
+    $app['service'] = function ($app) {
+        return new MyService($app['service_locator.factory'](array('foo', 'bar')));
+    };
+
+You can also inject a ``ServiceLocator`` instance into your controllers
+instead of the whole container by using the ``convert()`` function:
+
+.. code-block:: php
+
+    $app->get('/', function (ContainerInterface $container) {
+        // do something with the foo and the bar services
+    })->convert('container', function () use ($app) {
+        return $app['service_locator.factory'](array('foo', 'bar'));
+    });

--- a/src/Silex/Provider/HttpKernelServiceProvider.php
+++ b/src/Silex/Provider/HttpKernelServiceProvider.php
@@ -1,5 +1,14 @@
 <?php
 
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
 namespace Silex\Provider;
 
 use Pimple\Container;

--- a/src/Silex/Provider/Psr11/ContainerValueResolver.php
+++ b/src/Silex/Provider/Psr11/ContainerValueResolver.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Silex\Provider\Psr11;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentValueResolverInterface;
+use Symfony\Component\HttpKernel\ControllerMetadata\ArgumentMetadata;
+
+/**
+ * Resolves ContainerInterface arguments.
+ *
+ * @author Pascal Luna <skalpa@zetareticuli.org>
+ */
+class ContainerValueResolver implements ArgumentValueResolverInterface
+{
+    private $container;
+
+    public function __construct(ContainerInterface $container)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supports(Request $request, ArgumentMetadata $argument)
+    {
+        return is_a($this->container, $argument->getType());
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resolve(Request $request, ArgumentMetadata $argument)
+    {
+        yield $this->container;
+    }
+}

--- a/src/Silex/Provider/Psr11/ControllerResolver.php
+++ b/src/Silex/Provider/Psr11/ControllerResolver.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Provider\Psr11;
+
+use Psr\Container\ContainerInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Controller\ArgumentResolverInterface;
+use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+
+/**
+ * Resolves ContainerInterface arguments when using an old (<3.1) kernel.
+ *
+ * @author Pascal Luna <skalpa@zetareticuli.org>
+ */
+final class ControllerResolver implements ArgumentResolverInterface, ControllerResolverInterface
+{
+    private $resolver;
+    private $container;
+
+    public function __construct(ControllerResolverInterface $resolver, ContainerInterface $container)
+    {
+        $this->resolver = $resolver;
+        $this->container = $container;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getController(Request $request)
+    {
+        return $this->resolver->getController($request);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getArguments(Request $request, $controller)
+    {
+        if (is_array($controller)) {
+            $r = new \ReflectionMethod($controller[0], $controller[1]);
+        } elseif (is_object($controller) && !$controller instanceof \Closure) {
+            $r = new \ReflectionObject($controller);
+            $r = $r->getMethod('__invoke');
+        } else {
+            $r = new \ReflectionFunction($controller);
+        }
+        $this->resolveArguments($request, $r->getParameters());
+
+        return $this->resolver->getArguments($request, $controller);
+    }
+
+    private function resolveArguments(Request $request, array $parameters)
+    {
+        foreach ($parameters as $param) {
+            if (!$request->attributes->has($param->name) && $param->getClass() && is_a($this->container, $param->getClass()->name)) {
+                $request->attributes->set($param->name, $this->container);
+            }
+        }
+    }
+}

--- a/src/Silex/Provider/Psr11ServiceProvider.php
+++ b/src/Silex/Provider/Psr11ServiceProvider.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Provider;
+
+use Pimple\Container;
+use Pimple\Psr11\Container as PsrContainer;
+use Pimple\ServiceProviderInterface;
+use Silex\Provider\Psr11\ContainerValueResolver;
+use Silex\Provider\Psr11\ControllerResolver;
+use Symfony\Component\HttpKernel\Kernel;
+
+/**
+ * Provides a PSR-11 container and argument value resolver.
+ *
+ * @author Pascal Luna <skalpa@zetareticuli.org>
+ */
+class Psr11ServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $app)
+    {
+        $app['psr11'] = function ($app) {
+            return new PsrContainer($app);
+        };
+
+        if (Kernel::VERSION_ID >= 30100) {
+            $app->extend('argument_value_resolvers', function ($resolvers, $app) {
+                $resolvers[] = new ContainerValueResolver($app['psr11']);
+
+                return $resolvers;
+            });
+        } else {
+            $app->extend('resolver', function ($resolver, $app) {
+                return new ControllerResolver($resolver, $app['psr11']);
+            });
+        }
+    }
+}

--- a/src/Silex/Provider/Psr11ServiceProvider.php
+++ b/src/Silex/Provider/Psr11ServiceProvider.php
@@ -13,6 +13,7 @@ namespace Silex\Provider;
 
 use Pimple\Container;
 use Pimple\Psr11\Container as PsrContainer;
+use Pimple\Psr11\ServiceLocator;
 use Pimple\ServiceProviderInterface;
 use Silex\Provider\Psr11\ContainerValueResolver;
 use Silex\Provider\Psr11\ControllerResolver;
@@ -30,6 +31,10 @@ class Psr11ServiceProvider implements ServiceProviderInterface
         $app['container'] = function ($app) {
             return new PsrContainer($app);
         };
+
+        $app['service_locator.factory'] = $app->protect(function ($ids) use ($app) {
+            return new ServiceLocator($app, $ids);
+        });
 
         if (Kernel::VERSION_ID >= 30100) {
             $app->extend('argument_value_resolvers', function ($resolvers, $app) {

--- a/src/Silex/Provider/Psr11ServiceProvider.php
+++ b/src/Silex/Provider/Psr11ServiceProvider.php
@@ -27,19 +27,19 @@ class Psr11ServiceProvider implements ServiceProviderInterface
 {
     public function register(Container $app)
     {
-        $app['psr11'] = function ($app) {
+        $app['container'] = function ($app) {
             return new PsrContainer($app);
         };
 
         if (Kernel::VERSION_ID >= 30100) {
             $app->extend('argument_value_resolvers', function ($resolvers, $app) {
-                $resolvers[] = new ContainerValueResolver($app['psr11']);
+                $resolvers[] = new ContainerValueResolver($app['container']);
 
                 return $resolvers;
             });
         } else {
             $app->extend('resolver', function ($resolver, $app) {
-                return new ControllerResolver($resolver, $app['psr11']);
+                return new ControllerResolver($resolver, $app['container']);
             });
         }
     }

--- a/tests/Silex/Tests/Fixtures/Psr11/ChildContainer.php
+++ b/tests/Silex/Tests/Fixtures/Psr11/ChildContainer.php
@@ -1,0 +1,16 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Fixtures\Psr11;
+
+class ChildContainer extends ParentContainer implements ChildInterface
+{
+}

--- a/tests/Silex/Tests/Fixtures/Psr11/ChildInterface.php
+++ b/tests/Silex/Tests/Fixtures/Psr11/ChildInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Fixtures\Psr11;
+
+use Psr\Container\ContainerInterface;
+
+interface ChildInterface extends ContainerInterface
+{
+}

--- a/tests/Silex/Tests/Fixtures/Psr11/ParentContainer.php
+++ b/tests/Silex/Tests/Fixtures/Psr11/ParentContainer.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Fixtures\Psr11;
+
+use Psr\Container\ContainerInterface;
+
+class ParentContainer implements ContainerInterface
+{
+    public function get($id)
+    {
+    }
+
+    public function has($id)
+    {
+    }
+}

--- a/tests/Silex/Tests/Provider/Psr11ServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/Psr11ServiceProviderTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the Silex framework.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Silex\Tests\Provider;
+
+use PHPUnit\Framework\TestCase;
+use Pimple\Psr11\Container;
+use Psr\Container\ContainerInterface;
+use Silex\Application;
+use Silex\Provider\Psr11ServiceProvider;
+use Silex\Tests\Fixtures\Psr11\ChildContainer;
+use Silex\Tests\Fixtures\Psr11\ChildInterface;
+use Silex\Tests\Fixtures\Psr11\ParentContainer;
+use Symfony\Component\HttpFoundation\Request;
+
+class Psr11ServiceProviderTest extends TestCase
+{
+    public function testCanAccessSilexServices()
+    {
+        $app = new Application();
+        $app->register(new Psr11ServiceProvider());
+
+        $app['service'] = function () {
+            return new \stdClass();
+        };
+
+        $this->assertSame($app['service'], $app['psr11']->get('service'));
+    }
+
+    /**
+     * @dataProvider provideControllers
+     */
+    public function testResolvableArgument($controller, $containerFactory)
+    {
+        $app = new Application();
+        $app->register(new Psr11ServiceProvider());
+
+        if (null !== $containerFactory) {
+            $app['psr11'] = $containerFactory;
+        }
+        $app->get('/', $controller);
+
+        $this->assertSame('ok', $app->handle(Request::create('/'))->getContent());
+    }
+
+    public function provideControllers()
+    {
+        return array(
+            // ContainerInterface
+            array(
+                function (Application $app, ContainerInterface $container) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                null,
+            ),
+            // Exact class of the container
+            array(
+                function (Application $app, Container $container) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                null,
+            ),
+            // Child interface implemented by the container
+            array(
+                function (Application $app, ChildInterface $container) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                function () { return new ChildContainer(); },
+            ),
+            // Parent class
+            array(
+                function (Application $app, ParentContainer $container) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                function () { return new ChildContainer(); },
+            ),
+        );
+    }
+
+    /**
+     * @dataProvider provideBadControllers
+     */
+    public function testUnresolvableArgument($controller, $containerFactory)
+    {
+        $app = new Application();
+        $app->register(new Psr11ServiceProvider());
+
+        if (null !== $containerFactory) {
+            $app['psr11'] = $containerFactory;
+        }
+        $app->get('/', $controller);
+
+        $this->assertSame('ko', $app->handle(Request::create('/'))->getContent());
+    }
+
+    public function provideBadControllers()
+    {
+        return array(
+            // Unrelated class
+            array(
+                function (Application $app, ParentContainer $container = null) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                null,
+            ),
+            // Child interface not implemented by the container
+            array(
+                function (Application $app, ChildInterface $container = null) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                null,
+            ),
+        );
+    }
+
+    public function testResolvedArgumentIsNotOverridden()
+    {
+        $app = new Application();
+        $app->register(new Psr11ServiceProvider());
+
+        $app->get('/', function (Application $app, ContainerInterface $container) {
+            return $container === $app['psr11'] ? 'ok' : 'ko';
+        })->convert('container', function () {
+            return new ParentContainer();
+        });
+
+        $this->assertSame('ko', $app->handle(Request::create('/'))->getContent());
+    }
+}

--- a/tests/Silex/Tests/Provider/Psr11ServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/Psr11ServiceProviderTest.php
@@ -32,7 +32,7 @@ class Psr11ServiceProviderTest extends TestCase
             return new \stdClass();
         };
 
-        $this->assertSame($app['service'], $app['psr11']->get('service'));
+        $this->assertSame($app['service'], $app['container']->get('service'));
     }
 
     /**
@@ -44,7 +44,7 @@ class Psr11ServiceProviderTest extends TestCase
         $app->register(new Psr11ServiceProvider());
 
         if (null !== $containerFactory) {
-            $app['psr11'] = $containerFactory;
+            $app['container'] = $containerFactory;
         }
         $app->get('/', $controller);
 
@@ -56,22 +56,22 @@ class Psr11ServiceProviderTest extends TestCase
         return array(
             // ContainerInterface
             array(
-                function (Application $app, ContainerInterface $container) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                function (Application $app, ContainerInterface $container) { return $container === $app['container'] ? 'ok' : 'ko'; },
                 null,
             ),
             // Exact class of the container
             array(
-                function (Application $app, Container $container) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                function (Application $app, Container $container) { return $container === $app['container'] ? 'ok' : 'ko'; },
                 null,
             ),
             // Child interface implemented by the container
             array(
-                function (Application $app, ChildInterface $container) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                function (Application $app, ChildInterface $container) { return $container === $app['container'] ? 'ok' : 'ko'; },
                 function () { return new ChildContainer(); },
             ),
             // Parent class
             array(
-                function (Application $app, ParentContainer $container) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                function (Application $app, ParentContainer $container) { return $container === $app['container'] ? 'ok' : 'ko'; },
                 function () { return new ChildContainer(); },
             ),
         );
@@ -86,7 +86,7 @@ class Psr11ServiceProviderTest extends TestCase
         $app->register(new Psr11ServiceProvider());
 
         if (null !== $containerFactory) {
-            $app['psr11'] = $containerFactory;
+            $app['container'] = $containerFactory;
         }
         $app->get('/', $controller);
 
@@ -98,12 +98,12 @@ class Psr11ServiceProviderTest extends TestCase
         return array(
             // Unrelated class
             array(
-                function (Application $app, ParentContainer $container = null) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                function (Application $app, ParentContainer $container = null) { return $container === $app['container'] ? 'ok' : 'ko'; },
                 null,
             ),
             // Child interface not implemented by the container
             array(
-                function (Application $app, ChildInterface $container = null) { return $container === $app['psr11'] ? 'ok' : 'ko'; },
+                function (Application $app, ChildInterface $container = null) { return $container === $app['container'] ? 'ok' : 'ko'; },
                 null,
             ),
         );
@@ -115,7 +115,7 @@ class Psr11ServiceProviderTest extends TestCase
         $app->register(new Psr11ServiceProvider());
 
         $app->get('/', function (Application $app, ContainerInterface $container) {
-            return $container === $app['psr11'] ? 'ok' : 'ko';
+            return $container === $app['container'] ? 'ok' : 'ko';
         })->convert('container', function () {
             return new ParentContainer();
         });

--- a/tests/Silex/Tests/Provider/Psr11ServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/Psr11ServiceProviderTest.php
@@ -35,6 +35,24 @@ class Psr11ServiceProviderTest extends TestCase
         $this->assertSame($app['service'], $app['container']->get('service'));
     }
 
+    public function testServiceLocatorFactory()
+    {
+        $app = new Application();
+        $app->register(new Psr11ServiceProvider());
+        $app['foo'] = function () {
+            return new \stdClass();
+        };
+        $app['bar'] = function () {
+            return new \stdClass();
+        };
+
+        $locator = $app['service_locator.factory'](array('foo'));
+
+        $this->assertInstanceOf(ContainerInterface::class, $locator);
+        $this->assertSame($app['foo'], $locator->get('foo'));
+        $this->assertFalse($locator->has('bar'));
+    }
+
     /**
      * @dataProvider provideControllers
      */


### PR DESCRIPTION
PSR-11 service provider that adds:
- A `psr11` service
- Argument value resolvers that inject the PSR-11 container into controllers:

```php
use Psr\Container\ContainerInterface;

$app->get('/', function (ContainerInterface $container) {
    $service = $container->get('service');
});
```

The resolution is performed by an `ArgumentValueResolverInterface` if the kernel is recent enough, or by a custom `ControllerResolverInterface` that decorates the `resolver` service otherwise (so we don't break BC).

AFAIK it's the only thing Silex will need, but if somebody can think of another use for the PSR-11 container give me a shout.

I'll add the documentation once Pimple has been updated.


