### PR TITLE
Refactoring tests

### DIFF
--- a/tests/Silex/Tests/ApplicationTest.php
+++ b/tests/Silex/Tests/ApplicationTest.php
@@ -88,7 +88,7 @@ class ApplicationTest extends TestCase
 
         $routes = $app['routes'];
         $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $routes);
-        $this->assertEquals(0, count($routes->all()));
+        $this->assertCount(0, $routes->all());
     }
 
     public function testGetRoutesWithRoutes()
@@ -105,9 +105,9 @@ class ApplicationTest extends TestCase
 
         $routes = $app['routes'];
         $this->assertInstanceOf('Symfony\Component\Routing\RouteCollection', $routes);
-        $this->assertEquals(0, count($routes->all()));
+        $this->assertCount(0, $routes->all());
         $app->flush();
-        $this->assertEquals(2, count($routes->all()));
+        $this->assertCount(2, $routes->all());
     }
 
     public function testOnCoreController()

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -30,7 +30,7 @@ class ControllerCollectionTest extends TestCase
     {
         $controllers = new ControllerCollection(new Route());
         $routes = $controllers->flush();
-        $this->assertEquals(0, count($routes->all()));
+        $this->assertCount(0, $routes->all());
     }
 
     public function testGetRouteCollectionWithRoutes()
@@ -40,7 +40,7 @@ class ControllerCollectionTest extends TestCase
         $controllers->match('/bar', function () {});
 
         $routes = $controllers->flush();
-        $this->assertEquals(2, count($routes->all()));
+        $this->assertCount(2, $routes->all());
     }
 
     public function testControllerFreezing()

--- a/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/DoctrineServiceProviderTest.php
@@ -88,7 +88,7 @@ class DoctrineServiceProviderTest extends TestCase
         }
 
         $app = new Application();
-        $this->assertTrue(isset($app['logger']));
+        $this->assertArrayHasKey('logger', $app);
         $this->assertNull($app['logger']);
         $app->register(new DoctrineServiceProvider(), array(
             'dbs.options' => array(

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -110,8 +110,8 @@ class ValidatorServiceProviderTest extends TestCase
         $form->submit(array('email' => $email));
 
         $this->assertEquals($isValid, $form->isValid());
-        $this->assertEquals($nbGlobalError, count($form->getErrors()));
-        $this->assertEquals($nbEmailError, count($form->offsetGet('email')->getErrors()));
+        $this->assertCount($nbGlobalError, $form->getErrors());
+        $this->assertCount($nbEmailError, $form->offsetGet('email')->getErrors());
     }
 
     public function testValidatorWillNotAddNonexistentTranslationFiles()

--- a/tests/Silex/Tests/StreamTest.php
+++ b/tests/Silex/Tests/StreamTest.php
@@ -28,7 +28,7 @@ class StreamTest extends TestCase
 
         $response = $app->stream();
         $this->assertInstanceOf('Symfony\Component\HttpFoundation\StreamedResponse', $response);
-        $this->assertSame(false, $response->getContent());
+        $this->assertFalse($response->getContent());
     }
 
     public function testStreamActuallyStreams()


### PR DESCRIPTION
I've refactored some tests, using:
- `assertCount` instead of `count` function;
- `assertFalse` instead of strict comparison with `false` keyword;
- `assertArrayHasKey` instead of `isset` function.