### PR TITLE
Treat user provider as a service in security service provider

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -247,7 +247,9 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                 $listeners = ['security.channel_listener'];
 
                 if (is_string($users)) {
-                    $users = $app->raw($users);
+                    $users = function () use ($app, $users) {
+                        return $app[$users];
+                    };
                 }
 
                 if ($protected) {

--- a/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/SecurityServiceProviderTest.php
@@ -307,6 +307,7 @@ class SecurityServiceProviderTest extends WebTestCase
         $request = Request::create('/');
         $app->handle($request);
         $this->assertNull($app['user']);
+        $this->assertSame($app['my_user_provider'], $app['security.user_provider.default']);
 
         $request->headers->set('PHP_AUTH_USER', 'fabien');
         $request->headers->set('PHP_AUTH_PW', 'foo');


### PR DESCRIPTION
Follow-up to https://github.com/silexphp/Silex/pull/1611 and https://github.com/silexphp/Silex/pull/1217.
Fixes https://github.com/silexphp/Silex/issues/1630.