### PR TITLE
Allow defining users provider as a service ID

### DIFF
--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -495,8 +495,8 @@ Defining a custom User Provider
 Using an array of users is simple and useful when securing an admin section of
 a personal website, but you can override this default mechanism with you own.
 
-The ``users`` setting can be defined as a service that returns an instance of
-`UserProviderInterface
+The ``users`` setting can be defined as a service or an service id that returns
+an instance of `UserProviderInterface
 <http://api.symfony.com/master/Symfony/Component/Security/Core/User/UserProviderInterface.html>`_::
 
     'users' => function () use ($app) {

--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -495,7 +495,7 @@ Defining a custom User Provider
 Using an array of users is simple and useful when securing an admin section of
 a personal website, but you can override this default mechanism with you own.
 
-The ``users`` setting can be defined as a service or an service id that returns
+The ``users`` setting can be defined as a service or a service id that returns
 an instance of `UserProviderInterface
 <http://api.symfony.com/master/Symfony/Component/Security/Core/User/UserProviderInterface.html>`_::
 

--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -229,6 +229,10 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                 $protected = false === $security ? false : count($firewall);
                 $listeners = ['security.channel_listener'];
 
+                if (is_string($users)) {
+                    $users = $app->raw($users);
+                }
+
                 if ($protected) {
                     if (!isset($app['security.context_listener.'.$name])) {
                         if (!isset($app['security.user_provider.'.$name])) {

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
@@ -280,19 +280,19 @@ class SecurityServiceProviderTest extends WebTestCase
 
     public function testUserAsServiceString()
     {
-        $users = array(
-            'fabien' => array('ROLE_ADMIN', '5FZ2Z8QIkA7UTZ4BYkoC+GsReLf569mSKDsfods6LYQ8t+a8EW9oaircfMpmaLbPBh4FOBiiFyLfuZmTSUwzZg=='),
-        );
+        $users = [
+            'fabien' => ['ROLE_ADMIN', '5FZ2Z8QIkA7UTZ4BYkoC+GsReLf569mSKDsfods6LYQ8t+a8EW9oaircfMpmaLbPBh4FOBiiFyLfuZmTSUwzZg=='],
+        ];
 
         $app = new Application();
-        $app->register(new SecurityServiceProvider(), array(
-            'security.firewalls' => array(
-                'default' => array(
+        $app->register(new SecurityServiceProvider(), [
+            'security.firewalls' => [
+                'default' => [
                     'http' => true,
                     'users' => 'my_user_provider',
-                ),
-            ),
-        ));
+                ],
+            ],
+        ]);
         $app['my_user_provider'] = $app['security.user_provider.inmemory._proto']($users);
         $app->get('/', function () { return 'foo'; });
 

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
@@ -281,7 +281,7 @@ class SecurityServiceProviderTest extends WebTestCase
     public function testUserAsServiceString()
     {
         $users = [
-            'fabien' => ['ROLE_ADMIN', '5FZ2Z8QIkA7UTZ4BYkoC+GsReLf569mSKDsfods6LYQ8t+a8EW9oaircfMpmaLbPBh4FOBiiFyLfuZmTSUwzZg=='],
+            'fabien' => ['ROLE_ADMIN', '$2y$15$lzUNsTegNXvZW3qtfucV0erYBcEqWVeyOmjolB7R1uodsAVJ95vvu'],
         ];
 
         $app = new Application();


### PR DESCRIPTION
Replaces #1217.
Closes #1216.