### PR TITLE
Check for HttpKernelRuntime before using it in Twig runtimes

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -192,9 +192,11 @@ class TwigServiceProvider implements ServiceProviderInterface
         };
 
         $app['twig.runtimes'] = function ($app) {
-            $runtimes = [
-                HttpKernelRuntime::class => 'twig.runtime.httpkernel',
-            ];
+            $runtimes = [];
+
+            if (class_exists(HttpKernelRuntime::class)) {
+                $runtimes[HttpKernelRuntime::class] = 'twig.runtime.httpkernel';
+            }
 
             if (Kernel::VERSION_ID < 30400) {
                 $runtimes[TwigRenderer::class] = 'twig.form.renderer';


### PR DESCRIPTION
Fixes #1448.

This fixes an incompatibility with Symfony Twig bridge prior to 3.2.

The HttpKernelRuntime was introduced in https://github.com/silexphp/Silex/commit/72d7746ec216da230221c19aa6e3092b55596070.
It included checks whether the class exists, but not in the Twig runtimes list.