### PR TITLE
Removed tests for obsolete Symfony versions, remove HHVM support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,29 +12,31 @@ cache:
       - $HOME/.composer/cache/files
       - $HOME/.symfony-phpunit
 
-before_script:
+before_install:
+    - phpenv config-rm xdebug.ini
+
     # Twig 1.x
     - if [[ $TWIG_VERSION != 2.0 ]]; then sed -i 's/~1.8|~2.0/~1.8/g' composer.json; fi
 
     # Symfony 2.8
-    - if [[ $SYMFONY_DEPS_VERSION = 2.8 ]]; then sed -i 's/~2\.8|^3\.0/2.8.*@dev/g' composer.json; fi
+    - if [[ $SYMFONY_DEPS_VERSION = 2.8 ]]; then sed -i 's/~2\.8|^3\.0/2.8.*/g' composer.json; fi
     # Symfony 3.3
     - |
       if [[ $SYMFONY_DEPS_VERSION = 3.3 ]]; then
-          sed -i 's/~2\.8|^3\.0/3.3.*@dev/g' composer.json;
-          composer require --dev --no-update symfony/web-link:3.3.*
+          sed -i 's/~2\.8|^3\.0/3.3.*/g' composer.json;
+          composer require --no-update symfony/web-link:3.3.*
       fi
     # Symfony 3.4
     - |
       if [[ $SYMFONY_DEPS_VERSION = 3.4 ]]; then
-          sed -i 's/~2\.8|^3\.0/3.4.*@dev/g' composer.json;
-          composer require --dev --no-update symfony/web-link:3.3.*
+          sed -i 's/~2\.8|^3\.0/3.4.*/g' composer.json;
+          composer require --no-update symfony/web-link:3.4.*
       fi
 
     - composer update --no-suggest
 
 install:
-    - ./vendor/bin/simple-phpunit install 
+    - ./vendor/bin/simple-phpunit install
 
 script: ./vendor/bin/simple-phpunit
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ sudo: false
 env:
     global:
         - SYMFONY_DEPRECATIONS_HELPER=weak
+        - SYMFONY_PHPUNIT_DIR=$HOME/.symfony-phpunit
 
 cache:
     directories:
       - $HOME/.composer/cache/files
-      - .phpunit
+      - $HOME/.symfony-phpunit
 
 before_install:
     - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
@@ -20,20 +21,23 @@ before_script:
 
     # Symfony 2.8
     - if [[ $SYMFONY_DEPS_VERSION = 2.8 ]]; then sed -i 's/~2\.8|^3\.0/2.8.*@dev/g' composer.json; fi
-    # Symfony 3.0
-    - if [[ $SYMFONY_DEPS_VERSION = 3.0 ]]; then sed -i 's/~2\.8|^3\.0/3.0.*@dev/g' composer.json; fi
-    # Symfony 3.1
-    - if [[ $SYMFONY_DEPS_VERSION = 3.1 ]]; then sed -i 's/~2\.8|^3\.0/3.1.*@dev/g' composer.json; fi
-    # Symfony 3.2
-    - if [[ $SYMFONY_DEPS_VERSION = 3.2 ]]; then sed -i 's/~2\.8|^3\.0/3.2.*@dev/g' composer.json; fi
     # Symfony 3.3
     - |
       if [[ $SYMFONY_DEPS_VERSION = 3.3 ]]; then
           sed -i 's/~2\.8|^3\.0/3.3.*@dev/g' composer.json;
           composer require --dev --no-update symfony/web-link:3.3.*
       fi
+    # Symfony 3.4
+    - |
+      if [[ $SYMFONY_DEPS_VERSION = 3.4 ]]; then
+          sed -i 's/~2\.8|^3\.0/3.4.*@dev/g' composer.json;
+          composer require --dev --no-update symfony/web-link:3.3.*
+      fi
 
     - composer update --no-suggest
+
+install:
+    - ./vendor/bin/simple-phpunit install 
 
 script: ./vendor/bin/simple-phpunit
 
@@ -45,13 +49,9 @@ matrix:
         - php: 5.6
           env: SYMFONY_DEPS_VERSION=2.8
         - php: 5.6
-          env: SYMFONY_DEPS_VERSION=3.0
-        - php: 5.6
-          env: SYMFONY_DEPS_VERSION=3.1
-        - php: 5.6
-          env: SYMFONY_DEPS_VERSION=3.2
-        - php: 5.6
           env: SYMFONY_DEPS_VERSION=3.3
+        - php: 5.6
+          env: SYMFONY_DEPS_VERSION=3.4
         - php: 5.6
         - php: 7.0
         - php: 7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ cache:
       - $HOME/.composer/cache/files
       - $HOME/.symfony-phpunit
 
-before_install:
-    - if [[ $TRAVIS_PHP_VERSION != hhvm ]]; then phpenv config-rm xdebug.ini; fi
-
 before_script:
     # Twig 1.x
     - if [[ $TWIG_VERSION != 2.0 ]]; then sed -i 's/~1.8|~2.0/~1.8/g' composer.json; fi
@@ -56,5 +53,3 @@ matrix:
         - php: 7.0
         - php: 7.1
         - php: 7.2
-        - php: hhvm
-          dist: trusty

--- a/composer.json
+++ b/composer.json
@@ -67,6 +67,5 @@
         "branch-alias": {
             "dev-master": "2.2.x-dev"
         }
-    },
-    "minimum-stability": "dev"
+    }
 }

--- a/tests/Silex/Tests/ControllerCollectionTest.php
+++ b/tests/Silex/Tests/ControllerCollectionTest.php
@@ -58,11 +58,15 @@ class ControllerCollectionTest extends TestCase
         } catch (ControllerFrozenException $e) {
         }
 
+        $this->addToAssertionCount(1);
+
         try {
             $barController->bind('bar2');
             $this->fail();
         } catch (ControllerFrozenException $e) {
         }
+
+        $this->addToAssertionCount(1);
     }
 
     public function testConflictingRouteNames()

--- a/tests/Silex/Tests/Provider/FormServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/FormServiceProviderTest.php
@@ -275,6 +275,7 @@ class FormServiceProviderTest extends TestCase
 
         try {
             $translator->trans('test');
+            $this->addToAssertionCount(1);
         } catch (NotFoundResourceException $e) {
             $this->fail('Form factory should not add a translation resource that does not exist');
         }

--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -36,6 +36,8 @@ class ValidatorServiceProviderTest extends TestCase
         $app->register(new ValidatorServiceProvider());
         $app->register(new FormServiceProvider());
 
+        $this->assertInstanceOf('Symfony\Component\Validator\Validator\ValidatorInterface', $app['validator']);
+
         return $app;
     }
 
@@ -52,6 +54,8 @@ class ValidatorServiceProviderTest extends TestCase
                 'test.custom.validator' => 'custom.validator',
             ),
         ));
+
+        $this->assertInstanceOf('Symfony\Component\Validator\Validator\ValidatorInterface', $app['validator']);
 
         return $app;
     }
@@ -130,6 +134,7 @@ class ValidatorServiceProviderTest extends TestCase
 
         try {
             $translator->trans('test');
+            $this->addToAssertionCount(1);
         } catch (NotFoundResourceException $e) {
             $this->fail('Validator should not add a translation resource that does not exist');
         }


### PR DESCRIPTION
This PR does the following:

 * dropped support for non-supported Symfony versions
 * dropped support for HHVM
 * removed the "dev" minimum stability in `composer.json`
 * changed tests to run on stable versions of Symfony (instead of dev)
 * optimized PHPUnit cache
 * added tests for Symfony 3.4
 * fixed risky tests
