### PR TITLE
Explicitly add `symfony/debug` as a requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=5.5.9",
         "pimple/pimple": "~3.0",
+        "symfony/debug": "~2.8|^3.0",
         "symfony/event-dispatcher": "~2.8|^3.0",
         "symfony/http-foundation": "~2.8|^3.0",
         "symfony/http-kernel": "~2.8|^3.0",


### PR DESCRIPTION
The code: https://github.com/silexphp/Silex/blob/master/src/Silex/ExceptionHandler.php#L37 uses `symfony/debug` classes directly. However it is currently only installed by inference from `symfony/http-kernel` when not installing the development dependencies.

If you do a `composer update --prefer-stable --prefer-lowest` from outside of silex it will grab the `2.6` version of `symfony/debug` which does not include the `getHtml` method on `DebugExceptionHandler` and thus everything fails.

This was discovered in: graze/silex-trailing-slash-handler#9