### PR TITLE
Handle the ControllerResolverInterface::getArguments deprecation in tests

### DIFF
--- a/tests/Silex/Tests/ControllerResolverTest.php
+++ b/tests/Silex/Tests/ControllerResolverTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Silex\ControllerResolver;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * ControllerResolver test cases.
@@ -28,6 +29,10 @@ class ControllerResolverTest extends TestCase
      */
     public function testGetArguments()
     {
+        if (Kernel::VERSION_ID >= 30100) {
+            self::markTestSkipped('HttpKernel < 3.1.0 is required');
+        }
+
         $app = new Application();
         $resolver = new ControllerResolver($app);
 

--- a/tests/Silex/Tests/ServiceControllerResolverTest.php
+++ b/tests/Silex/Tests/ServiceControllerResolverTest.php
@@ -15,6 +15,7 @@ use PHPUnit\Framework\TestCase;
 use Silex\ServiceControllerResolver;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\Kernel;
 
 /**
  * Unit tests for ServiceControllerResolver, see ServiceControllerResolverRouterTest for some
@@ -77,8 +78,15 @@ class ServiceControllerResolverTest extends Testcase
         $this->assertEquals(123, $this->resolver->getController($req));
     }
 
+    /**
+     * @group legacy
+     */
     public function testShouldDelegateGetArguments()
     {
+        if (Kernel::VERSION_ID >= 40000) {
+            self::markTestSkipped('HttpKernel < 4.0 is required');
+        }
+
         $req = Request::create('/');
         $this->mockResolver->expects($this->once())
             ->method('getArguments')


### PR DESCRIPTION
Fixes deprecation notices/failures due to the deprecation of `ControllerResolverInterface::getArguments()`:

1. `Silex\ControllerResolver` [is not used by Silex](https://github.com/silexphp/Silex/blob/master/src/Silex/Provider/HttpKernelServiceProvider.php#L37) when using HttpKernel >= 3.1.0, so I skipped the only test present in `ControllerResolverTest` with recent versions, as it failed when testing against HttpKernel v4  (master).

2. `ServiceControllerResolverTest::testShouldDelegateGetArguments()` only asserts that the deprecated method is called, so added a `@group legacy` to handle the notice, and skipped the test with v4 to prevent a warning (PHPUnit complains when you mock a non-existent method).