### PR TITLE
Sync provider parameters in docs

### DIFF
--- a/doc/providers/asset.rst
+++ b/doc/providers/asset.rst
@@ -10,13 +10,18 @@ Parameters
 
 * **assets.version**: Default version for assets.
 
-* **assets.format_version** (optional): Default format for assets.
+* **assets.version_format** (optional): Default format for assets.
 
 * **assets.base_path**: Default path to prepend to all assets without a package.
+
+* **assets.base_urls**: (Alternative to ``assets.base_path``) List of base URLs to choose from to prepend to assets without a package.
 
 * **assets.named_packages** (optional): Named packages. Keys are the package
   names and values the configuration (supported keys are ``version``,
   ``version_format``, ``base_urls``, and ``base_path``).
+
+* **assets.json_manifest_path** (optional): Absolute path to a `JSON version manifest
+  <https://symfony.com/blog/new-in-symfony-3-3-manifest-based-asset-versioning>`_.
 
 Services
 --------

--- a/doc/providers/csrf.rst
+++ b/doc/providers/csrf.rst
@@ -7,7 +7,8 @@ application with the Symfony Form component.
 Parameters
 ----------
 
-* none
+* **csrf.session_namespace** (optional): The namespace under which the token
+  is stored in the session. Defaults to ``_csrf``.
 
 Services
 --------

--- a/doc/providers/monolog.rst
+++ b/doc/providers/monolog.rst
@@ -12,8 +12,8 @@ Parameters
 ----------
 
 * **monolog.logfile**: File where logs are written to.
-* **monolog.bubble**: (optional) Whether the messages that are handled can bubble up the stack or not.
-* **monolog.permission**: (optional) File permissions default (null), nothing change.
+* **monolog.bubble** (optional): Whether the messages that are handled can bubble up the stack or not.
+* **monolog.permission** (optional): File permissions default (null), nothing change.
 
 * **monolog.level** (optional): Level of logging, defaults
   to ``DEBUG``. Must be one of ``Logger::DEBUG``, ``Logger::INFO``,

--- a/doc/providers/routing.rst
+++ b/doc/providers/routing.rst
@@ -7,7 +7,7 @@ named routes.
 Parameters
 ----------
 
-None.
+* **route_class**: (optional): The default route class used by the route factory. (Defaults to ``Silex\Route``)
 
 Services
 --------

--- a/doc/providers/security.rst
+++ b/doc/providers/security.rst
@@ -12,6 +12,11 @@ Parameters
 
 * **security.encoder.bcrypt.cost** (optional): Defines BCrypt password encoder cost. Defaults to 13.
 
+* **security.role_hierarchy**:(optional): Defines a map of roles including other roles.
+
+* **security.access_rules** (optional): Defines rules based on paths and roles.
+  See `Defining Access Rule <#defining-access-rules>`_.
+
 Services
 --------
 

--- a/doc/providers/session.rst
+++ b/doc/providers/session.rst
@@ -35,6 +35,12 @@ Parameters
 * **session.test**: Whether to simulate sessions or not (useful when writing
   functional tests).
 
+* **session.attribute_bag** (optional): The attribute bag service to use in the session.
+  Instance of ``AttributeBagInterface``.
+
+* **session.flash_bag** (optional): The flash bag service to use in the session.
+  Instance of ``FlashBagInterface``.
+
 Services
 --------
 

--- a/doc/providers/translation.rst
+++ b/doc/providers/translation.rst
@@ -16,6 +16,9 @@ Parameters
 * **locale_fallbacks** (optional): Fallback locales for the translator. It will
   be used when the current locale has no messages set. Defaults to ``en``.
 
+* **translator.cache_dir** (optional): Defines the cache directory
+  if you want translations to be cached.
+
 Services
 --------
 

--- a/doc/providers/validator.rst
+++ b/doc/providers/validator.rst
@@ -8,8 +8,15 @@ standalone.
 Parameters
 ----------
 
-* **validator.validator_service_ids**: An array of service names representing
+* **validator.validator_service_ids** (optional): An array of service names representing
   validators.
+
+* **validator.translation_domain** (optional): The translation domain to use for translating validator messages.
+  (Defaults to ``validators``.)
+
+* **validator.object_initializers** (optional): An array of object initializers.
+  See `the relevant Validation documentation
+  <http://symfony.com/doc/current/reference/dic_tags.html#validator-initializer>`_.
 
 Services
 --------

--- a/src/Silex/Provider/SessionServiceProvider.php
+++ b/src/Silex/Provider/SessionServiceProvider.php
@@ -69,7 +69,6 @@ class SessionServiceProvider implements ServiceProviderInterface, EventListenerP
         };
 
         $app['session.storage.options'] = [];
-        $app['session.default_locale'] = 'en';
         $app['session.storage.save_path'] = null;
         $app['session.attribute_bag'] = null;
         $app['session.flash_bag'] = null;


### PR DESCRIPTION
This documents all parameter options to providers which were missing from the documentation.