### PR TITLE
Simplify extend call

### DIFF
--- a/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
+++ b/tests/Silex/Tests/Provider/ValidatorServiceProviderTest.php
@@ -155,7 +155,7 @@ class ValidatorServiceProviderTest extends TestCase
 
         $app->register(new ValidatorServiceProvider());
         $app->register(new TranslationServiceProvider());
-        $app['translator'] = $app->extend('translator', function ($translator, $app) {
+        $app->extend('translator', function ($translator, $app) {
             $translator->addResource('array', ['This value should not be blank.' => 'Pas vide'], 'fr', 'validators');
 
             return $translator;


### PR DESCRIPTION
Since Pimple 2.x there is no need to re-assign the result from `extend()` call to the same key. Pimple already does that.