### PR TITLE
Link to current documention of Symfony components

### DIFF
--- a/doc/providers/form.rst
+++ b/doc/providers/form.rst
@@ -213,4 +213,4 @@ Traits
     $app->namedForm($name, $data, $options, $type);
 
 For more information, consult the `Symfony Forms documentation
-<http://symfony.com/doc/2.8/book/forms.html>`_.
+<http://symfony.com/doc/current/forms.html>`_.

--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -90,7 +90,7 @@ Usage
 
 The Symfony Security component is powerful. To learn more about it, read the
 `Symfony Security documentation
-<http://symfony.com/doc/2.8/book/security.html>`_.
+<http://symfony.com/doc/current/security.html>`_.
 
 .. tip::
 


### PR DESCRIPTION
Prefer the latest Symfony documentation instead of a specific version which can easily become outdated.