### PR TITLE
Set new security.user_provider inside existing context

### DIFF
--- a/src/Silex/Provider/SecurityServiceProvider.php
+++ b/src/Silex/Provider/SecurityServiceProvider.php
@@ -237,11 +237,10 @@ class SecurityServiceProvider implements ServiceProviderInterface, EventListener
                 }
 
                 if ($protected) {
+                    if (!isset($app['security.user_provider.'.$name])) {
+                        $app['security.user_provider.'.$name] = is_array($users) ? $app['security.user_provider.inmemory._proto']($users) : $users;
+                    }
                     if (!isset($app['security.context_listener.'.$context])) {
-                        if (!isset($app['security.user_provider.'.$name])) {
-                            $app['security.user_provider.'.$name] = is_array($users) ? $app['security.user_provider.inmemory._proto']($users) : $users;
-                        }
-
                         $app['security.context_listener.'.$context] = $app['security.context_listener._proto']($name, [$app['security.user_provider.'.$name]]);
                     }
 


### PR DESCRIPTION
Set `$app['security.user_provider.'.$name]` even if the context already exists. See #1640