### PR TITLE
[SECURITY] fix before handlers not executed under mounts 

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-2.2.2 (2017-XX-XX)
+2.2.2 (2018-01-12)
 ------------------
 
-* n/a
+* [SECURITY] fixed before handlers not executed under mounts
 
 2.2.1 (2017-12-14)
 ------------------

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -41,7 +41,7 @@ use Silex\Provider\HttpKernelServiceProvider;
  */
 class Application extends Container implements HttpKernelInterface, TerminableInterface
 {
-    const VERSION = '2.2.2-DEV';
+    const VERSION = '2.2.2';
 
     const EARLY_EVENT = 512;
     const LATE_EVENT = -512;

--- a/src/Silex/ControllerCollection.php
+++ b/src/Silex/ControllerCollection.php
@@ -68,6 +68,7 @@ class ControllerCollection
     {
         if (is_callable($controllers)) {
             $collection = $this->controllersFactory ? call_user_func($this->controllersFactory) : new static(new Route(), new RouteCollection());
+            $collection->defaultRoute = clone $this->defaultRoute;
             call_user_func($controllers, $collection);
             $controllers = $collection;
         } elseif (!$controllers instanceof self) {

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -191,6 +191,23 @@ class ControllerCollectionTest extends TestCase
         $this->assertEquals('\w+', $controller->getRoute()->getRequirement('extra'));
     }
 
+    public function testAssertWithMountCallable()
+    {
+        $controllers = new ControllerCollection(new Route());
+        $controller = null;
+        $controllers->mount('/{name}', function ($mounted) use (&$controller) {
+            $mounted->assert('name', '\w+');
+            $mounted->mount('/{id}', function ($mounted2) use (&$controller) {
+                $mounted2->assert('id', '\d+');
+                $controller = $mounted2->match('/{extra}', function () {})->assert('extra', '\w+');
+            });
+        });
+
+        $this->assertEquals('\d+', $controller->getRoute()->getRequirement('id'));
+        $this->assertEquals('\w+', $controller->getRoute()->getRequirement('name'));
+        $this->assertEquals('\w+', $controller->getRoute()->getRequirement('extra'));
+    }
+
     public function testValue()
     {
         $controllers = new ControllerCollection(new Route());


### PR DESCRIPTION
Thanks to @MaPePeR for reporting this issue and providing a fix. Fix is part has been released in Silex v2.2.2.

Description of the issue:

`before` handlers are not always executed for all (sub-)routes of a `ControllerCollection`. This might cause security issues in Silex applications that rely on them being executed for validation and authorization purposes.

How to reproduce:

* Have a `->before`-Handler on the Silex\Application. This one will always be executed.
* Do a mount on `/AAA/`. Inside the mount-Handler: 
   * Set a `->before` handler on the `ControllerCollection`. This one is only executed, if a route from the same Collection will be accessed, but not any sub-mounts.
   * Define another mount on `/BBB`. Inside this `/AAA/BBB/`-ControllerCollection:
     * Set a `->before` handler.
     * Define a normal route (accessing this route will only execute the `/` and the `/AAA/BBB`-Middleware, but not the `/AAA`-Middleware).

Code:
```php
$app = new Silex\Application();

$app->before(function() {
    echo 'before/<br/>';
});
$app->mount('/AAA', function($aroutes) {
    $aroutes->before(function () {
        echo 'before/AAA<br/>';
    });
    $aroutes->get('/', function () {
        return "/AAA/<br/>";
    });
    $aroutes->mount('/BBB', function ($broutes) {
        $broutes->before(function () {
            echo 'before/AAA/BBB<br/>';
        });
        $broutes->get('/', function () {
            return "/AAA/BBB/<br/>";
        });
    });
});

$app->run();
```

When accessing `/AAA/BBB/` outputs:
```
before/
before/AAA/BBB
/AAA/BBB/
```

When accessing `/AAA/` outputs:
```
before/
before/AAA
/AAA/
```

Asserts are not being checked as well:

```
$app->mount('/{a}', function($aroutes) {
    $aroutes->assert('a', 'AAA');
    $aroutes->get('/', function () {
        return "/AAA/<br/>";
    });
    $aroutes->mount('/{b}', function ($broutes) {
        $broutes->assert('b', 'BBB');
        $broutes->get('/', function () {
            return "/AAA/BBB/<br/>";
        });
    });
});

$app->run();
```

`/someExploit/BBB` can be accessed.

Note that the issue only exists if `assert` and `before` are called before `mount` is called. If one moves them after the `mount`-call, they are working as expected.
