### PR TITLE
PHP7.2 compat

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,19 @@
+<?php
+
+return PhpCsFixer\Config::create()
+    ->setRules(array(
+        '@Symfony' => true,
+        '@Symfony:risky' => true,
+        'array_syntax' => array('syntax' => 'long'),
+        'php_unit_fqcn_annotation' => false,
+        'no_unreachable_default_argument_value' => false,
+        'braces' => array('allow_single_line_closure' => true),
+        'heredoc_to_nowdoc' => false,
+    ))
+    ->setRiskyAllowed(true)
+    ->setFinder(
+        PhpCsFixer\Finder::create()
+            ->in(__DIR__.'/src/')
+            ->in(__DIR__.'/tests/')
+            ->name('*.php')
+    );

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,28 +1,20 @@
 language: php
 
+git:
+    depth: 1
+
 sudo: false
 
 cache:
     directories:
       - $HOME/.composer/cache/files
 
-before_install:
-    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
-
-before_script:
-    # symfony/*
-    - sh -c "if [ '$TWIG_VERSION' != '2.0' ]; then sed -i 's/~1\.28|~2\.0/~1.28/g' composer.json; php -d memory_limit=-1 `which composer` update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.0' ]; then sed -i 's/~2\.3|3\.0\.\*/3.0.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.8' ]; then sed -i 's/~2\.3|3\.0\.\*/2.8.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.3|3\.0\.\*/2.7.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.3' ]; then sed -i 's/~2\.3|3\.0\.\*/2.3.*@dev/g' composer.json; composer update; fi"
-    - composer install
-
-script: phpunit
-
 matrix:
+    fast_finish: true
     include:
         - php: 5.3
+          env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+          dist: precise
         - php: 5.4
         - php: 5.5
         - php: 5.6
@@ -34,4 +26,25 @@ matrix:
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.0
         - php: 7.0
+        - php: 7.1
+        - php: 7.2
+          env: COMPOSER_FLAGS="--prefer-stable"
+        - php: nightly
         - php: hhvm
+    allow_failures:
+        - php: nightly
+
+before_install:
+    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
+
+before_script:
+    # symfony/*
+    - sh -c "if [ '$TWIG_VERSION' != '2.0' ]; then sed -i 's/~1\.28|~2\.0/~1.28/g' composer.json; php -d memory_limit=-1 `which composer` update; fi"
+    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.0' ]; then sed -i 's/~2\.3|3\.0\.\*/3.0.*@dev/g' composer.json; composer update $COMPOSER_FLAGS --no-interaction -v; fi"
+    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.8' ]; then sed -i 's/~2\.3|3\.0\.\*/2.8.*@dev/g' composer.json; composer update $COMPOSER_FLAGS --no-interaction -v; fi"
+    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.3|3\.0\.\*/2.7.*@dev/g' composer.json; composer update $COMPOSER_FLAGS --no-interaction -v; fi"
+    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '2.3' ]; then sed -i 's/~2\.3|3\.0\.\*/2.3.*@dev/g' composer.json; composer update $COMPOSER_FLAGS --no-interaction -v; fi"
+    - composer install
+    - composer info -D | sort
+
+script: phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -53,12 +53,11 @@
         "psr-4": { "Silex\\Tests\\" : "tests/Silex/Tests" }
     },
     "config": {
-        "optimize-autoloader": true,
         "sort-packages": true
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "2.3.x-dev"
+            "dev-master": "1.4.x-dev"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -23,33 +23,40 @@
         "symfony/routing": "~2.3|3.0.*"
     },
     "require-dev": {
-        "symfony/security": "~2.3|3.0.*",
-        "symfony/config": "~2.3|3.0.*",
-        "symfony/intl": "~2.3|3.0.*",
-        "symfony/form": "~2.3|3.0.*",
+        "doctrine/dbal": "~2.2",
+        "monolog/monolog": "^1.4.1",
+        "swiftmailer/swiftmailer": "~5",
         "symfony/browser-kit": "~2.3|3.0.*",
+        "symfony/config": "~2.3|3.0.*",
         "symfony/css-selector": "~2.3|3.0.*",
         "symfony/debug": "~2.3|3.0.*",
         "symfony/dom-crawler": "~2.3|3.0.*",
         "symfony/finder": "~2.3|3.0.*",
+        "symfony/form": "~2.3|3.0.*",
+        "symfony/intl": "~2.3|3.0.*",
         "symfony/monolog-bridge": "~2.3|3.0.*",
         "symfony/options-resolver": "~2.3|3.0.*",
         "symfony/phpunit-bridge": "~2.7",
         "symfony/process": "~2.3|3.0.*",
+        "symfony/security": "~2.3|3.0.*",
         "symfony/serializer": "~2.3|3.0.*",
         "symfony/translation": "~2.3|3.0.*",
         "symfony/twig-bridge": "~2.3|3.0.*",
-        "symfony/validator": "~2.3|3.0.*",
-        "twig/twig": "~1.28|~2.0",
-        "doctrine/dbal": "~2.2",
-        "swiftmailer/swiftmailer": "~5",
-        "monolog/monolog": "^1.4.1"
+        "symfony/validator": "~2.3|3.*",
+        "twig/twig": "~1.28|~2.0"
+    },
+    "conflict": {
+        "phpunit/phpunit": "<4.8.35 || >= 5.0, <5.4.3"
     },
     "autoload": {
         "psr-4": { "Silex\\": "src/Silex" }
     },
     "autoload-dev" : {
         "psr-4": { "Silex\\Tests\\" : "tests/Silex/Tests" }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "sort-packages": true
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
     "require-dev": {
         "doctrine/dbal": "~2.2",
         "monolog/monolog": "^1.4.1",
+        "phpunit/phpunit": "^5.7.23 || ^6.4.3",
         "swiftmailer/swiftmailer": "~5",
         "symfony/browser-kit": "~2.3|3.0.*",
         "symfony/config": "~2.3|3.0.*",
@@ -36,7 +37,7 @@
         "symfony/intl": "~2.3|3.0.*",
         "symfony/monolog-bridge": "~2.3|3.0.*",
         "symfony/options-resolver": "~2.3|3.0.*",
-        "symfony/phpunit-bridge": "~2.7",
+        "symfony/phpunit-bridge": "~2.7|^3.2.2|^4.0",
         "symfony/process": "~2.3|3.0.*",
         "symfony/security": "~2.3|3.0.*",
         "symfony/serializer": "~2.3|3.0.*",
@@ -44,9 +45,6 @@
         "symfony/twig-bridge": "~2.3|3.0.*",
         "symfony/validator": "~2.3|3.*",
         "twig/twig": "~1.28|~2.0"
-    },
-    "conflict": {
-        "phpunit/phpunit": "<4.8.35 || >= 5.0, <5.4.3"
     },
     "autoload": {
         "psr-4": { "Silex\\": "src/Silex" }
@@ -60,8 +58,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "2.3.x-dev"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -57,7 +57,7 @@ class Application extends \Pimple implements HttpKernelInterface, TerminableInte
      *
      * Objects and parameters can be passed as argument to the constructor.
      *
-     * @param array $values The parameters or objects.
+     * @param array $values the parameters or objects
      */
     public function __construct(array $values = array())
     {

--- a/src/Silex/Application/SecurityTrait.php
+++ b/src/Silex/Application/SecurityTrait.php
@@ -58,7 +58,7 @@ trait SecurityTrait
      *
      * @return bool
      *
-     * @throws AuthenticationCredentialsNotFoundException when the token storage has no authentication token.
+     * @throws AuthenticationCredentialsNotFoundException when the token storage has no authentication token
      */
     public function isGranted($attributes, $object = null)
     {

--- a/src/Silex/CallbackResolver.php
+++ b/src/Silex/CallbackResolver.php
@@ -41,7 +41,7 @@ class CallbackResolver
      *
      * @return array A callable array
      *
-     * @throws \InvalidArgumentException In case the method does not exist.
+     * @throws \InvalidArgumentException in case the method does not exist
      */
     public function convertCallback($name)
     {
@@ -61,7 +61,7 @@ class CallbackResolver
      *
      * @return array A callable array
      *
-     * @throws \InvalidArgumentException In case the method does not exist.
+     * @throws \InvalidArgumentException in case the method does not exist
      */
     public function resolveCallback($name)
     {

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -57,7 +57,7 @@ class ControllerCollection
      * @param string               $prefix      The route prefix
      * @param ControllerCollection $controllers A ControllerCollection instance
      */
-    public function mount($prefix, ControllerCollection $controllers)
+    public function mount($prefix, self $controllers)
     {
         $controllers->prefix = $prefix;
 
@@ -193,7 +193,7 @@ class ControllerCollection
 
     private function doFlush($prefix, RouteCollection $routes)
     {
-        if ($prefix !== '') {
+        if ('' !== $prefix) {
             $prefix = '/'.trim(trim($prefix), '/');
         }
 

--- a/src/Silex/RedirectableUrlMatcher.php
+++ b/src/Silex/RedirectableUrlMatcher.php
@@ -29,7 +29,7 @@ class RedirectableUrlMatcher extends BaseRedirectableUrlMatcher
         $url = $this->context->getBaseUrl().$path;
         $query = $this->context->getQueryString() ?: '';
 
-        if ($query !== '') {
+        if ('' !== $query) {
             $url .= '?'.$query;
         }
 

--- a/src/Silex/ServiceControllerResolver.php
+++ b/src/Silex/ServiceControllerResolver.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 /**
  * Enables name_of_service:method_name syntax for declaring controllers.
  *
- * @link http://silex.sensiolabs.org/doc/providers/service_controller.html
+ * @see http://silex.sensiolabs.org/doc/providers/service_controller.html
  */
 class ServiceControllerResolver implements ControllerResolverInterface
 {

--- a/src/Silex/WebTestCase.php
+++ b/src/Silex/WebTestCase.php
@@ -14,6 +14,10 @@ namespace Silex;
 use Symfony\Component\HttpKernel\Client;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+if (!\class_exists('PHPUnit_Framework_TestCase')) {
+    class_alias('PHPUnit\Framework\TestCase', 'PHPUnit_Framework_TestCase');
+}
+
 /**
  * WebTestCase is the base class for functional tests.
  *

--- a/tests/Silex/Tests/Application/FormTraitTest.php
+++ b/tests/Silex/Tests/Application/FormTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\FormServiceProvider;
 
 /**
@@ -20,7 +21,7 @@ use Silex\Provider\FormServiceProvider;
  *
  * @requires PHP 5.4
  */
-class FormTraitTest extends \PHPUnit_Framework_TestCase
+class FormTraitTest extends TestCase
 {
     public function testForm()
     {

--- a/tests/Silex/Tests/Application/MonologTraitTest.php
+++ b/tests/Silex/Tests/Application/MonologTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\MonologServiceProvider;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -22,7 +23,7 @@ use Monolog\Logger;
  *
  * @requires PHP 5.4
  */
-class MonologTraitTest extends \PHPUnit_Framework_TestCase
+class MonologTraitTest extends TestCase
 {
     public function testLog()
     {

--- a/tests/Silex/Tests/Application/SecurityTraitTest.php
+++ b/tests/Silex/Tests/Application/SecurityTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\SecurityServiceProvider;
 use Symfony\Component\Security\Core\User\User;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
@@ -23,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @requires PHP 5.4
  */
-class SecurityTraitTest extends \PHPUnit_Framework_TestCase
+class SecurityTraitTest extends TestCase
 {
     public function testUser()
     {

--- a/tests/Silex/Tests/Application/SwiftmailerTraitTest.php
+++ b/tests/Silex/Tests/Application/SwiftmailerTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\SwiftmailerServiceProvider;
 
 /**
@@ -20,7 +21,7 @@ use Silex\Provider\SwiftmailerServiceProvider;
  *
  * @requires PHP 5.4
  */
-class SwiftmailerTraitTest extends \PHPUnit_Framework_TestCase
+class SwiftmailerTraitTest extends TestCase
 {
     public function testMail()
     {

--- a/tests/Silex/Tests/Application/TranslationTraitTest.php
+++ b/tests/Silex/Tests/Application/TranslationTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\TranslationServiceProvider;
 
 /**
@@ -20,7 +21,7 @@ use Silex\Provider\TranslationServiceProvider;
  *
  * @requires PHP 5.4
  */
-class TranslationTraitTest extends \PHPUnit_Framework_TestCase
+class TranslationTraitTest extends TestCase
 {
     public function testTrans()
     {

--- a/tests/Silex/Tests/Application/TwigTraitTest.php
+++ b/tests/Silex/Tests/Application/TwigTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\TwigServiceProvider;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpFoundation\StreamedResponse;
  *
  * @requires PHP 5.4
  */
-class TwigTraitTest extends \PHPUnit_Framework_TestCase
+class TwigTraitTest extends TestCase
 {
     public function testRender()
     {

--- a/tests/Silex/Tests/Application/UrlGeneratorTraitTest.php
+++ b/tests/Silex/Tests/Application/UrlGeneratorTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Application;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Provider\UrlGeneratorServiceProvider;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
@@ -21,7 +22,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @requires PHP 5.4
  */
-class UrlGeneratorTraitTest extends \PHPUnit_Framework_TestCase
+class UrlGeneratorTraitTest extends TestCase
 {
     public function testUrl()
     {

--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -23,13 +23,14 @@ use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\EventDispatcher\Event;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Application test cases.
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     public function testMatchReturnValue()
     {

--- a/tests/Silex/Tests/CallbackResolverTest.php
+++ b/tests/Silex/Tests/CallbackResolverTest.php
@@ -11,9 +11,10 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\CallbackResolver;
 
-class CallbackResolverTest extends \PHPUnit_Framework_Testcase
+class CallbackResolverTest extends TestCase
 {
     private $app;
     private $resolver;

--- a/tests/Silex/Tests/CallbackServicesTest.php
+++ b/tests/Silex/Tests/CallbackServicesTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Silex\Provider\ServiceControllerServiceProvider;
@@ -20,7 +21,7 @@ use Silex\Provider\ServiceControllerServiceProvider;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class CallbackServicesTest extends \PHPUnit_Framework_TestCase
+class CallbackServicesTest extends TestCase
 {
     public $called = array();
 

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Controller;
 use Silex\ControllerCollection;
 use Silex\Exception\ControllerFrozenException;
@@ -21,7 +22,7 @@ use Silex\Route;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
+class ControllerCollectionTest extends TestCase
 {
     public function testGetRouteCollectionWithNoRoutes()
     {
@@ -55,11 +56,15 @@ class ControllerCollectionTest extends \PHPUnit_Framework_TestCase
         } catch (ControllerFrozenException $e) {
         }
 
+        $this->addToAssertionCount(1);
+
         try {
             $barController->bind('bar2');
             $this->fail();
         } catch (ControllerFrozenException $e) {
         }
+
+        $this->addToAssertionCount(1);
     }
 
     public function testConflictingRouteNames()

--- a/tests/Silex/Tests/ControllerResolverTest.php
+++ b/tests/Silex/Tests/ControllerResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\ControllerResolver;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class ControllerResolverTest extends \PHPUnit_Framework_TestCase
+class ControllerResolverTest extends TestCase
 {
     public function testGetArguments()
     {

--- a/tests/Silex/Tests/ControllerTest.php
+++ b/tests/Silex/Tests/ControllerTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Controller;
 use Silex\Route;
 
@@ -19,7 +20,7 @@ use Silex\Route;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ControllerTest extends \PHPUnit_Framework_TestCase
+class ControllerTest extends TestCase
 {
     public function testBind()
     {

--- a/tests/Silex/Tests/EventListener/LogListenerTest.php
+++ b/tests/Silex/Tests/EventListener/LogListenerTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\EventListener;
 
+use PHPUnit\Framework\TestCase;
 use Silex\EventListener\LogListener;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -27,7 +28,7 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
  *
  * @author Jérôme Tamarelle <jerome@tamarelle.net>
  */
-class LogListenerTest extends \PHPUnit_Framework_TestCase
+class LogListenerTest extends TestCase
 {
     public function testRequestListener()
     {

--- a/tests/Silex/Tests/ExceptionHandlerTest.php
+++ b/tests/Silex/Tests/ExceptionHandlerTest.php
@@ -308,7 +308,6 @@ class ExceptionHandlerTest extends TestCase
         // Since we throw a standard Exception above only
         // the second error handler should fire
         $app->error(function (\LogicException $e) { // Extends \Exception
-
             return 'Caught LogicException';
         });
         $app->error(function (\Exception $e) {
@@ -334,7 +333,6 @@ class ExceptionHandlerTest extends TestCase
         // Since we throw a LogicException above
         // the first error handler should fire
         $app->error(function (\LogicException $e) { // Extends \Exception
-
             return 'Caught LogicException';
         });
         $app->error(function (\Exception $e) {
@@ -365,7 +363,6 @@ class ExceptionHandlerTest extends TestCase
             return 'Caught Exception';
         });
         $app->error(function (\LogicException $e) { // Extends \Exception
-
             return 'Caught LogicException';
         });
 

--- a/tests/Silex/Tests/ExceptionHandlerTest.php
+++ b/tests/Silex/Tests/ExceptionHandlerTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class ExceptionHandlerTest extends \PHPUnit_Framework_TestCase
+class ExceptionHandlerTest extends TestCase
 {
     public function testExceptionHandlerExceptionNoDebug()
     {

--- a/tests/Silex/Tests/FunctionalTest.php
+++ b/tests/Silex/Tests/FunctionalTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Route;
 use Silex\ControllerCollection;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class FunctionalTest extends \PHPUnit_Framework_TestCase
+class FunctionalTest extends TestCase
 {
     public function testBind()
     {

--- a/tests/Silex/Tests/JsonTest.php
+++ b/tests/Silex/Tests/JsonTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 
 /**
@@ -18,7 +19,7 @@ use Silex\Application;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class JsonTest extends \PHPUnit_Framework_TestCase
+class JsonTest extends TestCase
 {
     public function testJsonReturnsJsonResponse()
     {

--- a/tests/Silex/Tests/LazyDispatcherTest.php
+++ b/tests/Silex/Tests/LazyDispatcherTest.php
@@ -11,10 +11,11 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 
-class LazyDispatcherTest extends \PHPUnit_Framework_TestCase
+class LazyDispatcherTest extends TestCase
 {
     /** @test */
     public function beforeMiddlewareShouldNotCreateDispatcherEarly()

--- a/tests/Silex/Tests/LazyUrlMatcherTest.php
+++ b/tests/Silex/Tests/LazyUrlMatcherTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\LazyUrlMatcher;
 
 /**
@@ -18,10 +19,10 @@ use Silex\LazyUrlMatcher;
  *
  * @author Leszek Prabucki <leszek.prabucki@gmail.com>
  */
-class LazyUrlMatcherTest extends \PHPUnit_Framework_TestCase
+class LazyUrlMatcherTest extends TestCase
 {
     /**
-     * @covers Silex\LazyUrlMatcher::getUrlMatcher
+     * @covers \Silex\LazyUrlMatcher::getUrlMatcher
      */
     public function testUserMatcherIsCreatedLazily()
     {

--- a/tests/Silex/Tests/LocaleTest.php
+++ b/tests/Silex/Tests/LocaleTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpKernel\HttpKernelInterface;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class LocaleTest extends \PHPUnit_Framework_TestCase
+class LocaleTest extends TestCase
 {
     public function testLocale()
     {

--- a/tests/Silex/Tests/MiddlewareTest.php
+++ b/tests/Silex/Tests/MiddlewareTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class MiddlewareTest extends \PHPUnit_Framework_TestCase
+class MiddlewareTest extends TestCase
 {
     public function testBeforeAndAfterFilter()
     {

--- a/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
@@ -43,7 +43,7 @@ class DoctrineServiceProviderTest extends TestCase
 
         $db = $app['db'];
         $params = $db->getParams();
-        $this->assertTrue(array_key_exists('memory', $params));
+        $this->assertArrayHasKey('memory', $params);
         $this->assertTrue($params['memory']);
         $this->assertInstanceof('Doctrine\DBAL\Driver\PDOSqlite\Driver', $db->getDriver());
         $this->assertEquals(22, $app['db']->fetchColumn('SELECT 22'));
@@ -67,7 +67,7 @@ class DoctrineServiceProviderTest extends TestCase
 
         $db = $app['db'];
         $params = $db->getParams();
-        $this->assertTrue(array_key_exists('memory', $params));
+        $this->assertArrayHasKey('memory', $params);
         $this->assertTrue($params['memory']);
         $this->assertInstanceof('Doctrine\DBAL\Driver\PDOSqlite\Driver', $db->getDriver());
         $this->assertEquals(22, $app['db']->fetchColumn('SELECT 22'));
@@ -76,7 +76,7 @@ class DoctrineServiceProviderTest extends TestCase
 
         $db2 = $app['dbs']['sqlite2'];
         $params = $db2->getParams();
-        $this->assertTrue(array_key_exists('path', $params));
+        $this->assertArrayHasKey('path', $params);
         $this->assertEquals(sys_get_temp_dir().'/silex', $params['path']);
     }
 }

--- a/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\DoctrineServiceProvider;
 
@@ -19,7 +20,7 @@ use Silex\Provider\DoctrineServiceProvider;
  *
  * Fabien Potencier <fabien@symfony.com>
  */
-class DoctrineServiceProviderTest extends \PHPUnit_Framework_TestCase
+class DoctrineServiceProviderTest extends TestCase
 {
     public function testOptionsInitializer()
     {

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\FormServiceProvider;
 use Silex\Provider\TranslationServiceProvider;
@@ -26,7 +27,7 @@ use Symfony\Component\Translation\Exception\NotFoundResourceException;
 use Symfony\Component\Security\Csrf\CsrfToken;
 use Symfony\Component\Security\Csrf\CsrfTokenManagerInterface;
 
-class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
+class FormServiceProviderTest extends TestCase
 {
     public function testFormFactoryServiceIsFormFactory()
     {
@@ -144,6 +145,8 @@ class FormServiceProviderTest extends \PHPUnit_Framework_TestCase
         } catch (NotFoundResourceException $e) {
             $this->fail('Form factory should not add a translation resource that does not exist');
         }
+
+        $this->addToAssertionCount(1);
     }
 }
 

--- a/tests/Silex/Tests/Provider/HttpCacheServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/HttpCacheServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\HttpCacheServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class HttpCacheServiceProviderTest extends \PHPUnit_Framework_TestCase
+class HttpCacheServiceProviderTest extends TestCase
 {
     public function testRegister()
     {

--- a/tests/Silex/Tests/Provider/HttpFragmentServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/HttpFragmentServiceProviderTest.php
@@ -11,13 +11,14 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\HttpCacheServiceProvider;
 use Silex\Provider\HttpFragmentServiceProvider;
 use Silex\Provider\TwigServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
 
-class HttpFragmentServiceProviderTest extends \PHPUnit_Framework_TestCase
+class HttpFragmentServiceProviderTest extends TestCase
 {
     public function testRenderFunction()
     {

--- a/tests/Silex/Tests/Provider/MonologServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/MonologServiceProviderTest.php
@@ -13,6 +13,7 @@ namespace Silex\Tests\Provider;
 
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\MonologServiceProvider;
 use Symfony\Component\HttpFoundation\RedirectResponse;
@@ -23,7 +24,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class MonologServiceProviderTest extends \PHPUnit_Framework_TestCase
+class MonologServiceProviderTest extends TestCase
 {
     private $currErrorHandler;
 

--- a/tests/Silex/Tests/Provider/SerializerServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SerializerServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\SerializerServiceProvider;
 
@@ -19,7 +20,7 @@ use Silex\Provider\SerializerServiceProvider;
  *
  * @author Fabien Potencier <fabien@symfony.com>
  */
-class SerializerServiceProviderTest extends \PHPUnit_Framework_TestCase
+class SerializerServiceProviderTest extends TestCase
 {
     public function testRegister()
     {

--- a/tests/Silex/Tests/Provider/SwiftmailerServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SwiftmailerServiceProviderTest.php
@@ -11,11 +11,12 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\SwiftmailerServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
 
-class SwiftmailerServiceProviderTest extends \PHPUnit_Framework_TestCase
+class SwiftmailerServiceProviderTest extends TestCase
 {
     public function testSwiftMailerServiceIsSwiftMailer()
     {

--- a/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TranslationServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\TranslationServiceProvider;
 
@@ -19,7 +20,7 @@ use Silex\Provider\TranslationServiceProvider;
  *
  * @author Daniel Tschinder <daniel@tschinder.de>
  */
-class TranslationServiceProviderTest extends \PHPUnit_Framework_TestCase
+class TranslationServiceProviderTest extends TestCase
 {
     /**
      * @return Application

--- a/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/TwigServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\TwigServiceProvider;
 use Silex\Provider\HttpFragmentServiceProvider;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class TwigServiceProviderTest extends \PHPUnit_Framework_TestCase
+class TwigServiceProviderTest extends TestCase
 {
     public function testRegisterAndRender()
     {

--- a/tests/Silex/Tests/Provider/UrlGeneratorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/UrlGeneratorServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\UrlGeneratorServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,7 +22,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class UrlGeneratorServiceProviderTest extends \PHPUnit_Framework_TestCase
+class UrlGeneratorServiceProviderTest extends TestCase
 {
     public function testRegister()
     {

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Provider;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\TranslationServiceProvider;
 use Silex\Provider\ValidatorServiceProvider;
@@ -27,13 +28,15 @@ use Symfony\Component\Validator\Validator\ValidatorInterface;
  *
  * Javier Lopez <f12loalf@gmail.com>
  */
-class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
+class ValidatorServiceProviderTest extends TestCase
 {
     public function testRegister()
     {
         $app = new Application();
 
         $app->register(new ValidatorServiceProvider());
+
+        $this->assertInstanceOf('Symfony\Component\Validator\Validator\ValidatorInterface', $app['validator']);
 
         return $app;
     }
@@ -51,6 +54,8 @@ class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
                 'test.custom.validator' => 'custom.validator',
             ),
         ));
+
+        $this->assertInstanceOf('Symfony\Component\Validator\Validator\ValidatorInterface', $app['validator']);
 
         return $app;
     }
@@ -140,6 +145,8 @@ class ValidatorServiceProviderTest extends \PHPUnit_Framework_TestCase
         } catch (NotFoundResourceException $e) {
             $this->fail('Validator should not add a translation resource that does not exist');
         }
+
+        $this->addToAssertionCount(1);
     }
 
     public function getTestValidatorConstraintProvider()

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -90,7 +90,7 @@ class ValidatorServiceProviderTest extends TestCase
      */
     public function testValidatorServiceIsAValidator($app)
     {
-        $this->assertTrue($app['validator'] instanceof ValidatorInterface || $app['validator'] instanceof LegacyValidatorInterface );
+        $this->assertTrue($app['validator'] instanceof ValidatorInterface || $app['validator'] instanceof LegacyValidatorInterface);
     }
 
     /**

--- a/tests/Silex/Tests/Route/SecurityTraitTest.php
+++ b/tests/Silex/Tests/Route/SecurityTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests\Route;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Silex\Provider\SecurityServiceProvider;
 use Symfony\Component\HttpFoundation\Request;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @requires PHP 5.4
  */
-class SecurityTraitTest extends \PHPUnit_Framework_TestCase
+class SecurityTraitTest extends TestCase
 {
     public function testSecureWithNoAuthenticatedUser()
     {

--- a/tests/Silex/Tests/RouterTest.php
+++ b/tests/Silex/Tests/RouterTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
@@ -21,7 +22,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class RouterTest extends \PHPUnit_Framework_TestCase
+class RouterTest extends TestCase
 {
     public function testMapRouting()
     {

--- a/tests/Silex/Tests/ServiceControllerResolverTest.php
+++ b/tests/Silex/Tests/ServiceControllerResolverTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\ServiceControllerResolver;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
@@ -19,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
  * Unit tests for ServiceControllerResolver, see ServiceControllerResolverRouterTest for some
  * integration tests.
  */
-class ServiceControllerResolverTest extends \PHPUnit_Framework_Testcase
+class ServiceControllerResolverTest extends TestCase
 {
     private $app;
     private $mockCallbackResolver;

--- a/tests/Silex/Tests/StreamTest.php
+++ b/tests/Silex/Tests/StreamTest.php
@@ -28,7 +28,7 @@ class StreamTest extends TestCase
 
         $response = $app->stream();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response);
-        $this->assertSame(false, $response->getContent());
+        $this->assertFalse($response->getContent());
     }
 
     public function testStreamActuallyStreams()

--- a/tests/Silex/Tests/StreamTest.php
+++ b/tests/Silex/Tests/StreamTest.php
@@ -11,6 +11,7 @@
 
 namespace Silex\Tests;
 
+use PHPUnit\Framework\TestCase;
 use Silex\Application;
 use Symfony\Component\HttpFoundation\Request;
 
@@ -19,7 +20,7 @@ use Symfony\Component\HttpFoundation\Request;
  *
  * @author Igor Wiedler <igor@wiedler.ch>
  */
-class StreamTest extends \PHPUnit_Framework_TestCase
+class StreamTest extends TestCase
 {
     public function testStreamReturnsStreamingResponse()
     {


### PR DESCRIPTION
`symfony/validator": "~2.3|3.0.*` is not compat with PHP7.2, 
this has been resolved on a higher minor so lets drop that constraint.
I'll check the failing session test later when Travis has a meaningful report here.

closes https://github.com/silexphp/Silex/issues/1566

when this is all OK I'll prep. one for `master` line