### PR TITLE
Allow setting custom status code on exception response

### DIFF
--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -516,10 +516,23 @@ setting a more specific type hint for the Closure argument::
 
     As Silex ensures that the Response status code is set to the most
     appropriate one depending on the exception, setting the status on the
-    response won't work. If you want to overwrite the status code, set the
-    ``X-Status-Code`` header::
+    response alone won't work. If you want to overwrite the status code
+    of the exception response, which you should not without a good reason, call
+    ``GetResponseForExceptionEvent::allowCustomResponseCode()`` first and then
+    then set the status code on the response as normal. The kernel will
+    now use your status code when sending the response to the client.
+    The ``GetResponseForExceptionEvent`` is passed to the error callback as a 4th parameter::
 
-        return new Response('Error', 404 /* ignored */, array('X-Status-Code' => 200));
+        use Symfony\Component\HttpFoundation\Response;
+        use Symfony\Component\HttpFoundation\Request;
+        use Symfony\Component\HttpKernel\Event\GetResponseForExceptionEvent;
+
+        $app->error(function (\Exception $e, Request $request, $code, GetResponseForExceptionEvent $event) {
+            $event->allowCustomResponseCode();
+            $response = new Response('No Content', 204);
+            
+            return $response;
+        });
 
 If you want to use a separate error handler for logging, make sure you register
 it with a higher priority than response error handlers, because once a response

--- a/src/Silex/ExceptionListenerWrapper.php
+++ b/src/Silex/ExceptionListenerWrapper.php
@@ -50,7 +50,7 @@ class ExceptionListenerWrapper
 
         $code = $exception instanceof HttpExceptionInterface ? $exception->getStatusCode() : 500;
 
-        $response = call_user_func($this->callback, $exception, $event->getRequest(), $code);
+        $response = call_user_func($this->callback, $exception, $event->getRequest(), $code, $event);
 
         $this->ensureResponse($response, $event);
     }


### PR DESCRIPTION
Closes #1450.

Prior and related PRs and issues:

- https://github.com/symfony/symfony/pull/19822
- https://github.com/symfony/symfony-docs/commit/5f0becf3233238a9d96cba39f3146a0e7ae03763
- https://github.com/symfony/symfony-docs/pull/9336