### PR TITLE
Support PSR-3 log levels in MonologServiceProvider

### DIFF
--- a/doc/changelog.rst
+++ b/doc/changelog.rst
@@ -14,6 +14,7 @@ Changelog
  * dropped support for PHP < 7.1
  * dropped support for Symfony 2.x and 3.x
  * added support for Symfony 4
+ * added support PSR-3 log levels in MonologServiceProvider
 
 2.2.3 (2018-02-25)
 ------------------

--- a/doc/providers/monolog.rst
+++ b/doc/providers/monolog.rst
@@ -25,6 +25,8 @@ Parameters
   level in string form, for example: ``"DEBUG"``, ``"INFO"``, ``"WARNING"``,
   ``"ERROR"``.
 
+  PSR-3 log levels from ``\Psr\Log\LogLevel::`` constants are also supported.
+
 * **monolog.name** (optional): Name of the monolog channel,
   defaults to ``myapp``.
 

--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -125,6 +125,12 @@ class MonologServiceProvider implements ServiceProviderInterface, BootableProvid
             return $name;
         }
 
+        $psrLevel = Logger::toMonologLevel($name);
+
+        if (is_int($psrLevel)) {
+            return $psrLevel;
+        }
+
         $levels = Logger::getLevels();
         $upper = strtoupper($name);
 

--- a/src/Silex/Provider/MonologServiceProvider.php
+++ b/src/Silex/Provider/MonologServiceProvider.php
@@ -39,7 +39,9 @@ class MonologServiceProvider implements ServiceProviderInterface, BootableProvid
         if ($bridge = class_exists('Symfony\Bridge\Monolog\Logger')) {
             if (isset($app['request_stack'])) {
                 $app['monolog.not_found_activation_strategy'] = function () use ($app) {
-                    return new NotFoundActivationStrategy($app['request_stack'], ['^/'], $app['monolog.level']);
+                    $level = MonologServiceProvider::translateLevel($app['monolog.level']);
+
+                    return new NotFoundActivationStrategy($app['request_stack'], ['^/'], $level);
                 };
             }
         }


### PR DESCRIPTION
Monolog already support them everywhere, but when using the `MonologServiceProvider` you cannot use them reliably.