### PR TITLE
[RFC][WIP] Allow separate logging channels

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -65,6 +65,9 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         $this['debug'] = false;
         $this['charset'] = 'UTF-8';
         $this['logger'] = null;
+        $this['logger.request'] = function () {
+            return $this['logger'];
+        };
 
         $this->register(new HttpKernelServiceProvider());
         $this->register(new RoutingServiceProvider());

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -11,6 +11,7 @@
 
 namespace Silex;
 
+use Monolog\Logger;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -66,7 +67,13 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
         $this['charset'] = 'UTF-8';
         $this['logger'] = null;
         $this['logger.request'] = function () {
-            return $this['logger'];
+            $logger = $this['logger'];
+
+            if ($logger instanceof Logger) {
+                $logger = $logger->withName('request');
+            }
+
+            return $logger;
         };
 
         $this->register(new HttpKernelServiceProvider());

--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Provider;
 
+use Monolog\Logger;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Doctrine\DBAL\DriverManager;
@@ -28,7 +29,13 @@ class DoctrineServiceProvider implements ServiceProviderInterface
     public function register(Container $app)
     {
         $app['logger.doctrine'] = function (Container $app) {
-            return $app['logger'];
+            $logger = $app['logger'];
+
+            if ($logger instanceof Logger) {
+                $logger = $logger->withName('doctrine');
+            }
+
+            return $logger;
         };
 
         $app['db.default_options'] = array(

--- a/src/Silex/Provider/DoctrineServiceProvider.php
+++ b/src/Silex/Provider/DoctrineServiceProvider.php
@@ -27,6 +27,10 @@ class DoctrineServiceProvider implements ServiceProviderInterface
 {
     public function register(Container $app)
     {
+        $app['logger.doctrine'] = function (Container $app) {
+            return $app['logger'];
+        };
+
         $app['db.default_options'] = array(
             'driver' => 'pdo_mysql',
             'dbname' => null,
@@ -85,11 +89,14 @@ class DoctrineServiceProvider implements ServiceProviderInterface
             $app['dbs.options.initializer']();
 
             $configs = new Container();
-            $addLogger = isset($app['logger']) && null !== $app['logger'] && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger');
+            $addLogger = null !== $app['logger.doctrine'] && class_exists('Symfony\Bridge\Doctrine\Logger\DbalLogger');
             foreach ($app['dbs.options'] as $name => $options) {
                 $configs[$name] = new Configuration();
                 if ($addLogger) {
-                    $configs[$name]->setSQLLogger(new DbalLogger($app['logger'], isset($app['stopwatch']) ? $app['stopwatch'] : null));
+                    $configs[$name]->setSQLLogger(new DbalLogger(
+                        $app['logger.doctrine'],
+                        isset($app['stopwatch']) ? $app['stopwatch'] : null
+                    ));
                 }
             }
 

--- a/src/Silex/Provider/HttpKernelServiceProvider.php
+++ b/src/Silex/Provider/HttpKernelServiceProvider.php
@@ -36,10 +36,10 @@ class HttpKernelServiceProvider implements ServiceProviderInterface, EventListen
     {
         $app['resolver'] = function ($app) {
             if (Kernel::VERSION_ID >= 30100) {
-                return new SfControllerResolver($app['logger']);
+                return new SfControllerResolver($app['logger.request']);
             }
 
-            return new ControllerResolver($app, $app['logger']);
+            return new ControllerResolver($app, $app['logger.request']);
         };
 
         if (Kernel::VERSION_ID >= 30100) {

--- a/src/Silex/Provider/RememberMeServiceProvider.php
+++ b/src/Silex/Provider/RememberMeServiceProvider.php
@@ -75,7 +75,13 @@ class RememberMeServiceProvider implements ServiceProviderInterface, EventListen
                     'remember_me_parameter' => '_remember_me',
                 ), $options);
 
-                return new TokenBasedRememberMeServices(array($app['security.user_provider.'.$providerKey]), $options['key'], $providerKey, $options, $app['logger']);
+                return new TokenBasedRememberMeServices(
+                    array($app['security.user_provider.'.$providerKey]),
+                    $options['key'],
+                    $providerKey,
+                    $options,
+                    $app['logger.security']
+                );
             };
         });
 
@@ -85,7 +91,7 @@ class RememberMeServiceProvider implements ServiceProviderInterface, EventListen
                     $app['security.token_storage'],
                     $app['security.remember_me.service.'.$providerKey],
                     $app['security.authentication_manager'],
-                    $app['logger'],
+                    $app['logger.security'],
                     $app['dispatcher']
                 );
 

--- a/src/Silex/Provider/RoutingServiceProvider.php
+++ b/src/Silex/Provider/RoutingServiceProvider.php
@@ -76,7 +76,12 @@ class RoutingServiceProvider implements ServiceProviderInterface, EventListenerP
                 return $app['request_matcher'];
             });
 
-            return new RouterListener($urlMatcher, $app['request_stack'], $app['request_context'], $app['logger']);
+            return new RouterListener(
+                $urlMatcher,
+                $app['request_stack'],
+                $app['request_context'],
+                $app['logger.request']
+            );
         };
     }
 

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -74,6 +74,10 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
 
     public function register(Container $app)
     {
+        $app['logger.security'] = function (Container $app) {
+            return $app['logger'];
+        };
+
         // used to register routes for login_check and logout
         $this->fakeRoutes = array();
 
@@ -161,7 +165,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     isset($app['request.http_port']) ? $app['request.http_port'] : 80,
                     isset($app['request.https_port']) ? $app['request.https_port'] : 443
                 ),
-                $app['logger']
+                $app['logger.security']
             );
         };
 
@@ -345,7 +349,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                 $app['security.access_manager'],
                 $app['security.access_map'],
                 $app['security.authentication_manager'],
-                $app['logger']
+                $app['logger.security']
             );
         };
 
@@ -406,7 +410,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security.token_storage'],
                     $userProviders,
                     $providerKey,
-                    $app['logger'],
+                    $app['logger.security'],
                     $app['dispatcher']
                 );
             };
@@ -433,7 +437,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app[$entryPoint],
                     null, // errorPage
                     $accessDeniedHandler,
-                    $app['logger']
+                    $app['logger.security']
                 );
             };
         });
@@ -456,7 +460,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app,
                     $app['security.http_utils'],
                     $options,
-                    $app['logger']
+                    $app['logger.security']
                 );
             };
         });
@@ -477,7 +481,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security.authentication_manager'],
                     $providerKey,
                     $authenticators,
-                    $app['logger']
+                    $app['logger.security']
                 );
             };
         });
@@ -509,7 +513,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security.authentication.success_handler.'.$name],
                     $app['security.authentication.failure_handler.'.$name],
                     $options,
-                    $app['logger'],
+                    $app['logger.security'],
                     $app['dispatcher'],
                     isset($options['with_csrf']) && $options['with_csrf'] && isset($app['csrf.token_manager']) ? $app['csrf.token_manager'] : null
                 );
@@ -523,7 +527,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security.authentication_manager'],
                     $providerKey,
                     $app['security.entry_point.'.$providerKey.'.http'],
-                    $app['logger']
+                    $app['logger.security']
                 );
             };
         });
@@ -533,7 +537,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                 return new AnonymousAuthenticationListener(
                     $app['security.token_storage'],
                     $providerKey,
-                    $app['logger']
+                    $app['logger.security']
                 );
             };
         });
@@ -584,7 +588,7 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                     $app['security.user_checker'],
                     $name,
                     $app['security.access_manager'],
-                    $app['logger'],
+                    $app['logger.security'],
                     isset($options['parameter']) ? $options['parameter'] : '_switch_user',
                     isset($options['role']) ? $options['role'] : 'ROLE_ALLOWED_TO_SWITCH',
                     $app['dispatcher']

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Provider;
 
+use Monolog\Logger;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
 use Silex\Application;
@@ -75,7 +76,13 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
     public function register(Container $app)
     {
         $app['logger.security'] = function (Container $app) {
-            return $app['logger'];
+            $logger = $app['logger'];
+
+            if ($logger instanceof Logger) {
+                $logger = $logger->withName('security');
+            }
+
+            return $logger;
         };
 
         // used to register routes for login_check and logout


### PR DESCRIPTION
Right now using default providers has a big disadvantage: all logs (database, security, etc) are dumped into app channel. This makes the logs harder to read and harder to manage (eg. I want security logs in one file but rest in another). Currently I see two ways to improve this:

### Prototype-based
Introduce a logger factory (eg `monolog.logger._proto`) which will be responsible for creating loggers with a given name/channel and use it in other providers (if present). Closely mimics MonologBundle's behaviour but isn't BC in case somebody extended the `monolog` service (I know my code will break)

 ### `\Monolog\Logger::withName()`
Looks to be a safer bet BC-wise however (due to my lack of knowledge of monolog's inner workings) I'm not sure if this can cause any potential problems in future

When introducing this it's also important to think about other libraries out there (starting with the [profiler](https://github.com/silexphp/Silex-WebProfiler/blob/master/WebProfilerServiceProvider.php#L70))

Looking forward to any comments and suggestions

P.S. I know about https://silex.symfony.com/doc/2.0/cookbook/multiple_loggers.html but I'm talking about services where `$app['logger']` is hard coded

P.P.S. `MonologServiceProvider` is so opinionated and inflexible that the above tutorial doesn't even use it. Maybe it's better to try and make it more flexible first? Although I have no idea how to do that in BC-way