### PR TITLE
Fixed translator.resources definition

### DIFF
--- a/src/Silex/Provider/TranslationServiceProvider.php
+++ b/src/Silex/Provider/TranslationServiceProvider.php
@@ -80,9 +80,9 @@ class TranslationServiceProvider implements ServiceProviderInterface, EventListe
             return new MessageSelector();
         };
 
-        $app['translator.resources'] = $app->protect(function ($app) {
+        $app['translator.resources'] = function ($app) {
             return array();
-        });
+        };
 
         $app['translator.domains'] = array();
         $app['locale_fallbacks'] = array('en');

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -82,7 +82,7 @@ class ValidatorServiceProviderTest extends TestCase
      */
     public function testValidatorServiceIsAValidator($app)
     {
-        $this->assertTrue($app['validator'] instanceof ValidatorInterface || $app['validator'] instanceof LegacyValidatorInterface );
+        $this->assertTrue($app['validator'] instanceof ValidatorInterface || $app['validator'] instanceof LegacyValidatorInterface);
     }
 
     /**
@@ -191,5 +191,16 @@ class ValidatorServiceProviderTest extends TestCase
         $app['validator'];
 
         $this->assertEquals('Pas vide', $app['translator']->trans('This value should not be blank.', array(), 'validators', 'fr'));
+    }
+
+    public function testTranslatorResourcesIsArray()
+    {
+        $app = new Application();
+        $app['locale'] = 'fr';
+
+        $app->register(new ValidatorServiceProvider());
+        $app->register(new TranslationServiceProvider());
+
+        $this->assertInternalType('array', $app['translator.resources']);
     }
 }


### PR DESCRIPTION
`translator.resource` is wrongly registered as a protected closure in `TranslationServiceProvider` (it was originally added correctly in dd27038, but changed in 48a3fdc).

That makes a test fail with Pimple 3.2.1 due to the silexphp/Pimple#190 fix as `translator.resource` can't be extended.