### PR TITLE
Add a description of global.flashes

### DIFF
--- a/doc/providers/twig.rst
+++ b/doc/providers/twig.rst
@@ -164,6 +164,9 @@ It gives access to the following methods:
     {# The debug flag #}
     {{ global.debug }}
 
+    {# The flash messages (Symfony 3.3 or later) #}
+    {{ global.flashes }}
+
 Rendering a Controller
 ~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
global.flashes is available from symfony 3.3, I added it.
https://symfony.com/blog/new-in-symfony-3-3-improved-flash-messages