### PR TITLE
Do not re-set Twig options after registering

### DIFF
--- a/src/Silex/Provider/TwigServiceProvider.php
+++ b/src/Silex/Provider/TwigServiceProvider.php
@@ -54,15 +54,16 @@ class TwigServiceProvider implements ServiceProviderInterface
         $app['twig.number_format.thousands_separator'] = ',';
 
         $app['twig'] = function ($app) {
-            $app['twig.options'] = array_replace(
+            $options = array_replace(
                 [
                     'charset' => $app['charset'],
                     'debug' => $app['debug'],
                     'strict_variables' => $app['debug'],
-                ], $app['twig.options']
+                ],
+                $app['twig.options']
             );
 
-            $twig = $app['twig.environment_factory']($app);
+            $twig = $app['twig.environment_factory']($options);
             // registered for BC, but should not be used anymore
             // deprecated and should probably be removed in Silex 3.0
             $twig->addGlobal('app', $app);
@@ -183,8 +184,8 @@ class TwigServiceProvider implements ServiceProviderInterface
             ]);
         };
 
-        $app['twig.environment_factory'] = $app->protect(function ($app) {
-            return new \Twig_Environment($app['twig.loader'], $app['twig.options']);
+        $app['twig.environment_factory'] = $app->protect(function (array $options) use ($app) {
+            return new \Twig_Environment($app['twig.loader'], $options);
         });
 
         $app['twig.runtime.httpkernel'] = function ($app) {


### PR DESCRIPTION
This allows users to have `twig.options` as a closure for lazy evaluation.

Fixes https://github.com/silexphp/Silex/issues/1577.

This is the simplest approach introducing a BC break as `twig.environment_factory` service may have been used to create another Twig instance.