### PR TITLE
Use ArgumentResolver for calling the middleware before functions.

### DIFF
--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -252,16 +252,16 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
             }
 
             $request = $event->getRequest();
-            $c = $app['callback_resolver']->resolveCallback($callback);
+            $resolvedCallback = $app['callback_resolver']->resolveCallback($callback);
             try {
-                $arguments = $app['argument_resolver']->getArguments($request, $c);
+                $arguments = $app['argument_resolver']->getArguments($request, $resolvedCallback);
             } catch (\RuntimeException $e) {
                 $arguments = array(
                     $request, $app
                 );
             }
             
-            $ret = \call_user_func_array($c, $arguments);
+            $ret = \call_user_func_array($resolvedCallback, $arguments);
 
             if ($ret instanceof Response) {
                 $event->setResponse($ret);

--- a/src/Silex/Application.php
+++ b/src/Silex/Application.php
@@ -251,7 +251,17 @@ class Application extends Container implements HttpKernelInterface, TerminableIn
                 return;
             }
 
-            $ret = call_user_func($app['callback_resolver']->resolveCallback($callback), $event->getRequest(), $app);
+            $request = $event->getRequest();
+            $c = $app['callback_resolver']->resolveCallback($callback);
+            try {
+                $arguments = $app['argument_resolver']->getArguments($request, $c);
+            } catch (\RuntimeException $e) {
+                $arguments = array(
+                    $request, $app
+                );
+            }
+            
+            $ret = \call_user_func_array($c, $arguments);
 
             if ($ret instanceof Response) {
                 $event->setResponse($ret);

--- a/src/Silex/EventListener/MiddlewareListener.php
+++ b/src/Silex/EventListener/MiddlewareListener.php
@@ -51,7 +51,16 @@ class MiddlewareListener implements EventSubscriberInterface
         }
 
         foreach ((array) $route->getOption('_before_middlewares') as $callback) {
-            $ret = call_user_func($this->app['callback_resolver']->resolveCallback($callback), $request, $this->app);
+            $c = $this->app['callback_resolver']->resolveCallback($callback);
+            try {
+                $arguments = $this->app['argument_resolver']->getArguments($request, $c);
+            } catch (\RuntimeException $e) {
+                $arguments = array(
+                    $request, $this->app
+                );
+            }
+            
+            $ret = \call_user_func_array($c, $arguments);
             if ($ret instanceof Response) {
                 $event->setResponse($ret);
 

--- a/src/Silex/EventListener/MiddlewareListener.php
+++ b/src/Silex/EventListener/MiddlewareListener.php
@@ -51,16 +51,16 @@ class MiddlewareListener implements EventSubscriberInterface
         }
 
         foreach ((array) $route->getOption('_before_middlewares') as $callback) {
-            $c = $this->app['callback_resolver']->resolveCallback($callback);
+            $resolvedCallback = $this->app['callback_resolver']->resolveCallback($callback);
             try {
-                $arguments = $this->app['argument_resolver']->getArguments($request, $c);
+                $arguments = $this->app['argument_resolver']->getArguments($request, $resolvedCallback);
             } catch (\RuntimeException $e) {
                 $arguments = array(
                     $request, $this->app
                 );
             }
             
-            $ret = \call_user_func_array($c, $arguments);
+            $ret = \call_user_func_array($resolvedCallback, $arguments);
             if ($ret instanceof Response) {
                 $event->setResponse($ret);
 

--- a/tests/Silex/Tests/MiddlewareTest.php
+++ b/tests/Silex/Tests/MiddlewareTest.php
@@ -225,7 +225,7 @@ class MiddlewareTest extends TestCase
     {
         $app = new Application();
         
-        //Swapped Order of ->before Arguments, but with Type hints.
+        // Swap order of before() callback arguments based on type hints
         $app->match('/', function() use ($app) { return ''; })
             ->before(function (Application $app, Request $r) {
             $app['success'] = true;
@@ -242,7 +242,7 @@ class MiddlewareTest extends TestCase
         
         $test = $this;
         $i = 0;
-        //Normal order of arguments, but without type hints.
+        // Normal order of arguments, but without type hints.
         $app->match('/', function() use ($app) { return ''; })->before(function ($r, $a) use ($test, &$i){
             $test->assertInstanceOf(Application::class, $a);
             $test->assertInstanceOf(Request::class, $r);
@@ -260,7 +260,7 @@ class MiddlewareTest extends TestCase
         $test = $this;
         $i = 0;
         
-        //Normal order of arguments, but without type hints.
+        // Normal order of arguments, but without type hints.
         $app->before(function ($r, $a) use ($test, &$i){
             $test->assertInstanceOf(Application::class, $a);
             $test->assertInstanceOf(Request::class, $r);


### PR DESCRIPTION
Implementation of idea from #1637.

Had to implement this at 2 places, because `$app->before(...)` and `$app->match(...)->before(...)` behave different. 

This code does silently ignore an exception from `$this->app['argument_resolver']->getArguments($request, $c);` in case the argument resolving fails. (For example if there are not type hints).
Then it does use the "old" argument order (`Request, Application`) instead.

It is not implemented for the other Middleware handlers.